### PR TITLE
Adds json schema for emitted ExecutionCompletedV1

### DIFF
--- a/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
+++ b/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
@@ -105,6 +105,9 @@
                 "facts": {
                   "type": "object",
                   "title": "GatheredFacts",
+                  "propertyNames": {
+                    "pattern": "^[A-Za-z0-9_][A-Za-z0-9_]*$"
+                  },
                   "patternProperties": {
                     ".*": {
                       "type": [

--- a/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
+++ b/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
@@ -22,6 +22,7 @@
     "check_results": {
       "type": "array",
       "items": {
+        "title": "CheckResult",
         "type": "object",
         "properties": {
           "check_id": {
@@ -30,6 +31,7 @@
           "agents_check_results": {
             "type": "array",
             "items": {
+              "title": "AgentCheckResult",
               "type": "object",
               "properties": {
                 "agent_id": {
@@ -102,6 +104,7 @@
                 },
                 "facts": {
                   "type": "object",
+                  "title": "GatheredFacts",
                   "patternProperties": {
                     ".*": {
                       "type": [
@@ -127,6 +130,7 @@
             "type": "array",
             "items": [
               {
+                "title": "ExpectationResult",
                 "type": "object",
                 "properties": {
                   "name": {

--- a/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
+++ b/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
@@ -112,8 +112,7 @@
                         "string",
                         "boolean",
                         "object",
-                        "array",
-                        "null"
+                        "array"
                       ]
                     }
                   }

--- a/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
+++ b/priv/json_schema/trento.checks.v1.ExecutionCompleted.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "ExecutionCompletedV1",
+  "properties": {
+    "execution_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "group_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "passing",
+        "warning",
+        "critical"
+      ]
+    },
+    "check_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "check_id": {
+            "type": "string"
+          },
+          "agents_check_results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "expectation_evaluations": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "title": "ExpectationEvaluation",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "return_value": {
+                            "oneOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "expect",
+                              "expect_same"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "return_value",
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "title": "ExpectationEvaluationError",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "fact_missing_error",
+                              "illegal_expression_error"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "message",
+                          "type"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "facts": {
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "type": [
+                        "number",
+                        "string",
+                        "boolean",
+                        "object",
+                        "array",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              },
+              "required": [
+                "agent_id",
+                "expectation_evaluations",
+                "facts"
+              ]
+            }
+          },
+          "expectation_results": {
+            "type": "array",
+            "items": [
+              {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "result": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "expect",
+                      "expect_same"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "result",
+                  "type"
+                ]
+              }
+            ]
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "passing",
+              "warning",
+              "critical"
+            ]
+          }
+        },
+        "required": [
+          "agents_check_results",
+          "check_id",
+          "expectation_results",
+          "result"
+        ]
+      }
+    }
+  },
+  "required": [
+    "execution_id",
+    "group_id",
+    "result",
+    "check_results"
+  ]
+}


### PR DESCRIPTION
Adds the json schema for `ExecutionCompleted(V1)` (a json representation of [lib/wanda/execution/result.ex](https://github.com/trento-project/wanda/blob/main/lib/wanda/execution/result.ex)) event emitted by wanda when all the agents have gathered facts and evaluation was triggered.

Here's a bunch of json samples that would satisfy the schema https://gist.github.com/nelsonkopliku/3ff61acfe69ace5d200e0c2e21d0cd96

It can be tried out here https://www.jsonschemavalidator.net/ or here https://jsonschemalint.com/#!/version/draft-07/markup/json

Next steps:
- make sure wanda is able to codify in json the result
- produce a cloud-event enveloped version
- publish the resulting json on rabbit