### PR TITLE
Add Result OpenAPI Schema and cleanup

### DIFF
--- a/lib/wanda/execution/agent_check_result.ex
+++ b/lib/wanda/execution/agent_check_result.ex
@@ -13,9 +13,9 @@ defmodule Wanda.Execution.AgentCheckResult do
   @derive Jason.Encoder
   defstruct [
     :agent_id,
-    :facts,
-    :values,
-    :expectation_evaluations
+    values: [],
+    facts: [],
+    expectation_evaluations: []
   ]
 
   @type t :: %__MODULE__{

--- a/lib/wanda/execution/check_result.ex
+++ b/lib/wanda/execution/check_result.ex
@@ -8,9 +8,9 @@ defmodule Wanda.Execution.CheckResult do
   @derive Jason.Encoder
   defstruct [
     :check_id,
-    :expectation_results,
-    :agents_check_results,
-    :result
+    :result,
+    agents_check_results: [],
+    expectation_results: []
   ]
 
   @type t :: %__MODULE__{

--- a/lib/wanda/execution/fact.ex
+++ b/lib/wanda/execution/fact.ex
@@ -13,6 +13,6 @@ defmodule Wanda.Execution.Fact do
   @type t :: %__MODULE__{
           check_id: String.t(),
           name: String.t(),
-          value: String.t()
+          value: boolean() | number() | String.t()
         }
 end

--- a/lib/wanda/execution/result.ex
+++ b/lib/wanda/execution/result.ex
@@ -5,7 +5,7 @@ defmodule Wanda.Execution.Result do
 
   alias Wanda.Execution.CheckResult
 
-  @derive {Jason.Encoder, except: [:execution_id, :group_id]}
+  @derive Jason.Encoder
   defstruct [
     :execution_id,
     :group_id,

--- a/lib/wanda/execution/result.ex
+++ b/lib/wanda/execution/result.ex
@@ -9,9 +9,9 @@ defmodule Wanda.Execution.Result do
   defstruct [
     :execution_id,
     :group_id,
-    :check_results,
-    :timeout,
-    :result
+    :result,
+    check_results: [],
+    timeout: []
   ]
 
   @type t :: %__MODULE__{

--- a/lib/wanda_web/controllers/result_controller.ex
+++ b/lib/wanda_web/controllers/result_controller.ex
@@ -2,6 +2,8 @@ defmodule WandaWeb.ResultController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias OpenApiSpex.Schema
+
   alias Wanda.Results
   alias WandaWeb.Schemas.ListResultsResponse
 
@@ -13,7 +15,10 @@ defmodule WandaWeb.ResultController do
       group_id: [
         in: :query,
         description: "Filter by group_id",
-        type: :string,
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
         example: "00000000-0000-0000-0000-000000000001"
       ],
       page: [in: :query, description: "Page", type: :integer, example: 3],

--- a/lib/wanda_web/schemas/list_results_response.ex
+++ b/lib/wanda_web/schemas/list_results_response.ex
@@ -4,15 +4,16 @@ defmodule WandaWeb.Schemas.ListResultsResponse do
   require OpenApiSpex
 
   alias OpenApiSpex.Schema
+
   alias WandaWeb.Schemas.Result
 
   OpenApiSpex.schema(%{
     title: "ListResultsResponse",
-    description: "The paginated list of results.",
+    description: "The paginated list of results",
     type: :object,
     properties: %{
       items: %Schema{type: :array, items: Result},
-      total_count: %Schema{type: :integer, description: "Total count of results."}
+      total_count: %Schema{type: :integer, description: "Total count of results"}
     }
   })
 end

--- a/lib/wanda_web/schemas/result.ex
+++ b/lib/wanda_web/schemas/result.ex
@@ -5,15 +5,28 @@ defmodule WandaWeb.Schemas.Result do
 
   alias OpenApiSpex.Schema
 
+  alias WandaWeb.Schemas.Result.CheckResult
+
   OpenApiSpex.schema(%{
     title: "Result",
-    description: "The result of an execution",
+    description: "The result of an execution.",
     type: :object,
     properties: %{
-      execution_id: %Schema{type: :string, description: "Execution ID"},
-      group_id: %Schema{type: :string, description: "Group ID"},
-      payload: %Schema{type: :object, description: "Payload of the check execution"}
+      execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
+      group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},
+      inserted_at: %Schema{type: :string, format: :"date-time", description: "Inserted at"},
+      result: %Schema{
+        type: :string,
+        enum: ["passing", "warning", "critical"],
+        description: "Aggregated result of the execution"
+      },
+      timeout: %Schema{
+        type: :array,
+        items: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+        description: "Timed out agents"
+      },
+      check_results: %Schema{type: :array, items: CheckResult}
     },
-    required: [:execution_id, :group_id, :payload]
+    required: [:execution_id, :group_id, :inserted_at, :result, :timeout]
   })
 end

--- a/lib/wanda_web/schemas/result/agent_check_error.ex
+++ b/lib/wanda_web/schemas/result/agent_check_error.ex
@@ -12,12 +12,12 @@ defmodule WandaWeb.Schemas.Result.AgentCheckError do
     description: "The result of check on a specific agent",
     type: :object,
     properties: %{
-      agent_id: %Schema{type: :string, description: "Agent ID"},
+      agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
       expectation_evaluations: %Schema{
         type: :array,
         items: ExpectationEvaluation,
-        description: "Agent ID"
+        description: "Expectation evaluated during the check execution"
       }
     },
     required: [:agent_id, :facts, :expectation_evaluations]

--- a/lib/wanda_web/schemas/result/agent_check_error.ex
+++ b/lib/wanda_web/schemas/result/agent_check_error.ex
@@ -1,0 +1,25 @@
+defmodule WandaWeb.Schemas.Result.AgentCheckError do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.Result.{ExpectationEvaluation, Fact}
+
+  OpenApiSpex.schema(%{
+    title: "AgentCheckError",
+    description: "The result of check on a specific agent",
+    type: :object,
+    properties: %{
+      agent_id: %Schema{type: :string, description: "Agent ID"},
+      facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
+      expectation_evaluations: %Schema{
+        type: :array,
+        items: ExpectationEvaluation,
+        description: "Agent ID"
+      }
+    },
+    required: [:agent_id, :facts, :expectation_evaluations]
+  })
+end

--- a/lib/wanda_web/schemas/result/agent_check_result.ex
+++ b/lib/wanda_web/schemas/result/agent_check_result.ex
@@ -1,0 +1,30 @@
+defmodule WandaWeb.Schemas.Result.AgentCheckResult do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.Result.{ExpectationEvaluation, ExpectationEvaluationError, Fact}
+
+  OpenApiSpex.schema(%{
+    title: "AgentCheckResult",
+    description: "The result of check on a specific agent",
+    type: :object,
+    properties: %{
+      agent_id: %Schema{type: :string, description: "Agent ID"},
+      facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
+      expectation_evaluations: %Schema{
+        type: :array,
+        items: %Schema{
+          oneOf: [
+            ExpectationEvaluation,
+            ExpectationEvaluationError
+          ]
+        },
+        description: "Result of the single expectation evaluation"
+      }
+    },
+    required: [:agent_id, :facts, :expectation_evaluations]
+  })
+end

--- a/lib/wanda_web/schemas/result/agent_check_result.ex
+++ b/lib/wanda_web/schemas/result/agent_check_result.ex
@@ -12,7 +12,7 @@ defmodule WandaWeb.Schemas.Result.AgentCheckResult do
     description: "The result of check on a specific agent",
     type: :object,
     properties: %{
-      agent_id: %Schema{type: :string, description: "Agent ID"},
+      agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
       expectation_evaluations: %Schema{
         type: :array,

--- a/lib/wanda_web/schemas/result/check_result.ex
+++ b/lib/wanda_web/schemas/result/check_result.ex
@@ -1,0 +1,26 @@
+defmodule WandaWeb.Schemas.Result.CheckResult do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.Result.{AgentCheckResult, ExpectationResult}
+
+  OpenApiSpex.schema(%{
+    title: "CheckResult",
+    description: "The result of a check",
+    type: :object,
+    properties: %{
+      check_id: %Schema{type: :string, description: "Check ID"},
+      expectation_results: %Schema{type: :array, items: ExpectationResult},
+      agents_check_results: %Schema{type: :array, items: AgentCheckResult},
+      result: %Schema{
+        type: :string,
+        enum: ["passing", "warning", "critical"],
+        description: "Result of the check"
+      }
+    },
+    required: [:check_id, :expectation_results, :agents_check_results, :result]
+  })
+end

--- a/lib/wanda_web/schemas/result/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/result/expectation_evaluation.ex
@@ -1,0 +1,26 @@
+defmodule WandaWeb.Schemas.Result.ExpectationEvaluation do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "ExpectationEvaluation",
+    description: "Evaluation of an expectation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Name"},
+      return_value: %Schema{
+        oneOf: [%Schema{type: :string}, %Schema{type: :number}, %Schema{type: :boolean}],
+        description: "Return value"
+      },
+      type: %Schema{
+        type: :string,
+        enum: ["expect", "expect_same"],
+        description: "Evaluation type"
+      }
+    },
+    required: [:name, :return_value, :type]
+  })
+end

--- a/lib/wanda_web/schemas/result/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/result/expectation_evaluation_error.ex
@@ -1,0 +1,23 @@
+defmodule WandaWeb.Schemas.Result.ExpectationEvaluationError do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "ExpectationEvaluationError",
+    description: "An error occurred during the evaluation of an expectation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Expectation name"},
+      message: %Schema{type: :string, description: "Error message"},
+      type: %Schema{
+        type: :string,
+        enum: ["fact_missing_error", "illegal_expression_error"],
+        description: "Error type"
+      }
+    },
+    required: [:name, :message, :type]
+  })
+end

