### PR TITLE
Use env values

### DIFF
--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -10,7 +10,7 @@ defmodule Wanda.Execution do
   alias Wanda.Execution.{Server, Supervisor}
 
   @impl true
-  def start_execution(execution_id, group_id, targets, config \\ []) do
+  def start_execution(execution_id, group_id, targets, env, config \\ []) do
     checks =
       targets
       |> Enum.map(& &1.checks)
@@ -24,6 +24,7 @@ defmodule Wanda.Execution do
             group_id: group_id,
             targets: targets,
             checks: checks,
+            env: env,
             config: config}
          ) do
       {:ok, _} ->

--- a/lib/wanda/execution/behaviour.ex
+++ b/lib/wanda/execution/behaviour.ex
@@ -9,14 +9,14 @@ defmodule Wanda.Execution.Behaviour do
               execution_id :: String.t(),
               group_id :: String.t(),
               targets :: [Target.t()],
-              env :: %{String.t() => String.t()}
+              env :: map()
             ) :: :ok | {:error, any}
 
   @callback start_execution(
               execution_id :: String.t(),
               group_id :: String.t(),
               targets :: [Target.t()],
-              env :: %{String.t() => String.t()},
+              env :: map(),
               config :: Keyword.t()
             ) :: :ok | {:error, any}
 

--- a/lib/wanda/execution/behaviour.ex
+++ b/lib/wanda/execution/behaviour.ex
@@ -9,14 +9,14 @@ defmodule Wanda.Execution.Behaviour do
               execution_id :: String.t(),
               group_id :: String.t(),
               targets :: [Target.t()],
-              env :: map()
+              env :: %{String.t() => boolean() | number() | String.t()}
             ) :: :ok | {:error, any}
 
   @callback start_execution(
               execution_id :: String.t(),
               group_id :: String.t(),
               targets :: [Target.t()],
-              env :: map(),
+              env :: %{String.t() => boolean() | number() | String.t()},
               config :: Keyword.t()
             ) :: :ok | {:error, any}
 

--- a/lib/wanda/execution/behaviour.ex
+++ b/lib/wanda/execution/behaviour.ex
@@ -8,13 +8,15 @@ defmodule Wanda.Execution.Behaviour do
   @callback start_execution(
               execution_id :: String.t(),
               group_id :: String.t(),
-              targets :: [Target.t()]
+              targets :: [Target.t()],
+              env :: %{String.t() => String.t()}
             ) :: :ok | {:error, any}
 
   @callback start_execution(
               execution_id :: String.t(),
               group_id :: String.t(),
               targets :: [Target.t()],
+              env :: %{String.t() => String.t()},
               config :: Keyword.t()
             ) :: :ok | {:error, any}
 

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -24,6 +24,7 @@ defmodule Wanda.Execution.Server do
         group_id: Keyword.fetch!(opts, :group_id),
         targets: Keyword.fetch!(opts, :targets),
         checks: Keyword.fetch!(opts, :checks),
+        env: Keyword.fetch!(opts, :env),
         timeout: Keyword.get(config, :timeout, @default_timeout)
       },
       name: via_tuple(execution_id)

--- a/lib/wanda/execution/state.ex
+++ b/lib/wanda/execution/state.ex
@@ -12,6 +12,7 @@ defmodule Wanda.Execution.State do
     :timeout,
     targets: [],
     checks: [],
+    env: %{},
     gathered_facts: %{},
     agents_gathered: []
   ]
@@ -22,6 +23,7 @@ defmodule Wanda.Execution.State do
           timeout: integer(),
           targets: [Target.t()],
           checks: [Catalog.Check.t()],
+          env: %{String.t() => String.t()},
           gathered_facts: map(),
           agents_gathered: [String.t()]
         }

--- a/lib/wanda/execution/state.ex
+++ b/lib/wanda/execution/state.ex
@@ -23,7 +23,7 @@ defmodule Wanda.Execution.State do
           timeout: integer(),
           targets: [Target.t()],
           checks: [Catalog.Check.t()],
