### PR TITLE
Publish facts gathering initiation event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
   ELIXIR_VERSION: 1.13.4
   OTP_VERSION: 24
   MIX_ENV: test
-  CACHE_VERSION: 1.0
+  CACHE_VERSION: 1.1
 
 jobs:
   elixir-deps:

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -3,7 +3,7 @@ defmodule Wanda.Catalog do
   Function to interact with the checks catalog.
   """
 
-  alias Wanda.Catalog.Expectation
+  alias Wanda.Catalog.{Expectation, Fact}
 
   @catalog_path Application.compile_env!(:wanda, [__MODULE__, :catalog_path])
 
@@ -22,6 +22,17 @@ defmodule Wanda.Catalog do
     check_id
     |> get_expectations()
     |> Enum.find(&(&1.name == name))
+  end
+
+  @doc """
+  Get a list of facts for a given check.
+  """
+  @spec get_facts(String.t()) :: [Fact.t()]
+  def get_facts(check_id) do
+    check_id
+    |> get_check()
+    |> Map.fetch!("facts")
+    |> Enum.map(&map_fact(check_id, &1))
   end
 
   defp get_check(check_id) do
@@ -43,6 +54,19 @@ defmodule Wanda.Catalog do
       name: name,
       type: :expect_same,
       expression: expression
+    }
+  end
+
+  defp map_fact(check_id, %{
+         "name" => name,
+         "gatherer" => gatherer,
+         "argument" => argument
+       }) do
+    %Fact{
+      check_id: check_id,
+      name: name,
+      gatherer: gatherer,
+      argument: argument
     }
   end
 end

--- a/lib/wanda/catalog/fact.ex
+++ b/lib/wanda/catalog/fact.ex
@@ -1,0 +1,15 @@
+defmodule Wanda.Catalog.Fact do
+  @moduledoc """
+  Represents a Fact Definition of a Check in the Catalog.
+  """
+
+  @derive Jason.Encoder
+  defstruct [:check_id, :name, :gatherer, :argument]
+
+  @type t :: %__MODULE__{
+          check_id: String.t(),
+          name: String.t(),
+          gatherer: String.t(),
+          argument: String.t()
+        }
+end

--- a/lib/wanda/execution/agent_facts.ex
+++ b/lib/wanda/execution/agent_facts.ex
@@ -1,0 +1,15 @@
+defmodule Wanda.Execution.AgentFacts do
+  @moduledoc """
+  Represents the Facts to be gathered on a given agent
+  """
+
+  alias Wanda.Catalog.Fact
+
+  @derive Jason.Encoder
+  defstruct [:agent_id, :facts]
+
+  @type t :: %__MODULE__{
+          agent_id: String.t(),
+          facts: [Fact.t()]
+        }
+end

--- a/lib/wanda/execution/facts_request.ex
+++ b/lib/wanda/execution/facts_request.ex
@@ -1,0 +1,17 @@
+defmodule Wanda.Execution.FactsRequest do
+  @moduledoc """
+  Represents a request to gather Facts for a given Execution.
+  """
+
+  alias Wanda.Execution.AgentFacts
+
+  @derive Jason.Encoder
+  defstruct [:execution_id, :group_id, :targets, :facts]
+
+  @type t :: %__MODULE__{
+          execution_id: String.t(),
+          group_id: String.t(),
+          targets: [String.t()],
+          facts: [AgentFacts.t()]
+        }
+end

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -4,9 +4,12 @@ defmodule Wanda.Messaging.Mapper do
   """
   alias Cloudevents.Format.V_1_0.Event, as: CloudEvent
 
+  alias Wanda.Execution.{FactsRequest, Result}
+
   alias Wanda.JsonSchema
 
   @execution_completed_event "trento.checks.v1.ExecutionCompleted"
+  @facts_gathering_requested_event "trento.checks.v1.FactsGatheringRequested"
 
   # TODO: move this in the contract repository, keep this module to map domain structure to events.
 
@@ -38,8 +41,11 @@ defmodule Wanda.Messaging.Mapper do
   end
 
   @spec extract_metadata(any()) :: {:ok, {String.t(), String.t()}} | {:error, any()}
-  defp extract_metadata(%Wanda.Execution.Result{execution_id: execution_id}),
+  defp extract_metadata(%Result{execution_id: execution_id}),
     do: {:ok, {@execution_completed_event, execution_id}}
+
+  defp extract_metadata(%FactsRequest{execution_id: execution_id}),
+    do: {:ok, {@facts_gathering_requested_event, execution_id}}
 
   defp extract_metadata(_), do: {:error, :unsupported_event}
 end

