### PR TITLE
Rename controllers context

### DIFF
--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -6,8 +6,18 @@ defmodule Wanda.Execution.Server do
 
   use GenServer, restart: :transient
 
-  alias Wanda.Execution.{Evaluation, Gathering, State, Target}
-  alias Wanda.Messaging
+  alias Wanda.Execution.{
+    Evaluation,
+    Gathering,
+    Result,
+    State,
+    Target
+  }
+
+  alias Wanda.{
+    Messaging,
+    Results
+  }
 
   require Logger
 
@@ -137,8 +147,8 @@ defmodule Wanda.Execution.Server do
     end
   end
 
-  defp store_and_publish_execution_result(%Wanda.Execution.Result{} = result) do
-    Wanda.Results.create_execution_result(result)
+  defp store_and_publish_execution_result(%Result{} = result) do
+    Results.create_execution_result(result)
 
     execution_completed = Messaging.Mapper.to_execution_completed(result)
     :ok = Messaging.publish("results", execution_completed)

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -138,7 +138,7 @@ defmodule Wanda.Execution.Server do
   end
 
   defp store_and_publish_execution_result(%Wanda.Execution.Result{} = result) do
-    Wanda.Results.save_result(result)
+    Wanda.Results.create_execution_result(result)
 
     execution_completed = Messaging.Mapper.to_execution_completed(result)
     :ok = Messaging.publish("results", execution_completed)

--- a/lib/wanda/results.ex
+++ b/lib/wanda/results.ex
@@ -3,22 +3,24 @@ defmodule Wanda.Results do
   This module exposes functionalities to interact with the historycal log of ExecutionResults.
   """
 
+  alias Wanda.Repo
+
   alias Wanda.Execution.Result
   alias Wanda.Results.ExecutionResult
 
   import Ecto.Query
 
   @doc """
-  Saves a result to the database.
+  Create a new result.
   """
-  @spec save_result(Result.t()) :: ExecutionResult.t()
-  def save_result(
+  @spec create_execution_result(Result.t()) :: ExecutionResult.t()
+  def create_execution_result(
         %Result{
           execution_id: execution_id,
           group_id: group_id
         } = result
       ) do
-    Wanda.Repo.insert!(%ExecutionResult{
+    Repo.insert!(%ExecutionResult{
       execution_id: execution_id,
       group_id: group_id,
       payload: result
@@ -26,10 +28,12 @@ defmodule Wanda.Results do
   end
 
   @doc """
-  Gets execution results from the database.
+  Get a paginated list of results.
+
+  Can be filtered by group_id.
   """
   @spec list_execution_results(map()) :: [ExecutionResult.t()]
-  def list_execution_results(params) do
+  def list_execution_results(params \\ %{}) do
     page = Map.get(params, :page, 1)
     items_per_page = Map.get(params, :items_per_page, 10)
     group_id = Map.get(params, :group_id)
@@ -40,7 +44,7 @@ defmodule Wanda.Results do
     |> maybe_filter_by_group_id(group_id)
     |> limit([_], ^items_per_page)
     |> offset([_], ^offset)
-    |> Wanda.Repo.all()
+    |> Repo.all()
   end
 
   @doc """
@@ -53,7 +57,7 @@ defmodule Wanda.Results do
     from(e in ExecutionResult)
     |> maybe_filter_by_group_id(group_id)
     |> select([e], count())
-    |> Wanda.Repo.one()
+    |> Repo.one()
   end
 
   @spec maybe_filter_by_group_id(Ecto.Query.t(), String.t()) :: Ecto.Query.t()

--- a/lib/wanda_web/controllers/catalog_controller.ex
+++ b/lib/wanda_web/controllers/catalog_controller.ex
@@ -5,13 +5,13 @@ defmodule WandaWeb.CatalogController do
   alias Wanda.Catalog
   alias WandaWeb.Schemas.CatalogResponse
 
-  operation :list_catalog,
+  operation :catalog,
     summary: "List checks catalog",
     responses: [
       ok: {"Check catalog response", "application/json", CatalogResponse}
     ]
 
-  def list_catalog(conn, _) do
+  def catalog(conn, _) do
     catalog = Catalog.get_catalog()
     render(conn, catalog: catalog)
   end