-          env: map(),
+          env: %{String.t() => boolean() | number() | String.t()},
           gathered_facts: map(),
           agents_gathered: [String.t()]
         }

--- a/lib/wanda/execution/state.ex
+++ b/lib/wanda/execution/state.ex
@@ -23,7 +23,7 @@ defmodule Wanda.Execution.State do
           timeout: integer(),
           targets: [Target.t()],
           checks: [Catalog.Check.t()],
-          env: %{String.t() => String.t()},
+          env: map(),
           gathered_facts: map(),
           agents_gathered: [String.t()]
         }

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -35,7 +35,9 @@ defmodule Wanda.Policy do
       Enum.map(targets, fn %{agent_id: agent_id, checks: checks} ->
         %Target{agent_id: agent_id, checks: checks}
       end),
-      env
+      Enum.reduce(env, %{}, fn {key, %{kind: {_, value}}}, acc ->
+        Map.put(acc, key, value)
+      end)
     )
   end
 

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -50,15 +50,15 @@ defmodule Wanda.Policy do
       execution_id,
       agent_id,
       Enum.map(facts_gathered, fn %{check_id: check_id, name: name, value: value} ->
-        build_gathered_fact(check_id, name, value)
+        map_gathered_fact(check_id, name, value)
       end)
     )
   end
 
-  defp build_gathered_fact(check_id, name, {:error_value, %{type: type, message: message}}),
+  defp map_gathered_fact(check_id, name, {:error_value, %{type: type, message: message}}),
     do: %FactError{check_id: check_id, name: name, type: type, message: message}
 
-  defp build_gathered_fact(check_id, name, {_, value}),
+  defp map_gathered_fact(check_id, name, {_, value}),
     do: %Fact{check_id: check_id, name: name, value: value}
 
   defp execution_impl, do: Application.fetch_env!(:wanda, Wanda.Policy)[:execution_impl]

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -35,9 +35,7 @@ defmodule Wanda.Policy do
       Enum.map(targets, fn %{agent_id: agent_id, checks: checks} ->
         %Target{agent_id: agent_id, checks: checks}
       end),
-      Enum.reduce(env, %{}, fn {key, %{kind: {_, value}}}, acc ->
-        Map.put(acc, key, value)
-      end)
+      Map.new(env, fn {key, %{kind: {_, value}}} -> {key, value} end)
     )
   end
 

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -26,14 +26,16 @@ defmodule Wanda.Policy do
   defp handle(%ExecutionRequested{
          execution_id: execution_id,
          group_id: agent_id,
-         targets: targets
+         targets: targets,
+         env: env
        }) do
     execution_impl().start_execution(
       execution_id,
       agent_id,
       Enum.map(targets, fn %{agent_id: agent_id, checks: checks} ->
         %Target{agent_id: agent_id, checks: checks}
-      end)
+      end),
+      env
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Wanda.MixProject do
       {:jason, "~> 1.3"},
       {:yaml_elixir, "~> 2.9"},
       {:miss, "~> 0.1.5"},
-      {:trento_contracts, github: "trento-project/contracts", ref: "e4c2473", sparse: "elixir"},
+      {:trento_contracts, github: "trento-project/contracts", ref: "357519a", sparse: "elixir"},
       # test deps
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Wanda.MixProject do
       {:jason, "~> 1.3"},
       {:yaml_elixir, "~> 2.9"},
       {:miss, "~> 0.1.5"},
-      {:trento_contracts, github: "trento-project/contracts", ref: "6fabcbb", sparse: "elixir"},
+      {:trento_contracts, github: "trento-project/contracts", ref: "e4c2473", sparse: "elixir"},
       # test deps
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -49,7 +49,7 @@
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "telemetry_poller": {:hex, :telemetry_poller, "1.0.0", "db91bb424e07f2bb6e73926fcafbfcbcb295f0193e0a00e825e589a0a47e8453", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "b3a24eafd66c3f42da30fc3ca7dda1e9d546c12250a2d60d7b81d264fbec4f6e"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "e4c2473573e0ad127b5fcb437729130a9a1b7060", [ref: "e4c2473", sparse: "elixir"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "357519af9b32d2e96542f077914955aaf8033e08", [ref: "357519a", sparse: "elixir"]},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},