--- a/priv/json_schema/trento.checks.v1.FactsGatheringRequested.schema.json
+++ b/priv/json_schema/trento.checks.v1.FactsGatheringRequested.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "FactsGatheringRequestedV1",
+  "properties": {
+    "execution_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "group_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "facts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "AgentFacts",
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "facts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "FactDefinition",
+              "properties": {
+                "check_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "gatherer": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "argument": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "check_id",
+                "name",
+                "gatherer",
+                "argument"
+              ]
+            }
+          }
+        },
+        "required": [
+          "agent_id",
+          "facts"
+        ]
+      }
+    }
+  },
+  "required": [
+    "execution_id",
+    "group_id",
+    "targets",
+    "facts"
+  ]
+}

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -30,23 +30,106 @@ defmodule Wanda.Execution.ServerTest do
   describe "execution orchestration" do
     test "should start an execution" do
       pid = self()
+      execution_id = "d4a2cdd6-119e-40d3-96ef-9406ad993360"
+      group_id = "d1f268b4-d8df-4433-bab4-b094d32068a8"
+
+      target_agents =
+        [agent1, agent2, agent3] = [
+          "b6dc7b6d-5637-4c56-bcab-25c06bd27886",
+          "b5c82c8e-ade0-4e23-af51-01699db6b156",
+          "4e2ae182-83ee-4db0-9404-6efea74c7698"
+        ]
+
+      expected_facts_request = %Wanda.Execution.FactsRequest{
+        execution_id: execution_id,
+        group_id: group_id,
+        targets: target_agents,
+        facts: [
+          %Wanda.Execution.AgentFacts{
+            agent_id: agent1,
+            facts: [
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "expect_check",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              },
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "expect_same_check",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              }
+            ]
+          },
+          %Wanda.Execution.AgentFacts{
+            agent_id: agent2,
+            facts: [
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "expect_check",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              },
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "expect_same_check",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              }
+            ]
+          },
+          %Wanda.Execution.AgentFacts{
+            agent_id: agent3,
+            facts: [
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "0A0A0A",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              },
+              %Wanda.Catalog.Fact{
+                argument: "SBD_PACEMAKER",
+                check_id: "0A0A0A",
+                gatherer: "sbd_config",
+                name: "sbd_pacemaker"
+              },
+              %Wanda.Catalog.Fact{
+                argument: "SBD_STARTMODE",
+                check_id: "0A0A0A",
+                gatherer: "sbd_config",
+                name: "sbd_startmode"
+              },
+              %Wanda.Catalog.Fact{
+                argument: "totem.token",
+                check_id: "expect_check",
+                gatherer: "corosync",
+                name: "corosync_token_timeout"
+              }
+            ]
+          }
+        ]
+      }
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn "checks.agents.*",
-                                                         "initiate_facts_gathering" ->
+                                                         ^expected_facts_request ->
         send(pid, :wandalorian)
 
         :ok
       end)
 
-      execution_id = UUID.uuid4()
-      group_id = UUID.uuid4()
+      targets = [
+        build(:target, agent_id: agent1, checks: ["expect_check", "expect_same_check"]),
+        build(:target, agent_id: agent2, checks: ["expect_check", "expect_same_check"]),
+        build(:target, agent_id: agent3, checks: ["0A0A0A", "expect_check"])
+      ]
 
       start_supervised!(
         {Server,
          [
            execution_id: execution_id,
            group_id: group_id,
-           targets: build_list(10, :target)
+           targets: targets
          ]}
       )
 

--- a/test/fixtures/catalog/0A0A0A.yaml
+++ b/test/fixtures/catalog/0A0A0A.yaml
@@ -1,0 +1,22 @@
+id: 0A0A0A
+name: Fake Check
+group: Development
+description: |
+  Just a Fake Check
+remediation: |
+  ## Abstract
+  ## Remediation
+  ...
+facts:
+  - name: corosync_token_timeout
+    gatherer: corosync
+    argument: totem.token
+  - name: sbd_pacemaker
+    gatherer: sbd_config
+    argument: SBD_PACEMAKER
+  - name: sbd_startmode
+    gatherer: sbd_config
+    argument: SBD_STARTMODE
+expectations:
+  - name: timeout
+    expect: corosync_token_timeout == 30000