--- a/lib/wanda_web/schemas/result/expectation_result.ex
+++ b/lib/wanda_web/schemas/result/expectation_result.ex
@@ -1,0 +1,23 @@
+defmodule WandaWeb.Schemas.Result.ExpectationResult do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "ExpectationResult",
+    description: "The result of an expectation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Expectation name"},
+      result: %Schema{type: :boolean, description: "Result of the expectation condition"},
+      type: %Schema{
+        type: :string,
+        enum: ["expect", "expect_same"],
+        description: "Evaluation type"
+      }
+    },
+    required: [:name, :result, :type]
+  })
+end

--- a/lib/wanda_web/schemas/result/fact.ex
+++ b/lib/wanda_web/schemas/result/fact.ex
@@ -7,10 +7,10 @@ defmodule WandaWeb.Schemas.Result.Fact do
 
   OpenApiSpex.schema(%{
     title: "Fact",
-    description: "The result of a check.",
+    description: "The result of a check",
     type: :object,
     properties: %{
-      check_id: %Schema{type: :string, format: :uuid, description: "Check ID"},
+      check_id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Name"},
       value: %Schema{
         oneOf: [%Schema{type: :string}, %Schema{type: :number}, %Schema{type: :boolean}],

--- a/lib/wanda_web/schemas/result/fact.ex
+++ b/lib/wanda_web/schemas/result/fact.ex
@@ -1,0 +1,22 @@
+defmodule WandaWeb.Schemas.Result.Fact do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "Fact",
+    description: "The result of a check.",
+    type: :object,
+    properties: %{
+      check_id: %Schema{type: :string, format: :uuid, description: "Check ID"},
+      name: %Schema{type: :string, description: "Name"},
+      value: %Schema{
+        oneOf: [%Schema{type: :string}, %Schema{type: :number}, %Schema{type: :boolean}],
+        description: "Value"
+      }
+    },
+    required: [:check_id, :name, :value]
+  })
+end

--- a/lib/wanda_web/schemas/result/value.ex
+++ b/lib/wanda_web/schemas/result/value.ex
@@ -6,7 +6,7 @@ defmodule WandaWeb.Schemas.Result.Value do
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
-    title: "Fact",
+    title: "Value",
     description: "A Value used in the expectations evaluation",
     type: :object,
     properties: %{

--- a/lib/wanda_web/schemas/result/value.ex
+++ b/lib/wanda_web/schemas/result/value.ex
@@ -1,0 +1,21 @@
+defmodule WandaWeb.Schemas.Result.Value do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "Fact",
+    description: "A Value used in the expectations evaluation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Name"},
+      value: %Schema{
+        oneOf: [%Schema{type: :string}, %Schema{type: :number}, %Schema{type: :boolean}],
+        description: "Value"
+      }
+    },
+    required: [:check_id, :name, :value]
+  })
+end