--- a/mix.lock
+++ b/mix.lock
@@ -49,7 +49,7 @@
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "telemetry_poller": {:hex, :telemetry_poller, "1.0.0", "db91bb424e07f2bb6e73926fcafbfcbcb295f0193e0a00e825e589a0a47e8453", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "b3a24eafd66c3f42da30fc3ca7dda1e9d546c12250a2d60d7b81d264fbec4f6e"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "6fabcbb0202504c2cd8c466548efbe63a7e5920b", [ref: "6fabcbb", sparse: "elixir"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "e4c2473573e0ad127b5fcb437729130a9a1b7060", [ref: "e4c2473", sparse: "elixir"]},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -24,7 +24,7 @@ defmodule Wanda.Execution.ServerTest do
         |> Enum.flat_map(& &1.checks)
         |> Enum.map(&build(:check, id: &1))
 
-      env = %{"key1" => "value1", "key2" => "value2"}
+      env = build(:map)
 
       assert {:ok, pid} =
                start_supervised(
@@ -55,7 +55,7 @@ defmodule Wanda.Execution.ServerTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = %{"key1" => "value1", "key2" => "value2"}
+      env = build(:map)
 
       start_supervised!(
         {Server,
@@ -64,7 +64,7 @@ defmodule Wanda.Execution.ServerTest do
            group_id: group_id,
            targets: build_list(10, :target),
            checks: build_list(10, :check),
-           env: env,
+           env: env
          ]}
       )
 
@@ -76,7 +76,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = %{"key1" => "value1", "key2" => "value2"}
+      env = build(:map)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -124,7 +124,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = %{"key1" => "value1", "key2" => "value2"}
+      env = build(:map)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -164,7 +164,7 @@ defmodule Wanda.Execution.ServerTest do
     test "should go down when the timeout function gets called" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = %{"key1" => "value1", "key2" => "value2"}
+      env = build(:map)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -14,7 +14,7 @@ defmodule Wanda.Execution.ServerTest do
   setup [:set_mox_from_context, :verify_on_exit!]
 
   describe "start_link/3" do
-    test "should accept an execution_id, a group_id, targets and checks on start" do
+    test "should accept an execution_id, a group_id, targets, checks and env on start" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
       targets = build_list(10, :target)
@@ -24,6 +24,8 @@ defmodule Wanda.Execution.ServerTest do
         |> Enum.flat_map(& &1.checks)
         |> Enum.map(&build(:check, id: &1))
 
+      env = %{"key1" => "value1", "key2" => "value2"}
+
       assert {:ok, pid} =
                start_supervised(
                  {Server,
@@ -31,7 +33,8 @@ defmodule Wanda.Execution.ServerTest do
                     execution_id: execution_id,
                     group_id: group_id,
                     targets: targets,
-                    checks: checks
+                    checks: checks,
+                    env: env
                   ]}
                )
 
@@ -52,6 +55,7 @@ defmodule Wanda.Execution.ServerTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      env = %{"key1" => "value1", "key2" => "value2"}
 
       start_supervised!(
         {Server,
@@ -59,7 +63,8 @@ defmodule Wanda.Execution.ServerTest do
            execution_id: execution_id,
            group_id: group_id,
            targets: build_list(10, :target),
-           checks: build_list(10, :check)
+           checks: build_list(10, :check),
+           env: env,
          ]}
       )
 
@@ -71,6 +76,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      env = %{"key1" => "value1", "key2" => "value2"}
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -91,7 +97,8 @@ defmodule Wanda.Execution.ServerTest do
              execution_id: execution_id,
              group_id: group_id,
              targets: targets,