--- a/test/fixtures/events/facts_gathering_requested.json
+++ b/test/fixtures/events/facts_gathering_requested.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "execution_id": "dec60401-8f33-45d7-bbd5-f42a3f9e9b48",
+    "facts": [
+      {
+        "agent_id": "37b6a7ea-3f2e-45ed-b762-23bd39129a90",
+        "facts": [
+          {
+            "argument": "some_argument",
+            "check_id": "CHK01",
+            "gatherer": "some_gatherer",
+            "name": "some_fact_name"
+          },
+          {
+            "argument": "another_argument",
+            "check_id": "CHK02",
+            "gatherer": "another_gatherer",
+            "name": "another_fact_name"
+          }
+        ]
+      }
+    ],
+    "group_id": "421af233-dbb2-4328-907e-8b355b00bde8",
+    "targets": [
+      "37b6a7ea-3f2e-45ed-b762-23bd39129a90"
+    ]
+  },
+  "datacontenttype": "application/json",
+  "id": "dec60401-8f33-45d7-bbd5-f42a3f9e9b48",
+  "source": "https://github.com/trento-project/wanda",
+  "specversion": "1.0",
+  "type": "trento.checks.v1.FactsGatheringRequested"
+}

--- a/test/messaging/mapper_test.exs
+++ b/test/messaging/mapper_test.exs
@@ -7,6 +7,7 @@ defmodule Wanda.MapperTest do
 
   alias Wanda.Messaging.Mapper
 
+  alias Wanda.Support.CloudEventsHelper
   alias Wanda.Support.Messaging.DummyEvent
 
   describe "serializing outgoing events" do
@@ -21,9 +22,7 @@ defmodule Wanda.MapperTest do
           group_id: "421af233-dbb2-4328-907e-8b355b00bde8"
         )
 
-      expected_cloud_event =
-        File.read!("test/fixtures/events/execution_completed_succesfully.json")
-        |> String.replace(["\r", "\n", " "], "")
+      expected_cloud_event = CloudEventsHelper.load_event("execution_completed_succesfully")
 
       assert expected_cloud_event == Mapper.to_json(execution_result)
     end
@@ -34,6 +33,51 @@ defmodule Wanda.MapperTest do
 
       %{"data" => event_data, "type" => ^event_type} =
         execution_result
+        |> Mapper.to_json()
+        |> Jason.decode!()
+
+      assert :ok = Wanda.JsonSchema.validate(event_type, event_data)
+    end
+
+    test "should produce a serialized FactsGatheringRequestedV1 cloud event" do
+      facts_request =
+        build(
+          :facts_request,
+          execution_id: "dec60401-8f33-45d7-bbd5-f42a3f9e9b48",
+          group_id: "421af233-dbb2-4328-907e-8b355b00bde8",
+          targets: ["37b6a7ea-3f2e-45ed-b762-23bd39129a90"],
+          facts: [
+            %Wanda.Execution.AgentFacts{
+              agent_id: "37b6a7ea-3f2e-45ed-b762-23bd39129a90",
+              facts: [
+                %Wanda.Catalog.Fact{
+                  check_id: "CHK01",
+                  name: "some_fact_name",
+                  gatherer: "some_gatherer",
+                  argument: "some_argument"
+                },
+                %Wanda.Catalog.Fact{
+                  check_id: "CHK02",
+                  name: "another_fact_name",
+                  gatherer: "another_gatherer",
+                  argument: "another_argument"
+                }
+              ]
+            }
+          ]
+        )
+
+      expected_cloud_event = CloudEventsHelper.load_event("facts_gathering_requested")
+
+      assert expected_cloud_event == Mapper.to_json(facts_request)
+    end
+
+    test "should produce an FactsGatheringRequestedV1 with a valid event data, as per the schema" do
+      facts_request = build(:facts_request)
+      event_type = "trento.checks.v1.FactsGatheringRequested"
+
+      %{"data" => event_data, "type" => ^event_type} =
+        facts_request
         |> Mapper.to_json()
         |> Jason.decode!()
 

--- a/test/support/cloud_events_helper.ex
+++ b/test/support/cloud_events_helper.ex
@@ -1,0 +1,8 @@
+defmodule Wanda.Support.CloudEventsHelper do
+  @moduledoc false
+
+  def load_event(filename) do
+    File.read!("test/fixtures/events/#{filename}.json")
+    |> String.replace(["\r", "\n", " "], "")
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -9,6 +9,7 @@ defmodule Wanda.Factory do
     ExpectationEvaluation,
     ExpectationResult,
     Fact,
+    FactsRequest,
     Result,
     Target
   }