--- a/lib/wanda_web/views/result_view.ex
+++ b/lib/wanda_web/views/result_view.ex
@@ -10,7 +10,7 @@ defmodule WandaWeb.ResultView do
     }
   end
 
-  def render("result.json", %{result: %ExecutionResult{} = result}) do
-    result
+  def render("result.json", %{result: %ExecutionResult{payload: result, inserted_at: inserted_at}}) do
+    Map.put(result, "inserted_at", inserted_at)
   end
 end

--- a/priv/repo/migrations/20220928131105_add_execution_result.exs
+++ b/priv/repo/migrations/20220928131105_add_execution_result.exs
@@ -7,7 +7,7 @@ defmodule Wanda.Repo.Migrations.AddExecutionResult do
       add :group_id, :uuid, null: false
       add :payload, :map, null: false
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:execution_results, [:group_id])

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -101,7 +101,7 @@ defmodule Wanda.Factory do
         %CheckResult{
           agents_check_results: [
             %AgentCheckResult{
-              agent_id: "agent_1",
+              agent_id: UUID.uuid4(),
               expectation_evaluations: [
                 %ExpectationEvaluation{
                   name: "timeout",
@@ -111,7 +111,7 @@ defmodule Wanda.Factory do
               ]
             },
             %AgentCheckResult{
-              agent_id: "agent_2",
+              agent_id: UUID.uuid4(),
               expectation_evaluations: [
                 %ExpectationEvaluation{
                   name: "timeout",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -148,7 +148,9 @@ defmodule Wanda.Factory do
     %ExecutionResult{
       execution_id: execution_id,
       group_id: group_id,
-      payload: build(:result, execution_id: execution_id, group_id: group_id)
+      payload: build(:result, execution_id: execution_id, group_id: group_id),
+      inserted_at: Map.get(attrs, :inserted_at, DateTime.utc_now()),
+      updated_at: Map.get(attrs, :updated_at, DateTime.utc_now())
     }
   end
 

--- a/test/wanda_web/views/result_view_test.exs
+++ b/test/wanda_web/views/result_view_test.exs
@@ -4,16 +4,40 @@ defmodule WandaWeb.ListResultsViewTest do
   import Phoenix.View
   import Wanda.Factory
 
+  alias Wanda.Results.ExecutionResult
+
   describe "ResultView" do
     test "renders list_results.json" do
-      results = build_list(3, :execution_result)
+      inserted_at = DateTime.utc_now()
+
+      [
+        %ExecutionResult{execution_id: execution_id_1, group_id: group_id_1},
+        %ExecutionResult{execution_id: execution_id_2, group_id: group_id_2}
+      ] =
+        execution_results =
+        Enum.map(1..2, fn _ ->
+          :execution_result
+          |> build(inserted_at: inserted_at)
+          |> insert(returning: true)
+        end)
 
       assert %{
-               items: ^results,
+               items: [
+                 %{
+                   "execution_id" => ^execution_id_1,
+                   "group_id" => ^group_id_1,
+                   "inserted_at" => ^inserted_at
+                 },
+                 %{
+                   "execution_id" => ^execution_id_2,
+                   "group_id" => ^group_id_2,
+                   "inserted_at" => ^inserted_at
+                 }
+               ],
                total_count: 10
              } =
                render(WandaWeb.ResultView, "list_results.json",
-                 results: results,
+                 results: execution_results,
                  total_count: 10
                )
     end


### PR DESCRIPTION
Add Result OpenAPI Schema, general clean-up

NOTE: I've changed the already existing migration because the `timestamps` types were not populated correctly. Since we do not want to bloat the migration folders while in this early stages, please reset your ecto db with `mix ecto.reset` and `MIX_ENV=test mix ecto.reset`