-             checks: [Catalog.get_check("expect_check")]
+             checks: [Catalog.get_check("expect_check")],
+             env: env
            ]}
         )
 
@@ -117,6 +124,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      env = %{"key1" => "value1", "key2" => "value2"}
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -138,6 +146,7 @@ defmodule Wanda.Execution.ServerTest do
              group_id: group_id,
              targets: targets,
              checks: [Catalog.get_check("expect_check")],
+             env: env,
              config: [timeout: 100]
            ]}
         )
@@ -155,6 +164,7 @@ defmodule Wanda.Execution.ServerTest do
     test "should go down when the timeout function gets called" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
+      env = %{"key1" => "value1", "key2" => "value2"}
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -166,6 +176,7 @@ defmodule Wanda.Execution.ServerTest do
              group_id: group_id,
              targets: targets,
              checks: [Catalog.get_check("expect_check")],
+             env: env,
              config: [timeout: 99_999]
            ]}
         )

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -24,7 +24,7 @@ defmodule Wanda.Execution.ServerTest do
         |> Enum.flat_map(& &1.checks)
         |> Enum.map(&build(:check, id: &1))
 
-      env = build(:map)
+      env = build(:env)
 
       assert {:ok, pid} =
                start_supervised(
@@ -55,7 +55,7 @@ defmodule Wanda.Execution.ServerTest do
 
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = build(:map)
+      env = build(:env)
 
       start_supervised!(
         {Server,
@@ -76,7 +76,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = build(:map)
+      env = build(:env)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -124,7 +124,7 @@ defmodule Wanda.Execution.ServerTest do
       pid = self()
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = build(:map)
+      env = build(:env)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 
@@ -164,7 +164,7 @@ defmodule Wanda.Execution.ServerTest do
     test "should go down when the timeout function gets called" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      env = build(:map)
+      env = build(:env)
 
       targets = build_list(3, :target, %{checks: ["expect_check"]})
 

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -2,7 +2,6 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
   use ExUnit.Case
 
   import Mox
-  import Wanda.Factory
 
   alias Trento.Checks.V1.{
     ExecutionRequested,
@@ -29,7 +28,10 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
                  execution_id: UUID.uuid4(),
                  group_id: UUID.uuid4(),
                  targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}],
-                 env: build(:execution_requested_env)
+                 env: %{
+                   "key" => %{kind: {:string_value, "value"}},
+                   "other_key" => %{kind: {:string_value, "other_value"}}
+                 }
                }
                |> ExecutionRequested.new!()
                |> Trento.Contracts.to_event()

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -2,6 +2,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
   use ExUnit.Case
 
   import Mox
+  import Wanda.Factory
 
   alias Trento.Checks.V1.{
     ExecutionRequested,
@@ -28,7 +29,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
                  execution_id: UUID.uuid4(),
                  group_id: UUID.uuid4(),
                  targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}],
-                 env: %{"key" => "value"}
+                 env: build(:map)
                }
                |> ExecutionRequested.new!()
                |> Trento.Contracts.to_event()

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -29,7 +29,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
                  execution_id: UUID.uuid4(),
                  group_id: UUID.uuid4(),
                  targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}],
-                 env: build(:map)
+                 env: build(:execution_requested_env)
                }
                |> ExecutionRequested.new!()
                |> Trento.Contracts.to_event()

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -18,7 +18,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
     test "should consume ExecutionRequested" do
       pid = self()
 
-      expect(Wanda.Execution.Mock, :start_execution, fn _, _, _ ->
+      expect(Wanda.Execution.Mock, :start_execution, fn _, _, _, _ ->
         send(pid, :consumed)
         :ok
       end)
@@ -27,7 +27,8 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
                %{
                  execution_id: UUID.uuid4(),
                  group_id: UUID.uuid4(),
-                 targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}]
+                 targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}],
+                 env: %{"key" => "value"}
                }
                |> ExecutionRequested.new!()
                |> Trento.Contracts.to_event()

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -19,10 +19,7 @@ defmodule Wanda.PolicyTest do
     agent_id = UUID.uuid4()
     env = build(:execution_requested_env)
 
