### PR TITLE
Map ExecutionCompleted event

### DIFF
--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -25,12 +25,21 @@ defmodule Wanda.Messaging.Mapper do
     )
   end
 
-  def to_execution_completed(%Result{} = result) do
-    result
-    # TODO: do proper mapping, remove miss
-    |> Miss.Map.from_nested_struct()
-    |> ExecutionCompleted.new()
+  def to_execution_completed(%Result{
+        execution_id: execution_id,
+        group_id: group_id,
+        result: result
+      }) do
+    ExecutionCompleted.new!(
+      execution_id: execution_id,
+      group_id: group_id,
+      result: to_result(result)
+    )
   end
+
+  defp to_result(:passing), do: :PASSING
+  defp to_result(:warning), do: :WARNING
+  defp to_result(:critical), do: :CRITICAL
 
   defp to_facts_gathering_requested_target(
          %Target{agent_id: agent_id, checks: target_checks},

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Wanda.MixProject do
       {:jason, "~> 1.3"},
       {:yaml_elixir, "~> 2.9"},
       {:miss, "~> 0.1.5"},
-      {:trento_contracts, github: "trento-project/contracts", ref: "8947bc9", sparse: "elixir"},
+      {:trento_contracts, github: "trento-project/contracts", ref: "6fabcbb", sparse: "elixir"},
       # test deps
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -49,7 +49,7 @@
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "telemetry_poller": {:hex, :telemetry_poller, "1.0.0", "db91bb424e07f2bb6e73926fcafbfcbcb295f0193e0a00e825e589a0a47e8453", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "b3a24eafd66c3f42da30fc3ca7dda1e9d546c12250a2d60d7b81d264fbec4f6e"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "8947bc9e21f545d0840f8e6631c5c9a2ce0ed732", [ref: "8947bc9", sparse: "elixir"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "6fabcbb0202504c2cd8c466548efbe63a7e5920b", [ref: "6fabcbb", sparse: "elixir"]},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},

--- a/test/messaging/mapper_test.exs
+++ b/test/messaging/mapper_test.exs
@@ -88,9 +88,21 @@ defmodule Wanda.Messaging.MapperTest do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
 
-    execution_result = build(:execution_result, execution_id: execution_id, group_id: group_id)
+    result_map = %{passing: :PASSING, warning: :WARNING, critical: :CRITICAL}
 
-    assert %ExecutionCompleted{execution_id: ^execution_id, group_id: ^group_id} =
-             Mapper.to_execution_completed(execution_result)
+    Enum.each(result_map, fn {domain_result, event_result} ->
+      execution_result =
+        build(:execution_result,
+          execution_id: execution_id,
+          group_id: group_id,
+          result: domain_result
+        )
+
+      assert %ExecutionCompleted{
+               execution_id: ^execution_id,
+               group_id: ^group_id,
+               result: ^event_result
+             } = Mapper.to_execution_completed(execution_result)
+    end)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -110,7 +110,7 @@ defmodule Wanda.Factory do
           result: :passing
         }
       ],
-      result: :passing
+      result: Map.get(attrs, :result, Enum.random([:passing, :warning, :critical]))
     }
   end
 end


### PR DESCRIPTION
Map `ExecutionCompleted` event with the updated contract.

Depends on: https://github.com/trento-project/contracts/pull/19

A bit simpler than the previous one hehe: https://github.com/trento-project/wanda/pull/27