### PR TITLE
Integrate TLint into CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,21 @@ jobs:
           mix deps.compile --warnings-as-errors
           mix dialyzer --plt
 
+  tlint:
+    name: Run TLint over checks
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/trento-project/tlint:latest
+      volumes:
+        - ${{ github.workspace }}:/data
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run TLint
+        run: "/home/tlint/tlint lint -f /data/priv/catalog"
+
   static-code-analysis:
     name: Static Code Analysis
     needs: elixir-deps

--- a/priv/catalog/156F64.yaml
+++ b/priv/catalog/156F64.yaml
@@ -51,7 +51,7 @@ values:
       - value: 30000
         when: env.provider == "azure" || env.provider == "aws"
       - value: 20000
-        whens: env.provider == "gcp"
+        when: env.provider == "gcp"
 
 expectations:
   - name: timeout

--- a/priv/catalog/156F64.yaml
+++ b/priv/catalog/156F64.yaml
@@ -51,7 +51,7 @@ values:
       - value: 30000
         when: env.provider == "azure" || env.provider == "aws"
       - value: 20000
-        when: env.provider == "gcp"
+        whens: env.provider == "gcp"
 
 expectations:
   - name: timeout


### PR DESCRIPTION
Integrating TLint into the CI so no new checks hit `main` if not compliant