@@ -32,44 +33,75 @@ defmodule Wanda.Factory do
     %Result{
       execution_id: Map.get(attrs, :execution_id, UUID.uuid4()),
       group_id: Map.get(attrs, :group_id, UUID.uuid4()),
-      check_results: [
-        %CheckResult{
-          agents_check_results: [
-            %AgentCheckResult{
-              agent_id: "agent_1",
-              expectation_evaluations: [
-                %ExpectationEvaluation{
-                  name: "timeout",
-                  return_value: true,
-                  type: :expect
-                }
-              ],
-              facts: %{"corosync_token_timeout" => 30_000}
-            },
-            %AgentCheckResult{
-              agent_id: "agent_2",
-              expectation_evaluations: [
-                %ExpectationEvaluation{
-                  name: "timeout",
-                  return_value: true,
-                  type: :expect
-                }
-              ],
-              facts: %{"corosync_token_timeout" => 30_000}
-            }
-          ],
-          check_id: "expect_check",
-          expectation_results: [
-            %ExpectationResult{
-              name: "timeout",
-              result: true,
-              type: :expect
-            }
-          ],
-          result: :passing
-        }
-      ],
+      check_results:
+        Map.get(attrs, :check_results, [
+          %CheckResult{
+            agents_check_results: [
+              %AgentCheckResult{
+                agent_id: "agent_1",
+                expectation_evaluations: [
+                  %ExpectationEvaluation{
+                    name: "timeout",
+                    return_value: true,
+                    type: :expect
+                  }
+                ],
+                facts: %{"corosync_token_timeout" => 30_000}
+              },
+              %AgentCheckResult{
+                agent_id: "agent_2",
+                expectation_evaluations: [
+                  %ExpectationEvaluation{
+                    name: "timeout",
+                    return_value: true,
+                    type: :expect
+                  }
+                ],
+                facts: %{"corosync_token_timeout" => 30_000}
+              }
+            ],
+            check_id: "expect_check",
+            expectation_results: [
+              %ExpectationResult{
+                name: "timeout",
+                result: true,
+                type: :expect
+              }
+            ],
+            result: :passing
+          }
+        ]),
       result: :passing
+    }
+  end
+
+  def facts_request_factory(attrs) do
+    agent_id = UUID.uuid4()
+
+    %FactsRequest{
+      execution_id: Map.get(attrs, :execution_id, UUID.uuid4()),
+      group_id: Map.get(attrs, :group_id, UUID.uuid4()),
+      targets: Map.get(attrs, :targets, [agent_id]),
+      facts:
+        Map.get(attrs, :facts, [
+          %Wanda.Execution.AgentFacts{
+            agent_id: agent_id,
+            facts: [
+              %Wanda.Catalog.Fact{
+                check_id: "CHK01",
+                name: "some_fact_name",
+                gatherer: "some_gatherer",
+                argument: "some_argument"
+              },
+              %Wanda.Catalog.Fact{
+                check_id: "CHK02",
+                name: "another_fact_name",
+                gatherer: "another_gatherer",
+                argument: "another_argument"
+              }
+            ]
+          }
+        ])
     }
   end
 end


### PR DESCRIPTION
This PR adds the ability to react on an `ExecutionRequested` from the web, with a `FactsGatheringRequested` event that will contain information for the interested agents to actually start gathering facts.

This implementation goes in the direction of publishing only one message to all agents, and interested ones will actually do something upon consumption, while not interested ones might just ack/nack the message and do nothing.
**example routing_key**:  `checks.(execution|facts_gathering).${execution_id}`

The alternative would be sending one message per agent, each message containing the facts for a specific agent.
**example routing_key**:  `checks.agents.${agent_id}`

I see both acceptable, yet not sure which way is the best. 
This needs to be investigated a bit more, and possibly tried in integration with the agent.

I have no strong opinions, and I am open to change my mind and the code, yet this is at least a starting point.

<details>
  <summary>Here's some notes i used for reasoning on the thing</summary>
  
  ```
Each target represents a node in the cluster plus the selected checks to be executed on that node
 One-to-one relationship Agent:CheckSelection
 Different Agents may have partially or totally same selection, or differ completely

 The following is a valid scenario
 Target{agent-1, [c1, c2, c3]}
 Target{agent-2, [c1, c5]}
 Target{agent-3, [c1, c5]}
 Target{agent-5, [c6, c7, c8, c9]}

Given the checks selection we need to communicate each agent which facts to gather.
Shoot your thoughts.

pseudo-message

 execution_id uuid
 group_id uuid
 targets [agent1, agentX] ->  the consuming agent checks if its agent id is in the list, so it should react
 facts [
  AgentFacts{ -> Facts to be gathered per each agent
    agent_id: agent1, -> an interested agents extracts only its own facts to be gathered
    facts: [
      Fact{check_id-1, name-1, gatherer-1, argument-1},
      Fact{check_id-2, name-2, gatherer-2, argument-2}
    ]
  },
  AgentFacts{...}
 ]
```
</details>