### PR TITLE
Add checks to execution server state

### DIFF
--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -5,13 +5,26 @@ defmodule Wanda.Execution do
 
   @behaviour Wanda.Execution.Behaviour
 
+  alias Wanda.Catalog
+
   alias Wanda.Execution.{Server, Supervisor}
 
   @impl true
   def start_execution(execution_id, group_id, targets, config \\ []) do
+    checks =
+      targets
+      |> Enum.map(& &1.check)
+      |> Enum.uniq()
+      |> Enum.map(&Catalog.get_check/1)
+
     DynamicSupervisor.start_child(
       Supervisor,
-      {Server, execution_id: execution_id, group_id: group_id, targets: targets, config: config}
+      {Server,
+       execution_id: execution_id,
+       group_id: group_id,
+       targets: targets,
+       checks: checks,
+       config: config}
     )
   end
 

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -87,6 +87,7 @@ defmodule Wanda.Execution.Server do
            group_id: group_id,
            gathered_facts: gathered_facts,
            targets: targets,
+           checks: checks,
            agents_gathered: agents_gathered
          } = state,
          agent_id,
@@ -98,7 +99,7 @@ defmodule Wanda.Execution.Server do
     state = %State{state | gathered_facts: gathered_facts, agents_gathered: agents_gathered}
 
     if Gathering.all_agents_sent_facts?(agents_gathered, targets) do
-      result = Evaluation.execute(execution_id, group_id, gathered_facts)
+      result = Evaluation.execute(execution_id, group_id, checks, gathered_facts)
 
       :ok = Messaging.publish("checks.execution", result)
       {:stop, :normal, state}

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -23,6 +23,7 @@ defmodule Wanda.Execution.Server do
         execution_id: execution_id,
         group_id: Keyword.fetch!(opts, :group_id),
         targets: Keyword.fetch!(opts, :targets),
+        checks: Keyword.fetch!(opts, :checks),
         timeout: Keyword.get(config, :timeout, @default_timeout)
       },
       name: via_tuple(execution_id)

