### PR TITLE
Revert "Adds cache version to pipeline"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ env:
   ELIXIR_VERSION: 1.13.4
   OTP_VERSION: 24
   MIX_ENV: test
-  CACHE_VERSION: 1.0
 
 jobs:
   elixir-deps:
@@ -42,7 +41,7 @@ jobs:
             deps
             _build/test
             priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}-${{ env.CACHE_VERSION }}
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
 
       - name: Install Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
@@ -81,7 +80,7 @@ jobs:
             deps
             _build/test
             priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}-${{ env.CACHE_VERSION }}
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
 
       - name: Check Code Format
         run: mix format --check-formatted
@@ -117,7 +116,7 @@ jobs:
             deps
             _build/test
             priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}-${{ env.CACHE_VERSION }}
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
 
       - name: Run test
         run: mix test --color --trace --slowest 10


### PR DESCRIPTION
Reverts trento-project/wanda#12

We should never change the CI, which is standard.

The problem is the JSON schema macro that doesn't realize that a new file is added and does not trigger the recompilation.
Since the contract repo supersedes the current macro, we could remove it instead of fixing it. (Coming in a follow up PR)