### PR TITLE
Use strict module ordering

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -157,7 +157,10 @@
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
-          {Credo.Check.Warning.UnsafeExec, []}
+          {Credo.Check.Warning.UnsafeExec, []},
+
+          # Controversial checks
+          {Credo.Check.Readability.StrictModuleLayout, []}
         ],
         disabled: [
           #
@@ -179,7 +182,6 @@
           {Credo.Check.Readability.SeparateAliasRequire, []},
           {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
           {Credo.Check.Readability.Specs, []},
-          {Credo.Check.Readability.StrictModuleLayout, []},
           {Credo.Check.Readability.WithCustomTaggedTuple, []},
           {Credo.Check.Refactor.ABCSize, []},
           {Credo.Check.Refactor.AppendSingleItem, []},

--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Executions do
   This module exposes functionalities to interact with the historycal log of executions.
   """
 
+  import Ecto.Query
+
   alias Wanda.Repo
 
   alias Wanda.Executions.{
@@ -10,8 +12,6 @@ defmodule Wanda.Executions do
     Result,
     Target
   }
-
-  import Ecto.Query
 
   @doc """
   Create a new execution.

--- a/lib/wanda/messaging/adapters/amqp/processor.ex
+++ b/lib/wanda/messaging/adapters/amqp/processor.ex
@@ -5,10 +5,10 @@ defmodule Wanda.Messaging.Adapters.AMQP.Processor do
 
   @behaviour GenRMQ.Processor
 
-  require Logger
-
   alias Trento.Contracts
   alias Wanda.Policy
+
+  require Logger
 
   def process(%GenRMQ.Message{payload: payload} = message) do
     Logger.debug("Received message: #{inspect(message)}")

--- a/lib/wanda/messaging/adapters/amqp/publisher.ex
+++ b/lib/wanda/messaging/adapters/amqp/publisher.ex
@@ -3,9 +3,9 @@ defmodule Wanda.Messaging.Adapters.AMQP.Publisher do
   AMQP publisher.
   """
 
-  alias Trento.Contracts
-
   @behaviour GenRMQ.Publisher
+
+  alias Trento.Contracts
 
   require Logger
 

--- a/lib/wanda_web/api_spec.ex
+++ b/lib/wanda_web/api_spec.ex
@@ -1,11 +1,12 @@
 defmodule WandaWeb.ApiSpec do
   @moduledoc false
 
+  @behaviour OpenApiSpex.OpenApi
+
   alias OpenApiSpex.{Info, OpenApi, Paths, Server}
   alias WandaWeb.{Endpoint, Router}
-  @behaviour OpenApi
 
-  @impl OpenApi
+  @impl true
   def spec do
     # Discover request/response schemas from path specs
     OpenApiSpex.resolve_schema_modules(%OpenApi{

--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -3,9 +3,9 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
   Individual check of the catalog response API spec
   """
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "Check",

--- a/lib/wanda_web/schemas/catalog_response.ex
+++ b/lib/wanda_web/schemas/catalog_response.ex
@@ -3,10 +3,10 @@ defmodule WandaWeb.Schemas.CatalogResponse do
   Checks catalog response API spec
   """
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
   alias WandaWeb.Schemas.CatalogResponse.Check
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "CatalogResponse",

--- a/lib/wanda_web/schemas/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/execution/agent_check_error.ex
@@ -1,11 +1,11 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckError do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.ExecutionResponse.{ExpectationEvaluation, Fact}
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "AgentCheckError",

--- a/lib/wanda_web/schemas/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/execution/agent_check_result.ex
@@ -1,8 +1,6 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckResult do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.ExecutionResponse.{
@@ -10,6 +8,8 @@ defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckResult do
     ExpectationEvaluationError,
     Fact
   }
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "AgentCheckResult",

--- a/lib/wanda_web/schemas/execution/check_result.ex
+++ b/lib/wanda_web/schemas/execution/check_result.ex
@@ -1,11 +1,11 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.CheckResult do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.ExecutionResponse.{AgentCheckResult, ExpectationResult}
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "CheckResult",

--- a/lib/wanda_web/schemas/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/execution/expectation_evaluation.ex
@@ -1,9 +1,9 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluation do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "ExpectationEvaluation",

--- a/lib/wanda_web/schemas/execution/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/execution/expectation_evaluation_error.ex
@@ -1,9 +1,9 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluationError do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "ExpectationEvaluationError",

--- a/lib/wanda_web/schemas/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/execution/expectation_result.ex
@@ -1,9 +1,9 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationResult do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "ExpectationResult",

--- a/lib/wanda_web/schemas/execution/fact.ex
+++ b/lib/wanda_web/schemas/execution/fact.ex
@@ -1,9 +1,9 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.Fact do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "Fact",

--- a/lib/wanda_web/schemas/execution/value.ex
+++ b/lib/wanda_web/schemas/execution/value.ex
@@ -1,9 +1,9 @@
 defmodule WandaWeb.Schemas.ExecutionResponse.Value do
   @moduledoc false
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "Value",

--- a/lib/wanda_web/schemas/execution_response.ex
+++ b/lib/wanda_web/schemas/execution_response.ex
@@ -3,11 +3,11 @@ defmodule WandaWeb.Schemas.ExecutionResponse do
   Execution item response API spec
   """
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.ExecutionResponse.CheckResult
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "ExecutionResponse",

--- a/lib/wanda_web/schemas/list_executions_response.ex
+++ b/lib/wanda_web/schemas/list_executions_response.ex
@@ -3,11 +3,11 @@ defmodule WandaWeb.Schemas.ListExecutionsResponse do
   Execution list response API spec
   """
 
-  require OpenApiSpex
-
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.ExecutionResponse
+
+  require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "ListExecutionsResponse",


### PR DESCRIPTION
Enables a credo check to enforce the ordering of the module parts and reactors the relevant modules.