--- a/lib/wanda_web/controllers/result_controller.ex
+++ b/lib/wanda_web/controllers/result_controller.ex
@@ -9,7 +9,7 @@ defmodule WandaWeb.ResultController do
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
-  operation :list_results,
+  operation :index,
     summary: "List results",
     parameters: [
       group_id: [
@@ -29,7 +29,7 @@ defmodule WandaWeb.ResultController do
       422 => OpenApiSpex.JsonErrorResponse.response()
     }
 
-  def list_results(conn, params) do
+  def index(conn, params) do
     results = Results.list_execution_results(params)
     total_count = Results.count_execution_results(params)
 

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -6,10 +6,11 @@ defmodule WandaWeb.Router do
     plug OpenApiSpex.Plug.PutApiSpec, module: WandaWeb.ApiSpec
   end
 
-  scope "/api", WandaWeb do
+  scope "/api/checks", WandaWeb do
     pipe_through :api
-    get "/checks/results", ResultController, :list_results
-    get "/checks/catalog", CatalogController, :list_catalog
+
+    resources "/results", ResultController, only: [:index]
+    get "/catalog", CatalogController, :catalog
   end
 
   scope "/api" do

--- a/lib/wanda_web/views/catalog_view.ex
+++ b/lib/wanda_web/views/catalog_view.ex
@@ -3,7 +3,7 @@ defmodule WandaWeb.CatalogView do
 
   alias Wanda.Catalog.Check
 
-  def render("list_catalog.json", %{catalog: catalog}) do
+  def render("catalog.json", %{catalog: catalog}) do
     %{items: render_many(catalog, WandaWeb.CatalogView, "check.json", as: :check)}
   end
 

--- a/lib/wanda_web/views/result_view.ex
+++ b/lib/wanda_web/views/result_view.ex
@@ -3,7 +3,7 @@ defmodule WandaWeb.ResultView do
 
   alias Wanda.Results.ExecutionResult
 
-  def render("list_results.json", %{results: results, total_count: total_count}) do
+  def render("index.json", %{results: results, total_count: total_count}) do
     %{
       items: render_many(results, WandaWeb.ResultView, "result.json", as: :result),
       total_count: total_count

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 execution_id = "00000000-0000-0000-0000-000000000001"
 group_id = "00000000-0000-0000-0000-000000000002"
 
-Wanda.Results.save_result(%Wanda.Execution.Result{
+Wanda.Results.create_execution_result(%Wanda.Execution.Result{
   execution_id: execution_id,
   group_id: group_id,
   check_results: [

--- a/test/results_test.exs
+++ b/test/results_test.exs
@@ -13,7 +13,7 @@ defmodule Wanda.ResultsTest do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
 
-      Results.save_result(
+      Results.create_execution_result(
         build(
           :result,
           execution_id: execution_id,
@@ -42,7 +42,7 @@ defmodule Wanda.ResultsTest do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
 
-      Results.save_result(
+      Results.create_execution_result(
         build(
           :result,
           execution_id: execution_id,

--- a/test/wanda_web/controllers/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/catalog_controller_test.exs
@@ -8,7 +8,7 @@ defmodule WandaWeb.CatalogControllerTest do
     test "listing the checks catalog produces a CatalogResponse", %{conn: conn} do
       json =
         conn
-        |> get(Routes.catalog_path(conn, :list_catalog))
+        |> get(Routes.catalog_path(conn, :catalog))
         |> json_response(200)
 
       api_spec = ApiSpec.spec()

--- a/test/wanda_web/views/catalog_view_test.exs
+++ b/test/wanda_web/views/catalog_view_test.exs
@@ -5,12 +5,12 @@ defmodule WandaWeb.CatalogViewTest do
   import Wanda.Factory
 
   describe "CatalogView" do
-    test "renders list_catalog.json" do
+    test "renders catalog.json" do
       checks = build_list(3, :check)
 
       assert %{
                items: ^checks
-             } = render(WandaWeb.CatalogView, "list_catalog.json", catalog: checks)
+             } = render(WandaWeb.CatalogView, "catalog.json", catalog: checks)
     end
   end
 end

--- a/test/wanda_web/views/result_view_test.exs
+++ b/test/wanda_web/views/result_view_test.exs
@@ -7,7 +7,7 @@ defmodule WandaWeb.ListResultsViewTest do
   alias Wanda.Results.ExecutionResult
 
   describe "ResultView" do
-    test "renders list_results.json" do
+    test "renders index.json" do
       inserted_at = DateTime.utc_now()
 
       [
@@ -36,7 +36,7 @@ defmodule WandaWeb.ListResultsViewTest do
                ],
                total_count: 10
              } =
-               render(WandaWeb.ResultView, "list_results.json",
+               render(WandaWeb.ResultView, "index.json",
                  results: execution_results,
                  total_count: 10
                )


### PR DESCRIPTION
Rename controller actions and context to be as close as possible to Phoenix standards, so we can use the `resource` directive in the router.

