### PR TITLE
Do not requeue amqp message on error

### DIFF
--- a/lib/wanda/messaging/adapters/amqp/consumer.ex
+++ b/lib/wanda/messaging/adapters/amqp/consumer.ex
@@ -36,9 +36,9 @@ defmodule Wanda.Messaging.Adapters.AMQP.Consumer do
 
   @impl GenRMQ.Consumer
   def handle_error(message, _reason) do
-    Logger.error("Unable to handle message", message: inspect(message))
+    Logger.error("Unable to handle message: #{inspect(message)}")
 
-    GenRMQ.Consumer.reject(message, true)
+    GenRMQ.Consumer.reject(message)
   end
 
   def child_spec(opts) do


### PR DESCRIPTION
Change the `requeue` option to not do it. Otherwise, the messages are read in a loop constantly. At this point, we could publish in a dead letters queue or something.
Besides that, I have changed the logging line as it wasn't logging anything. To make this work the `message` atom should be whitelisted in the logger configuration in the `config.ex` file.