-    expected_env =
-      Enum.reduce(env, %{}, fn {key, %{kind: {_, value}}}, acc ->
-        Map.put(acc, key, value)
-      end)
+    expected_env = Map.new(env, fn {key, %{kind: {_, value}}} -> {key, value} end)
 
     expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
                                                       ^group_id,

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -2,7 +2,6 @@ defmodule Wanda.PolicyTest do
   use ExUnit.Case
 
   import Mox
-  import Wanda.Factory
 
   alias Trento.Checks.V1.{
     ExecutionRequested,
@@ -17,9 +16,6 @@ defmodule Wanda.PolicyTest do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
     agent_id = UUID.uuid4()
-    env = build(:execution_requested_env)
-
-    expected_env = Map.new(env, fn {key, %{kind: {_, value}}} -> {key, value} end)
 
     expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
                                                       ^group_id,
@@ -29,7 +25,10 @@ defmodule Wanda.PolicyTest do
                                                           checks: ["check_id"]
                                                         }
                                                       ],
-                                                      ^expected_env ->
+                                                      %{
+                                                        "key" => "value",
+                                                        "other_key" => "other_value"
+                                                      } ->
       :ok
     end)
 
@@ -38,7 +37,10 @@ defmodule Wanda.PolicyTest do
                execution_id: execution_id,
                group_id: group_id,
                targets: [%{agent_id: agent_id, checks: ["check_id"]}],
-               env: env
+               env: %{
+                 "key" => %{kind: {:string_value, "value"}},
+                 "other_key" => %{kind: {:string_value, "other_value"}}
+               }
              }
              |> ExecutionRequested.new!()
              |> Wanda.Policy.handle_event()

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -17,7 +17,12 @@ defmodule Wanda.PolicyTest do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
     agent_id = UUID.uuid4()
-    env = build(:map)
+    env = build(:execution_requested_env)
+
+    expected_env =
+      Enum.reduce(env, %{}, fn {key, %{kind: {_, value}}}, acc ->
+        Map.put(acc, key, value)
+      end)
 
     expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
                                                       ^group_id,
@@ -27,7 +32,7 @@ defmodule Wanda.PolicyTest do
                                                           checks: ["check_id"]
                                                         }
                                                       ],
-                                                      ^env ->
+                                                      ^expected_env ->
       :ok
     end)
 

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -2,6 +2,7 @@ defmodule Wanda.PolicyTest do
   use ExUnit.Case
 
   import Mox
+  import Wanda.Factory
 
   alias Trento.Checks.V1.{
     ExecutionRequested,
@@ -16,7 +17,7 @@ defmodule Wanda.PolicyTest do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
     agent_id = UUID.uuid4()
-    env = %{"key1" => "value1", "key2" => "value2"}
+    env = build(:map)
 
     expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
                                                       ^group_id,

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -16,6 +16,7 @@ defmodule Wanda.PolicyTest do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
     agent_id = UUID.uuid4()
+    env = %{"key1" => "value1", "key2" => "value2"}
 
     expect(Wanda.Execution.Mock, :start_execution, fn ^execution_id,
                                                       ^group_id,
@@ -24,7 +25,8 @@ defmodule Wanda.PolicyTest do
                                                           agent_id: ^agent_id,
                                                           checks: ["check_id"]
                                                         }
-                                                      ] ->
+                                                      ],
+                                                      ^env ->
       :ok
     end)
 
@@ -32,7 +34,8 @@ defmodule Wanda.PolicyTest do
              %{
                execution_id: execution_id,
                group_id: group_id,
-               targets: [%{agent_id: agent_id, checks: ["check_id"]}]
+               targets: [%{agent_id: agent_id, checks: ["check_id"]}],
+               env: env
              }
              |> ExecutionRequested.new!()
              |> Wanda.Policy.handle_event()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,14 +19,6 @@ defmodule Wanda.Factory do
 
   alias Wanda.Results.ExecutionResult
 
