### PR TITLE
Do not raise if an execution already exists

### DIFF
--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -15,6 +15,8 @@ defmodule Wanda.Executions do
 
   @doc """
   Create a new execution.
+
+  If the execution already exists, it will be returned.
   """
   @spec create_execution!(String.t(), String.t(), [Target.t()]) :: Execution.t()
   def create_execution!(execution_id, group_id, targets) do
@@ -25,7 +27,7 @@ defmodule Wanda.Executions do
       status: :running,
       targets: Enum.map(targets, &Map.from_struct/1)
     })
-    |> Repo.insert!()
+    |> Repo.insert!(on_conflict: :nothing)
   end
 
   @doc """

--- a/test/executions_test.exs
+++ b/test/executions_test.exs
@@ -53,22 +53,6 @@ defmodule Wanda.ExecutionsTest do
                }
              ] = Repo.all(Execution)
     end
-
-    test "should raise an error when trying to create an already existing execution" do
-      [
-        %Execution{execution_id: execution_id, group_id: group_id},
-        %Execution{}
-      ] = insert_list(2, :execution)
-
-      assert_raise Ecto.ConstraintError, fn ->
-        Executions.create_execution!(execution_id, group_id, build_list(2, :target))
-      end
-
-      assert 2 =
-               Execution
-               |> Repo.all()
-               |> length()
-    end
   end
 
   describe "Completing an Execution" do


### PR DESCRIPTION
We should not raise if we try to create an execution that already exists.
This prevents the GenServer to go into a state of crash loops.
If the GenServer is restarted, it will try to re-create the execution, so `on_conflic: :nothing` does the trick.
