### PR TITLE
Set execution GenServer restart policy as transient

### DIFF
--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -4,7 +4,7 @@ defmodule Wanda.Execution.Server do
   Orchestrates facts gathering on the targets - issuing execution and receiving back facts - and following check evaluations.
   """
 
-  use GenServer
+  use GenServer, restart: :transient
 
   alias Wanda.Execution.{Evaluation, Gathering, State}
   alias Wanda.Messaging


### PR DESCRIPTION
Change the Executions GenServer restart policy to `transient`, so the supervisor doesn't restart the server once it is finished gracefully. Otherwise, the default value is `permanent` and the server is restarted 3 times.

Some docs:
https://hexdocs.pm/elixir/1.13/Supervisor.html#module-restart-values-restart
https://hexdocs.pm/elixir/1.13/GenServer.html#module-how-to-supervise