### PR TITLE
Detect already running execution for group_id

### DIFF
--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -27,21 +27,43 @@ defmodule Wanda.Execution do
   defp maybe_start_execution(_, _, _, [], _, _), do: {:error, :no_checks_selected}
 
   defp maybe_start_execution(execution_id, group_id, targets, checks, env, config) do
-    case DynamicSupervisor.start_child(
-           Supervisor,
-           {Server,
-            execution_id: execution_id,
-            group_id: group_id,
-            targets: targets,
-            checks: checks,
-            env: env,
-            config: config}
-         ) do
-      {:ok, _} ->
-        :ok
+    with false <- execution_for_group_id_already_running(group_id),
+         {:ok, _} <-
+           DynamicSupervisor.start_child(
+             Supervisor,
+             {Server,
+              execution_id: execution_id,
+              group_id: group_id,
+              targets: targets,
+              checks: checks,
+              env: env,
+              config: config}
+           ) do
+      :ok
+    else
+      true ->
+        {:error, :group_already_running}
 
       {:error, _} = error ->
         error
     end
+  end
+
+  defp execution_for_group_id_already_running(group_id) do
+    :global.registered_names()
+    |> Enum.flat_map(fn entry ->
+      case entry do
+        {Server, execution_id} -> [{Server, execution_id}]
+        _ -> []
+      end
+    end)
+    |> Enum.any?(fn name ->
+      %{group_id: g} =
+        name
+        |> :global.whereis_name()
+        |> :sys.get_state()
+
+      g == group_id
+    end)
   end
 end

--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -58,12 +58,14 @@ defmodule Wanda.Execution do
       end
     end)
     |> Enum.any?(fn name ->
-      %{group_id: g} =
+      group_id ==
         name
         |> :global.whereis_name()
-        |> :sys.get_state()
-
-      g == group_id
+        |> get_group_id()
     end)
+  end
+
+  defp get_group_id(name) do
+    GenServer.call(name, :get_group_id)
   end
 end

--- a/lib/wanda/execution.ex
+++ b/lib/wanda/execution.ex
@@ -41,7 +41,7 @@ defmodule Wanda.Execution do
         :ok
 
       {:error, {:already_started, _}} ->
-        {:error, :group_already_running}
+        {:error, :already_running}
 
       {:error, _} = error ->
         error

--- a/lib/wanda/execution/behaviour.ex
+++ b/lib/wanda/execution/behaviour.ex
@@ -22,6 +22,7 @@ defmodule Wanda.Execution.Behaviour do
 
   @callback receive_facts(
               execution_id :: String.t(),
+              group_id :: String.t(),
               agent_id :: String.t(),
               facts :: [Fact.t() | FactError.t()]
             ) ::

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -91,6 +91,16 @@ defmodule Wanda.Execution.Server do
   end
 
   @impl true
+  def handle_cast(
+        {:receive_facts, execution_id, _, _},
+        %State{group_id: group_id} = state
+      ) do
+    Logger.error("Execution #{execution_id} does not match for group #{group_id}")
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info(
         :timeout,
         %State{

--- a/lib/wanda/execution/server.ex
+++ b/lib/wanda/execution/server.ex
@@ -120,6 +120,11 @@ defmodule Wanda.Execution.Server do
     {:stop, :normal, state}
   end
 
+  @impl true
+  def handle_call(:get_group_id, _from, %State{group_id: group_id} = state) do
+    {:reply, group_id, state}
+  end
+
   defp continue_or_complete_execution(
          %State{
            execution_id: execution_id,

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -41,11 +41,13 @@ defmodule Wanda.Policy do
 
   defp handle(%FactsGathered{
          execution_id: execution_id,
+         group_id: group_id,
          agent_id: agent_id,
          facts_gathered: facts_gathered
        }) do
     execution_impl().receive_facts(
       execution_id,
+      group_id,
       agent_id,
       Enum.map(facts_gathered, fn %{check_id: check_id, name: name, fact_value: fact_value} ->
         map_gathered_fact(check_id, name, fact_value)

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Wanda.MixProject do
       {:credentials_obfuscation, "3.0.0", override: true},
       {:jason, "~> 1.3"},
       {:yaml_elixir, "~> 2.9"},
-      {:trento_contracts, github: "trento-project/contracts", ref: "5a23ea0", sparse: "elixir"},
+      {:trento_contracts, github: "trento-project/contracts", ref: "01db6a7", sparse: "elixir"},
       # test deps
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -41,7 +41,7 @@
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "telemetry_poller": {:hex, :telemetry_poller, "1.0.0", "db91bb424e07f2bb6e73926fcafbfcbcb295f0193e0a00e825e589a0a47e8453", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "b3a24eafd66c3f42da30fc3ca7dda1e9d546c12250a2d60d7b81d264fbec4f6e"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "5a23ea08ca25c5cb2ea91691736ad814f52abc3e", [ref: "5a23ea0", sparse: "elixir"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "01db6a7002729f82d6104104dd9f983c7215fcc0", [ref: "01db6a7", sparse: "elixir"]},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.9.0", "9a256da867b37b8d2c1ffd5d9de373a4fda77a32a45b452f1708508ba7bbcb53", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "0cb0e7d4c56f5e99a6253ed1a670ed0e39c13fc45a6da054033928607ac08dfc"},
 }

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -8,7 +8,7 @@ defmodule Wanda.Execution.ServerTest do
   alias Trento.Checks.V1.FactsGatheringRequested
   alias Wanda.Catalog
 
-  alias Wanda.Execution.{Server, State}
+  alias Wanda.Execution.Server
   alias Wanda.Results.ExecutionResult
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -52,7 +52,7 @@ defmodule Wanda.Execution.ServerTest do
                   ]}
                )
 
-      assert pid == :global.whereis_name({Server, execution_id})
+      assert pid == :global.whereis_name({Server, group_id})
     end
   end
 
@@ -122,6 +122,7 @@ defmodule Wanda.Execution.ServerTest do
       Enum.each(targets, fn target ->
         Server.receive_facts(
           execution_id,
+          group_id,
           target.agent_id,
           build_list(1, :fact, check_id: context[:check].id)
         )
@@ -216,13 +217,6 @@ defmodule Wanda.Execution.ServerTest do
              } = Repo.one!(ExecutionResult)
 
       assert timedout_targets == Enum.map(targets, & &1.agent_id)
-    end
-
-    test "should return group_id" do
-      group_id = UUID.uuid4()
-
-      assert {:reply, ^group_id, _} =
-               Server.handle_call(:get_group_id, "", %State{group_id: group_id})
     end
   end
 end

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -8,7 +8,7 @@ defmodule Wanda.Execution.ServerTest do
   alias Trento.Checks.V1.FactsGatheringRequested
   alias Wanda.Catalog
 
-  alias Wanda.Execution.Server
+  alias Wanda.Execution.{Server, State}
   alias Wanda.Results.ExecutionResult
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -216,6 +216,13 @@ defmodule Wanda.Execution.ServerTest do
              } = Repo.one!(ExecutionResult)
 
       assert timedout_targets == Enum.map(targets, & &1.agent_id)
+    end
+
+    test "should return group_id" do
+      group_id = UUID.uuid4()
+
+      assert {:reply, ^group_id, _} =
+               Server.handle_call(:get_group_id, "", %State{group_id: group_id})
     end
   end
 end

--- a/test/execution/server_test.exs
+++ b/test/execution/server_test.exs
@@ -8,7 +8,7 @@ defmodule Wanda.Execution.ServerTest do
   alias Trento.Checks.V1.FactsGatheringRequested
   alias Wanda.Catalog
 
-  alias Wanda.Execution.Server
+  alias Wanda.Execution.{Server, State}
   alias Wanda.Results.ExecutionResult
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -217,6 +217,21 @@ defmodule Wanda.Execution.ServerTest do
              } = Repo.one!(ExecutionResult)
 
       assert timedout_targets == Enum.map(targets, & &1.agent_id)
+    end
+
+    @tag capture_log: true
+    test "should discard execution ids that does not match for current group", context do
+      state = %State{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: build_list(2, :target, %{checks: [context[:check].id]})
+      }
+
+      assert {:noreply, ^state} =
+               Server.handle_cast(
+                 {:receive_facts, UUID.uuid4(), UUID.uuid4(), []},
+                 state
+               )
     end
   end
 end

--- a/test/execution_test.exs
+++ b/test/execution_test.exs
@@ -36,7 +36,7 @@ defmodule Wanda.ExecutionTest do
                   ]}
                )
 
