### PR TITLE
Abstract RabbitMQ processing logic

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,8 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   publisher: [
     exchange: "trento.checks",
     connection: "amqp://wanda:wanda@localhost:5672"
-  ]
+  ],
+  processor: Wanda.Messaging.Adapters.AMQP.Processor
 
 config :wanda, Wanda.Catalog, catalog_path: "priv/catalog"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,29 +29,29 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :wanda, Wanda.Catalog, catalog_path: "test/fixtures/catalog"
 
-config :wanda, :messaging,
-  adapter: Wanda.Messaging.Adapters.AMQP,
-  amqp: [
-    consumer: [
-      queue: "trento.test.checks.executions",
-      exchange: "trento.test.checks",
-      routing_key: "executions",
-      prefetch_count: "10",
-      connection: "amqp://wanda:wanda@localhost:5672",
-      queue_options: [
-        durable: false,
-        auto_delete: true
-      ],
-      deadletter_queue_options: [
-        durable: false,
-        auto_delete: true
-      ]
+config :wanda, :messaging, adapter: Wanda.Messaging.Adapters.AMQP
+
+config :wanda, Wanda.Messaging.Adapters.AMQP,
+  consumer: [
+    queue: "trento.test.checks.executions",
+    exchange: "trento.test.checks",
+    routing_key: "executions",
+    prefetch_count: "10",
+    connection: "amqp://wanda:wanda@localhost:5672",
+    queue_options: [
+      durable: false,
+      auto_delete: true
     ],
-    publisher: [
-      exchange: "trento.test.checks",
-      connection: "amqp://wanda:wanda@localhost:5672"
+    deadletter_queue_options: [
+      durable: false,
+      auto_delete: true
     ]
-  ]
+  ],
+  publisher: [
+    exchange: "trento.test.checks",
+    connection: "amqp://wanda:wanda@localhost:5672"
+  ],
+  processor: GenRMQ.Processor.Mock
 
 config :wanda,
   children: [Wanda.Messaging.Adapters.AMQP.Publisher, Wanda.Messaging.Adapters.AMQP.Consumer]

--- a/lib/wanda/messaging/adapters/amqp/consumer.ex
+++ b/lib/wanda/messaging/adapters/amqp/consumer.ex
@@ -21,7 +21,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.Consumer do
   def consumer_tag, do: "wanda"
 
   @impl GenRMQ.Consumer
-  def handle_message(%GenRMQ.Message{payload: _payload} = message) do
+  def handle_message(%GenRMQ.Message{} = message) do
     case processor().process(message) do
       :ok -> GenRMQ.Consumer.ack(message)
       {:error, reason} -> handle_error(message, reason)

--- a/lib/wanda/messaging/adapters/amqp/processor.ex
+++ b/lib/wanda/messaging/adapters/amqp/processor.ex
@@ -5,10 +5,10 @@ defmodule Wanda.Messaging.Adapters.AMQP.Processor do
 
   @behaviour GenRMQ.Processor
 
+  require Logger
+
   alias Trento.Contracts
   alias Wanda.Policy
-
-  require Logger
 
   def process(%GenRMQ.Message{payload: payload} = message) do
     Logger.debug("Received message: #{inspect(message)}")

--- a/lib/wanda/messaging/adapters/amqp/processor.ex
+++ b/lib/wanda/messaging/adapters/amqp/processor.ex
@@ -1,0 +1,19 @@
+defmodule Wanda.Messaging.Adapters.AMQP.Processor do
+  @moduledoc """
+  AMQP processor.
+  """
+
+  alias Trento.Contracts
+  alias Wanda.Policy
+
+  @behaviour GenRMQ.Processor
+
+  require Logger
+
+  def process(%GenRMQ.Message{payload: payload}) do
+    case Contracts.from_event(payload) do
+      {:ok, event} -> Policy.handle_event(event)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/wanda/messaging/adapters/amqp/processor.ex
+++ b/lib/wanda/messaging/adapters/amqp/processor.ex
@@ -3,14 +3,16 @@ defmodule Wanda.Messaging.Adapters.AMQP.Processor do
   AMQP processor.
   """
 
+  @behaviour GenRMQ.Processor
+
   alias Trento.Contracts
   alias Wanda.Policy
 
-  @behaviour GenRMQ.Processor
-
   require Logger
 
-  def process(%GenRMQ.Message{payload: payload}) do
+  def process(%GenRMQ.Message{payload: payload} = message) do
+    Logger.debug("Received message: #{inspect(message)}")
+
     case Contracts.from_event(payload) do
       {:ok, event} -> Policy.handle_event(event)
       {:error, reason} -> {:error, reason}

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -27,7 +27,7 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
   end
 
   describe "handle_error/1" do
-    test "should reject unknown events and move them to the dead letter queue" do
+    test "should reject unknown messages and move them to the dead letter queue" do
       pid = self()
 
       expect(GenRMQ.Processor.Mock, :process, fn _ ->

--- a/test/messaging/adapters/amqp/consumer_test.exs
+++ b/test/messaging/adapters/amqp/consumer_test.exs
@@ -3,11 +3,6 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
 
   import Mox
 
-  alias Trento.Checks.V1.{
-    ExecutionRequested,
-    FactsGathered
-  }
-
   alias Wanda.Messaging.Adapters.AMQP.Publisher
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -15,54 +10,17 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
   @moduletag :integration
 
   describe "handle_message/1" do
-    test "should consume ExecutionRequested" do
+    test "should consume any incoming message" do
       pid = self()
+      message = Faker.StarWars.quote()
 
-      expect(Wanda.Execution.Mock, :start_execution, fn _, _, _, _ ->
+      expect(GenRMQ.Processor.Mock, :process, fn %{payload: payload} ->
+        assert ^message = payload
         send(pid, :consumed)
         :ok
       end)
 
-      assert :ok =
-               %{
-                 execution_id: UUID.uuid4(),
-                 group_id: UUID.uuid4(),
-                 targets: [%{agent_id: UUID.uuid4(), checks: ["check_id"]}],
-                 env: %{
-                   "key" => %{kind: {:string_value, "value"}},
-                   "other_key" => %{kind: {:string_value, "other_value"}}
-                 }
-               }
-               |> ExecutionRequested.new!()
-               |> Trento.Contracts.to_event()
-               |> Publisher.publish_message("executions")
-
-      assert_receive :consumed, 1_000
-    end
-
-    test "should consume FactsGathered" do
-      pid = self()
-
-      expect(Wanda.Execution.Mock, :receive_facts, fn _, _, _ ->
-        send(pid, :consumed)
-        :ok
-      end)
-
-      assert :ok =
-               %{
-                 execution_id: UUID.uuid4(),
-                 agent_id: UUID.uuid4(),
-                 facts_gathered: [
-                   %{
-                     check_id: "check_id",
-                     name: "name",
-                     fact_value: {:value, %{kind: {:string_value, "value"}}}
-                   }
-                 ]
-               }
-               |> FactsGathered.new!()
-               |> Trento.Contracts.to_event()
-               |> Publisher.publish_message("executions")
+      assert :ok = Publisher.publish_message(message, "executions")
 
       assert_receive :consumed, 1_000
     end
@@ -70,7 +28,15 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
 
   describe "handle_error/1" do
     test "should reject unknown events and move them to the dead letter queue" do
+      pid = self()
+
+      expect(GenRMQ.Processor.Mock, :process, fn _ ->
+        send(pid, :consumed)
+        {:error, "invalid payload"}
+      end)
+
       config = Application.fetch_env!(:wanda, Wanda.Messaging.Adapters.AMQP)[:consumer]
+
       connection = Keyword.get(config, :connection)
       routing_key = Keyword.get(config, :routing_key)
       deadletter_queue = Keyword.get(config, :queue) <> "_error"
@@ -84,6 +50,8 @@ defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
       assert_receive {:basic_deliver, "bad_payload", _}
 
       :ok = AMQP.Channel.close(chan)
+
+      assert_receive :consumed, 1_000
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,8 @@ Application.put_env(:wanda, :messaging, adapter: Wanda.Messaging.Adapters.Mock)
 Mox.defmock(Wanda.Execution.Mock, for: Wanda.Execution.Behaviour)
 Application.put_env(:wanda, Wanda.Policy, execution_impl: Wanda.Execution.Mock)
 
+Mox.defmock(GenRMQ.Processor.Mock, for: GenRMQ.Processor)
+
 ExUnit.start(capture_log: true)
 Faker.start()
 


### PR DESCRIPTION
Use GenRMQ processor to abstract the processing logic in Wanda AMQP consumer, this allow us to write better tests and separate concerns.