### PR TITLE
Receive Execution Requested event

### DIFF
--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -6,6 +6,8 @@ defmodule Wanda.Messaging.Mapper do
 
   alias Wanda.JsonSchema
 
+  # TODO: move this in the contract repository, keep this module to map domain structure to events.
+
   @spec from_json(binary()) :: {:ok, CloudEvent.t()} | {:error, any}
   def from_json(json) do
     with {:ok, %CloudEvent{data: data, type: type} = cloud_event} <- Cloudevents.from_json(json),

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -4,14 +4,31 @@ defmodule Wanda.Policy do
   """
 
   alias Cloudevents.Format.V_1_0.Event, as: CloudEvent
-  alias Wanda.Execution.Fact
+  alias Wanda.Execution.{Fact, Target}
 
+  @execution_requested_event "trento.checks.v1.ExecutionRequested"
   @facts_gathered_event "trento.checks.v1.FactsGathered"
+
+  # TODO: move the CloudEvent unwrapping part in the contract repository.
+  # we want to receive just the domain event here
 
   @spec handle_event(CloudEvent.t()) :: :ok | {:error, any}
   def handle_event(%CloudEvent{
+        type: @execution_requested_event,
+        data: %{"execution_id" => execution_id, "group_id" => agent_id, "targets" => targets}
+      }) do
+    execution_impl().start_execution(
+      execution_id,
+      agent_id,
+      Enum.map(targets, fn %{"agent_id" => agent_id, "checks" => checks} ->
+        %Target{agent_id: agent_id, checks: checks}
+      end)
+    )
+  end
+
+  def handle_event(%CloudEvent{
         type: @facts_gathered_event,
-        data: %{execution_id: execution_id, agent_id: agent_id, facts: facts}
+        data: %{"execution_id" => execution_id, "agent_id" => agent_id, "facts" => facts}
       }) do
     execution_impl().receive_facts(
       execution_id,

--- a/priv/json_schema/trento.checks.v1.ExecutionRequested.schema.json
+++ b/priv/json_schema/trento.checks.v1.ExecutionRequested.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "execution_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "group_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "checks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["agent_id", "checks"]
+      }
+    }
+  },
+  "required": ["execution_id", "agent_id", "targets"]
+}

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -4,9 +4,39 @@ defmodule Wanda.PolicyTest do
   import Mox
 
   alias Cloudevents.Format.V_1_0.Event, as: CloudEvent
-  alias Wanda.Execution.Fact
+  alias Wanda.Execution.{Fact, Target}
 
   setup :verify_on_exit!
+
+  test "should handle a ExecutionRequested event" do
+    execution_id = UUID.uuid4()
+    group_id = UUID.uuid4()
+    agent_id = UUID.uuid4()
+    targets = [%{"agent_id" => agent_id, "checks" => ["check_id"]}]
+
+    expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
+                                                      ^group_id,
+                                                      [
+                                                        %Target{
+                                                          agent_id: ^agent_id,
+                                                          checks: ["check_id"]
+                                                        }
+                                                      ] ->
+      :ok
+    end)
+
+    assert :ok =
+             Wanda.Policy.handle_event(%CloudEvent{
+               id: UUID.uuid4(),
+               source: "trento.wanda",
+               type: "trento.checks.v1.ExecutionRequested",
+               data: %{
+                 "execution_id" => execution_id,
+                 "group_id" => group_id,
+                 "targets" => targets
+               }
+             })
+  end
 
   test "should handle a FactsGathered event" do
     execution_id = UUID.uuid4()
@@ -30,7 +60,7 @@ defmodule Wanda.PolicyTest do
                id: UUID.uuid4(),
                source: "trento.wanda",
                type: "trento.checks.v1.FactsGathered",
-               data: %{execution_id: execution_id, agent_id: agent_id, facts: facts}
+               data: %{"execution_id" => execution_id, "agent_id" => agent_id, "facts" => facts}
              })
   end
 


### PR DESCRIPTION
Basic setup to receive an execution requested event.
For now, events are treated as maps and validated inside Wanda.
After were switch to the contract repo, we can move the schema and cloudevents unwrapping part.
