### PR TITLE
Some needed improvements to make the code runnable on prod environment

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -77,4 +77,12 @@ if config_env() == :prod do
     publisher: [
       connection: amqp_url
     ]
+
+  # Update catalog path to the current application dir during runtime
+  config :wanda, Wanda.Catalog,
+    catalog_path:
+      Application.app_dir(
+        :wanda,
+        Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
+      )
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -62,4 +62,19 @@ if config_env() == :prod do
       port: port
     ],
     secret_key_base: secret_key_base
+
+  amqp_url =
+    System.get_env("AMQP_URL") ||
+      raise """
+      environment variable AMQP_URL is missing.
+      For example: amqp://USER:PASSWORD@HOST
+      """
+
+  config :wanda, Wanda.Messaging.Adapters.AMQP,
+    consumer: [
+      connection: amqp_url
+    ],
+    publisher: [
+      connection: amqp_url
+    ]
 end

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -9,16 +9,18 @@ defmodule Wanda.Catalog do
     Fact
   }
 
-  @catalog_path Application.compile_env!(:wanda, [__MODULE__, :catalog_path])
-
   @doc """
   Get a check from the catalog.
   """
   def get_check(check_id) do
-    @catalog_path
+    get_catalog_path()
     |> Path.join("#{check_id}.yaml")
     |> YamlElixir.read_from_file!()
     |> map_check()
+  end
+
+  defp get_catalog_path do
+    Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
   end
 
   defp map_check(%{


### PR DESCRIPTION
Make the amqp url configurable on runtime and update how the catalog path is obtained.

This 2nd thing is needed to run the code in our docker file, as we don't copy the whole release files. We would need to copy the `/build/_build/prod/lib/wanda/priv/` folder as it is, with that exact path. The old `@catalog_path` was build on compilation time, which is less flexible. (Most probably there is some better way for doing this properly hehe)