--- a/lib/wanda/execution/state.ex
+++ b/lib/wanda/execution/state.ex
@@ -3,6 +3,7 @@ defmodule Wanda.Execution.State do
   State of an execution.
   """
 
+  alias Wanda.Catalog
   alias Wanda.Execution.Target
 
   defstruct [
@@ -10,6 +11,7 @@ defmodule Wanda.Execution.State do
     :group_id,
     :timeout,
     targets: [],
+    checks: [],
     gathered_facts: %{},
     agents_gathered: []
   ]
@@ -19,6 +21,7 @@ defmodule Wanda.Execution.State do
           group_id: String.t(),
           timeout: integer(),
           targets: [Target.t()],
+          checks: [Catalog.Check.t()],
           gathered_facts: map(),
           agents_gathered: [String.t()]
         }

--- a/test/execution/evaluation_test.exs
+++ b/test/execution/evaluation_test.exs
@@ -1,6 +1,8 @@
 defmodule Wanda.Execution.EvaluationTest do
   use ExUnit.Case
 
+  alias Wanda.Catalog
+
   alias Wanda.Execution.{
     AgentCheckResult,
     CheckResult,
@@ -27,6 +29,7 @@ defmodule Wanda.Execution.EvaluationTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      checks = [Catalog.get_check("expect_check")]
 
       assert %Result{
                execution_id: ^execution_id,
@@ -81,7 +84,7 @@ defmodule Wanda.Execution.EvaluationTest do
                  }
                ],
                result: :passing
-             } = Evaluation.execute(execution_id, group_id, gathered_facts)
+             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts)
     end
 
     test "should return a critical result when not all the agents fullfill the expectations with an expect condition" do
@@ -98,6 +101,7 @@ defmodule Wanda.Execution.EvaluationTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      checks = [Catalog.get_check("expect_check")]
 
       assert %Result{
                execution_id: ^execution_id,
@@ -152,7 +156,7 @@ defmodule Wanda.Execution.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, gathered_facts)
+             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts)
     end
 
     test "should return a passing result when all the agents fullfill the expectations with an expect_same condition" do
@@ -169,6 +173,7 @@ defmodule Wanda.Execution.EvaluationTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      checks = [Catalog.get_check("expect_same_check")]
 
       assert %Result{
                execution_id: ^execution_id,
@@ -223,7 +228,7 @@ defmodule Wanda.Execution.EvaluationTest do
                  }
                ],
                result: :passing
-             } = Evaluation.execute(execution_id, group_id, gathered_facts)
+             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts)
     end
 
     test "should return a passing result when not all the agents fullfill the expectations with an expect_same condition" do
@@ -240,6 +245,7 @@ defmodule Wanda.Execution.EvaluationTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      checks = [Catalog.get_check("expect_same_check")]
 
       assert %Result{
                execution_id: ^execution_id,
@@ -294,7 +300,7 @@ defmodule Wanda.Execution.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, gathered_facts)
+             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts)
     end
 
     test "should return a critical result if a fact is missing from the agent fact gathering" do
@@ -306,6 +312,8 @@ defmodule Wanda.Execution.EvaluationTest do
           "agent_2" => %{}
         }
       }
+
+      checks = [Catalog.get_check("with_fact_missing_check")]
 
       assert %Result{
                result: :critical,
@@ -335,7 +343,7 @@ defmodule Wanda.Execution.EvaluationTest do
                    ]
                  }
                ]
-             } = Evaluation.execute(UUID.uuid4(), UUID.uuid4(), gathered_facts)
+             } = Evaluation.execute(UUID.uuid4(), UUID.uuid4(), checks, gathered_facts)
     end
 
     test "should return a critical result if an illegal expression was specified in a check expectation" do
@@ -349,6 +357,8 @@ defmodule Wanda.Execution.EvaluationTest do
           }
         }
       }
+
+      checks = [Catalog.get_check("with_illegal_expression_check")]
 
       assert %Result{
                result: :critical,
@@ -385,7 +395,7 @@ defmodule Wanda.Execution.EvaluationTest do
                    ]
                  }
                ]
-             } = Evaluation.execute(UUID.uuid4(), UUID.uuid4(), gathered_facts)
+             } = Evaluation.execute(UUID.uuid4(), UUID.uuid4(), checks, gathered_facts)
     end
   end
 end

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -9,9 +9,15 @@ defmodule Wanda.Execution.ServerTest do
   setup [:set_mox_from_context, :verify_on_exit!]
 
   describe "start_link/3" do
-    test "should accept an execution_id, a group_id and targets on start" do
+    test "should accept an execution_id, a group_id, targets and checks on start" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      targets = build_list(10, :target)
+
+      checks =
+        targets
+        |> Enum.flat_map(& &1.checks)
+        |> Enum.map(&build(:check, id: &1))
 
       assert {:ok, pid} =
                start_supervised(
@@ -19,7 +25,8 @@ defmodule Wanda.Execution.ServerTest do
                   [
                     execution_id: execution_id,
                     group_id: group_id,
-                    targets: build_list(10, :target)
+                    targets: targets,
+                    checks: checks
                   ]}
                )
 
@@ -46,7 +53,8 @@ defmodule Wanda.Execution.ServerTest do
          [
            execution_id: execution_id,
            group_id: group_id,
-           targets: build_list(10, :target)
+           targets: build_list(10, :target),
+           checks: []
          ]}
       )
 
@@ -76,7 +84,8 @@ defmodule Wanda.Execution.ServerTest do
            [
              execution_id: execution_id,
              group_id: group_id,
-             targets: targets
+             targets: targets,
+             checks: build_list(1, :check, name: "expect_check")
            ]}
         )
 
@@ -120,6 +129,7 @@ defmodule Wanda.Execution.ServerTest do
              execution_id: execution_id,
              group_id: group_id,
              targets: targets,
+             checks: build_list(1, :check, name: "expect_check"),
              config: [timeout: 100]
            ]}
         )

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -4,6 +4,7 @@ defmodule Wanda.Execution.ServerTest do
   import Mox
   import Wanda.Factory
 
+  alias Wanda.Catalog
   alias Wanda.Execution.Server
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -85,7 +86,7 @@ defmodule Wanda.Execution.ServerTest do
              execution_id: execution_id,
              group_id: group_id,
              targets: targets,
-             checks: build_list(1, :check, name: "expect_check")
+             checks: [Catalog.get_check("expect_check")]
            ]}
         )
 

--- a/test/fixtures/catalog/expect_check.yaml
+++ b/test/fixtures/catalog/expect_check.yaml
@@ -1,4 +1,4 @@
-id: happy
+id: expect_check
 name: Test check
 group: Test
 description: |

--- a/test/fixtures/catalog/expect_same_check.yaml
+++ b/test/fixtures/catalog/expect_same_check.yaml
@@ -1,4 +1,4 @@
-id: group_expect_all
+id: expect_same_check
 name: Test check
 group: Test
 description: |

--- a/test/fixtures/catalog/with_fact_missing_check.yaml
+++ b/test/fixtures/catalog/with_fact_missing_check.yaml
@@ -1,4 +1,4 @@
-id: with_fact_missing
+id: with_fact_missing_check
 name: Checks with missing fact
 group: Test
 description: |

--- a/test/fixtures/catalog/with_illegal_expression_check.yaml
+++ b/test/fixtures/catalog/with_illegal_expression_check.yaml
@@ -1,4 +1,4 @@
-id: with_illegal_expression
+id: with_illegal_expression_check
 name: Checks with illegal expression
 group: Test
 description: |

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Factory do
 
   use ExMachina
 
+  alias Wanda.Catalog
+
   alias Wanda.Execution.{
     AgentCheckResult,
     CheckResult,
@@ -13,6 +15,31 @@ defmodule Wanda.Factory do
     Result,
     Target
   }
+
+  def check_factory(attrs) do
+    %Catalog.Check{
+      id: Map.get(attrs, :id, UUID.uuid4()),
+      name: Map.get(attrs, :id, Faker.StarWars.character()),
+      facts: Map.get(attrs, :facts, build_list(10, :catalog_fact)),
+      expectations: Map.get(attrs, :expectations, build_list(10, :catalog_expectation))
+    }
+  end
+
+  def catalog_fact_factory(attrs) do
+    %Catalog.Fact{
+      name: Map.get(attrs, :name, Faker.StarWars.character()),
+      gatherer: Map.get(attrs, :gatherer, Faker.StarWars.character()),
+      argument: Map.get(attrs, :argument, Faker.StarWars.quote())
+    }
+  end
+
+  def catalog_expectation_factory(attrs) do
+    %Catalog.Fact{
+      name: Map.get(attrs, :name, Faker.StarWars.character()),
+      gatherer: Map.get(attrs, :gatherer, Faker.StarWars.character()),
+      argument: Map.get(attrs, :argument, Faker.StarWars.quote())
+    }
+  end
 
   def target_factory(attrs) do
     %Target{


### PR DESCRIPTION
Refactors execution server and evaluation functional core so we don't do any side effects to load the catalog.
Checks are preloaded and passed to the server when it is started by the `DynamicSupervisor`, if something bad happens or if the targets are asking checks that do not exist this is where we will do the error handling.
