### PR TITLE
Add initialization tasks for a release

### DIFF
--- a/lib/wanda/release.ex
+++ b/lib/wanda/release.ex
@@ -1,0 +1,32 @@
+defmodule Wanda.Release do
+  @moduledoc """
+  Used for executing DB release tasks when run in production without Mix
+  installed.
+  """
+
+  @app :wanda
+
+  def init do
+    migrate()
+  end
+
+  def migrate do
+    load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp load_app do
+    Application.load(@app)
+  end
+
+  defp repos do
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+end


### PR DESCRIPTION
More goodies for a "prod/released". It adds the auto migration feature. It can be used like:
` bin/wanda eval "Wanda.Release.init"`

Ref: https://hexdocs.pm/ecto_sql/Ecto.Migrator.html#module-example-running-migrations-in-a-release
I did some small changes to make it more simillar to the web, adding the `init` function to just have an unique entry point in the helm chart init container