### PR TITLE
Check severity

### DIFF
--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -26,12 +26,14 @@ defmodule Wanda.Catalog do
   defp map_check(%{
          "id" => id,
          "name" => name,
+         "severity" => severity,
          "facts" => facts,
          "expectations" => expectations
        }) do
     %Check{
       id: id,
       name: name,
+      severity: severity,
       facts: Enum.map(facts, &map_fact/1),
       expectations: Enum.map(expectations, &map_expectation/1)
     }

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -9,6 +9,8 @@ defmodule Wanda.Catalog do
     Fact
   }
 
+  @default_severity :critical
+
   @doc """
   Get a check from the catalog.
   """
@@ -23,21 +25,26 @@ defmodule Wanda.Catalog do
     Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
   end
 
-  defp map_check(%{
-         "id" => id,
-         "name" => name,
-         "severity" => severity,
-         "facts" => facts,
-         "expectations" => expectations
-       }) do
+  defp map_check(
+         %{
+           "id" => id,
+           "name" => name,
+           "facts" => facts,
+           "expectations" => expectations
+         } = check
+       ) do
     %Check{
       id: id,
       name: name,
-      severity: severity,
+      severity: map_severity(check),
       facts: Enum.map(facts, &map_fact/1),
       expectations: Enum.map(expectations, &map_expectation/1)
     }
   end
+
+  defp map_severity(%{"severity" => "critical"}), do: :critical
+  defp map_severity(%{"severity" => "warning"}), do: :warning
+  defp map_severity(_), do: @default_severity
 
   defp map_expectation(%{"name" => name, "expect" => expression}) do
     %Expectation{

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -5,11 +5,12 @@ defmodule Wanda.Catalog.Check do
 
   alias Wanda.Catalog.{Expectation, Fact}
 
-  defstruct [:id, :name, :facts, :expectations]
+  defstruct [:id, :name, :severity, :facts, :expectations]
 
   @type t :: %__MODULE__{
           id: String.t(),
           name: String.t(),
+          severity: :warning | :critical,
           facts: [Fact.t()],
           expectations: [Expectation.t()]
         }

--- a/test/fixtures/catalog/warning_severity_check.yaml
+++ b/test/fixtures/catalog/warning_severity_check.yaml
@@ -1,12 +1,12 @@
-id: expect_check
-name: Test check
+id: warning_severity_check
+name: Warning check
 group: Test
 description: |
-  Just a check
+  Check with warning severity
 remediation: |
   ## Remediation
   Remediation text
-severity: critical
+severity: warning
 facts:
   - name: corosync_token_timeout
     gatherer: corosync


### PR DESCRIPTION
Add `severity` usage in the checks definition. If it is not defined, `critical` continues being the default severity.
Have a look on the test check to see how it can be used.