### PR TITLE
More prod fixes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,6 +67,6 @@ if config_env() == :prod do
     catalog_path:
       Application.app_dir(
         :wanda,
-        Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
+        "priv/catalog"
       )
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,20 +6,6 @@ import Config
 # and secrets from environment variables or elsewhere. Do not define
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
-
-# ## Using releases
-#
-# If you use `mix release`, you need to explicitly enable the server
-# by passing the PHX_SERVER=true when you start it:
-#
-#     PHX_SERVER=true bin/wanda start
-#
-# Alternatively, you can use `mix phx.gen.release` to generate a `bin/server`
-# script that automatically sets the env var above.
-if System.get_env("PHX_SERVER") do
-  config :wanda, WandaWeb.Endpoint, server: true
-end
-
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,11 +34,9 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :wanda, WandaWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
Some additional changes on prod config.
- Remove default "leftovers" (related to: https://github.com/trento-project/wanda/pull/50, which we could at the end undo, if we change the dockerfile. I prefer the hardcoded. I don't see when we would like a prod deployment without server)
- Use hardcoded priv path. The `fetch_env` gives errors in some scenarios (when you run release operations for example)