### PR TITLE
Add timeout logic to Wanda.Execution.Server

### DIFF
--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -8,10 +8,10 @@ defmodule Wanda.Execution do
   alias Wanda.Execution.{Server, Supervisor}
 
   @impl true
-  def start_execution(execution_id, group_id, targets) do
+  def start_execution(execution_id, group_id, targets, config \\ []) do
     DynamicSupervisor.start_child(
       Supervisor,
-      {Server, execution_id: execution_id, group_id: group_id, targets: targets}
+      {Server, execution_id: execution_id, group_id: group_id, targets: targets, config: config}
     )
   end
 

--- a/lib/wanda/execution/behaviour.ex
+++ b/lib/wanda/execution/behaviour.ex
@@ -11,6 +11,13 @@ defmodule Wanda.Execution.Behaviour do
               targets :: [Target.t()]
             ) :: :ok | {:error, any}
 
+  @callback start_execution(
+              execution_id :: String.t(),
+              group_id :: String.t(),
+              targets :: [Target.t()],
+              config :: Keyword.t()
+            ) :: :ok | {:error, any}
+
   @callback receive_facts(execution_id :: String.t(), agent_id :: String.t(), facts :: [Fact.t()]) ::
               :ok | {:error, any}
 end

--- a/lib/wanda/execution/state.ex
+++ b/lib/wanda/execution/state.ex
@@ -8,6 +8,7 @@ defmodule Wanda.Execution.State do
   defstruct [
     :execution_id,
     :group_id,
+    :timeout,
     targets: [],
     gathered_facts: %{},
     agents_gathered: []
@@ -16,6 +17,7 @@ defmodule Wanda.Execution.State do
   @type t :: %__MODULE__{
           execution_id: String.t(),
           group_id: String.t(),
+          timeout: integer(),
           targets: [Target.t()],
           gathered_facts: map(),
           agents_gathered: [String.t()]


### PR DESCRIPTION
As above, Wanda needs to be able to act upon timeouts.

Edit: we're actually splitting this PR in two or more, because it's a little bit though and it's better to do that iteratively.

The current goal is to just introduce the timeout logic.