### PR TITLE
Add a storable Wanda.Result.ExecutionResult entity

### DIFF
--- a/lib/wanda/execution/fact.ex
+++ b/lib/wanda/execution/fact.ex
@@ -3,6 +3,7 @@ defmodule Wanda.Execution.Fact do
   A fact is a piece of information that was gathered from a target.
   """
 
+  @derive Jason.Encoder
   defstruct [
     :check_id,
     :name,

--- a/lib/wanda/execution/fact_error.ex
+++ b/lib/wanda/execution/fact_error.ex
@@ -3,6 +3,7 @@ defmodule Wanda.Execution.FactError do
   Fact with an error.
   """
 
+  @derive Jason.Encoder
   defstruct [
     :check_id,
     :name,

--- a/lib/wanda/results/execution_result.ex
+++ b/lib/wanda/results/execution_result.ex
@@ -1,0 +1,18 @@
+defmodule Wanda.Results.ExecutionResult do
+  @moduledoc """
+  Represents a storable ExecutionResult, available after check evaluation
+  """
+
+  use Ecto.Schema
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  schema "execution_results" do
+    field :execution_id, Ecto.UUID, primary_key: true
+    field :group_id, Ecto.UUID
+    field :payload, :map
+
+    timestamps(type: :utc_datetime_usec)
+  end
+end

--- a/priv/repo/migrations/20220928131105_add_execution_result.exs
+++ b/priv/repo/migrations/20220928131105_add_execution_result.exs
@@ -1,0 +1,16 @@
+defmodule Wanda.Repo.Migrations.AddExecutionResult do
+  use Ecto.Migration
+
+  def change do
+    create table(:execution_results, primary_key: false) do
+      add :execution_id, :uuid, primary_key: true
+      add :group_id, :uuid, null: false
+      add :payload, :map, null: false
+
+      timestamps()
+    end
+
+    create index(:execution_results, [:group_id])
+    create unique_index(:execution_results, [:execution_id, :group_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,66 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+execution_id = "00000000-0000-0000-0000-000000000001"
+group_id = "00000000-0000-0000-0000-000000000002"
+
+%Wanda.Results.ExecutionResult{
+  execution_id: execution_id,
+  group_id: group_id,
+  payload: %Wanda.Execution.Result{
+    execution_id: execution_id,
+    group_id: group_id,
+    check_results: [
+      %Wanda.Execution.CheckResult{
+        agents_check_results: [
+          %Wanda.Execution.AgentCheckResult{
+            agent_id: "agent_1",
+            expectation_evaluations: [
+              %Wanda.Execution.ExpectationEvaluation{
+                name: "timeout",
+                return_value: true,
+                type: :expect
+              }
+            ],
+            facts: [
+              %Wanda.Execution.Fact{
+                check_id: "expect_check",
+                name: "corosync_token_timeout",
+                value: 30_000
+              }
+            ]
+          },
+          %Wanda.Execution.AgentCheckResult{
+            agent_id: "agent_2",
+            expectation_evaluations: [
+              %Wanda.Execution.ExpectationEvaluation{
+                name: "timeout",
+                return_value: true,
+                type: :expect
+              }
+            ],
+            facts: [
+              %Wanda.Execution.Fact{
+                check_id: "expect_check",
+                name: "corosync_token_timeout",
+                value: 30_000
+              }
+            ]
+          }
+        ],
+        check_id: "expect_check",
+        expectation_results: [
+          %Wanda.Execution.ExpectationResult{
+            name: "timeout",
+            result: true,
+            type: :expect
+          }
+        ],
+        result: :passing
+      }
+    ],
+    result: :passing
+  }
+}
+|> Wanda.Repo.insert!()


### PR DESCRIPTION
# Description

This pr adds a `Wanda.Result.ExecutionResult` entity storable on the database.
This entity is as simple as containing:
- an `execution_id`
- a `group_id`
- a `payload` with the whole content of a `Wanda.Result.ExecutionResult`

![image](https://user-images.githubusercontent.com/8167114/192818018-3903136e-2a7e-4d5b-bb8f-3f8a241e1009.png)

![image](https://user-images.githubusercontent.com/8167114/192818154-b152494c-d874-44e8-b607-696ce8c7b0ad.png)


this entity in upcoming PRs would:
- be stored when an execution completed
- read and exposed in the list API
- read and exposed in the detail API

## How was this tested?

At the moment manually by running a `mix ecto.setup` or a `mix ecto.reset`.
By doing so we should have one record in the database.

![image](https://user-images.githubusercontent.com/8167114/192818664-e1f940de-4479-4f09-a9cc-cf0ef77472ac.png)