-      assert {:error, :group_already_running} =
+      assert {:error, :already_running} =
                Execution.start_execution(UUID.uuid4(), group_id, targets, %{})
     end
   end

--- a/test/execution_test.exs
+++ b/test/execution_test.exs
@@ -20,7 +20,7 @@ defmodule Wanda.ExecutionTest do
       group_id = UUID.uuid4()
       targets = build_list(2, :target, checks: ["expect_check"])
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _ ->
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 0, fn _, _ ->
         :ok
       end)
 

--- a/test/execution_test.exs
+++ b/test/execution_test.exs
@@ -1,9 +1,12 @@
 defmodule Wanda.ExecutionTest do
   use ExUnit.Case
 
+  import Mox
   import Wanda.Factory
 
   alias Wanda.Execution
+
+  setup [:set_mox_from_context, :verify_on_exit!]
 
   describe "execution" do
     test "should skip execution if no checks are selected" do
@@ -11,6 +14,30 @@ defmodule Wanda.ExecutionTest do
 
       assert {:error, :no_checks_selected} =
                Execution.start_execution(UUID.uuid4(), UUID.uuid4(), targets, %{})
+    end
+
+    test "should know if the other execution for the same group_id is running" do
+      group_id = UUID.uuid4()
+      targets = build_list(2, :target, checks: ["expect_check"])
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _ ->
+        :ok
+      end)
+
+      assert {:ok, _} =
+               start_supervised(
+                 {Execution.Server,
+                  [
+                    execution_id: UUID.uuid4(),
+                    group_id: group_id,
+                    targets: targets,
+                    checks: build_list(10, :check),
+                    env: %{}
+                  ]}
+               )
+
+      assert {:error, :group_already_running} =
+               Execution.start_execution(UUID.uuid4(), group_id, targets, %{})
     end
   end
 end

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -48,9 +48,11 @@ defmodule Wanda.PolicyTest do
 
   test "should handle a FactsGathered event" do
     execution_id = UUID.uuid4()
+    group_id = UUID.uuid4()
     agent_id = UUID.uuid4()
 
     expect(Wanda.Execution.Mock, :receive_facts, fn ^execution_id,
+                                                    ^group_id,
                                                     ^agent_id,
                                                     [
                                                       %Fact{
@@ -65,6 +67,7 @@ defmodule Wanda.PolicyTest do
     assert :ok =
              %{
                execution_id: execution_id,
+               group_id: group_id,
                agent_id: agent_id,
                facts_gathered: [
                  %{


### PR DESCRIPTION
Detect if an execution with a specific group id is already being executed. Using the `:global` registry should make this distributed as well. Raise an error in this case by now.
We can do different things with this error later on: stop current execution, requeue message...

Some refs on the name registration: https://hexdocs.pm/elixir/1.12/GenServer.html#module-name-registration
PD: Maybe there better solutions for this, but I had some fun learning the :global registry usage hehe