-  def map_factory(attrs) do
-    count = Map.get(attrs, :count, 5)
-
-    Enum.reduce(0..count, %{}, fn _, acc ->
-      Map.put(acc, Faker.Pokemon.name(), Faker.Pokemon.name())
-    end)
-  end
-
   def check_factory(attrs) do
     %Catalog.Check{
       id: Map.get(attrs, :id, UUID.uuid4()),
@@ -56,6 +48,41 @@ defmodule Wanda.Factory do
     %Target{
       agent_id: Map.get(attrs, :agent_id, UUID.uuid4()),
       checks: Map.get(attrs, :checks, Enum.map(1..10, fn _ -> UUID.uuid4() end))
+    }
+  end
+
+  def env_factory(attrs) do
+    count = Map.get(attrs, :count, 5)
+
+    Enum.reduce(0..count, %{}, fn _, acc ->
+      Map.put(acc, Faker.Pokemon.name(), random_env_value())
+    end)
+  end
+
+  defp random_env_value do
+    Faker.Util.pick([
+      Faker.Pokemon.name(),
+      Enum.random(1..10),
+      Enum.random([false, true])
+    ])
+  end
+
+  def execution_requested_env_factory(attrs) do
+    count = Map.get(attrs, :count, 5)
+
+    Enum.reduce(0..count, %{}, fn _, acc ->
+      Map.put(acc, Faker.Pokemon.name(), random_env_kind())
+    end)
+  end
+
+  defp random_env_kind do
+    %{
+      kind:
+        Faker.Util.pick([
+          {:string_value, Faker.Pokemon.name()},
+          {:number_value, Enum.random(1..10)},
+          {:bool_value, Enum.random([false, true])}
+        ])
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -67,25 +67,6 @@ defmodule Wanda.Factory do
     ])
   end
 
-  def execution_requested_env_factory(attrs) do
-    count = Map.get(attrs, :count, 5)
-
-    Enum.reduce(0..count, %{}, fn _, acc ->
-      Map.put(acc, Faker.Pokemon.name(), random_env_kind())
-    end)
-  end
-
-  defp random_env_kind do
-    %{
-      kind:
-        Faker.Util.pick([
-          {:string_value, Faker.Pokemon.name()},
-          {:number_value, Enum.random(1..10)},
-          {:bool_value, Enum.random([false, true])}
-        ])
-    }
-  end
-
   def fact_factory(attrs) do
     %Fact{
       check_id: Map.get(attrs, :check_id, UUID.uuid4()),

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -59,14 +59,6 @@ defmodule Wanda.Factory do
     end)
   end
 
-  defp random_env_value do
-    Faker.Util.pick([
-      Faker.Pokemon.name(),
-      Enum.random(1..10),
-      Enum.random([false, true])
-    ])
-  end
-
   def fact_factory(attrs) do
     %Fact{
       check_id: Map.get(attrs, :check_id, UUID.uuid4()),
@@ -141,5 +133,13 @@ defmodule Wanda.Factory do
       group_id: group_id,
       payload: build(:result, execution_id: execution_id, group_id: group_id)
     }
+  end
+
+  defp random_env_value do
+    Faker.Util.pick([
+      Faker.Pokemon.name(),
+      Enum.random(1..10),
+      Enum.random([false, true])
+    ])
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,6 +19,14 @@ defmodule Wanda.Factory do
 
   alias Wanda.Results.ExecutionResult
 
+  def map_factory(attrs) do
+    count = Map.get(attrs, :count, 5)
+
+    Enum.reduce(0..count, %{}, fn _, acc ->
+      Map.put(acc, Faker.Pokemon.name(), Faker.Pokemon.name())
+    end)
+  end
+
   def check_factory(attrs) do
     %Catalog.Check{
       id: Map.get(attrs, :id, UUID.uuid4()),


### PR DESCRIPTION
Load the new `env` field from the contract and expand it to the execution dynamic server.