### PR TITLE
Add /etc/hosts file gatherer documentation

### DIFF
--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -82,7 +82,7 @@ Sample arguments
 | ------------------------------------ | --------------------------------------------------------
 | `localhost`                          | list of IPs resolving `localhost` e.g. `["127.0.0.1", "::1"]`
 | `node1`                              | list of IPs resolving `node1` e.g. `["172.22.0.1"]`
-| `nil` or `""`                        | map with hostnames and IP addresses e.g. `{"localhost": ["127.0.0.1", "::1"], "node1": ["172.22.0.1"]}`
+| `no argument provided`               | map with hostnames and IP addresses e.g. `{"localhost": ["127.0.0.1", "::1"], "node1": ["172.22.0.1"]}`
 
 Specification examples:
 ```yaml

--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -77,10 +77,6 @@ It allows one argument to be specified or none at all:
  - When a hostname is provided as an argument, the gatherer will return an array of IPv4 and/or IPv6 addresses.
  - When no argument is provided, the gatherer will return a map with hostname as keys and arrays with IPv4 and/or IPv6 addresses.
 
-```
-hosts_related_fact = hosts(example.com)
-```
-
 Sample arguments
 | name                                 | Return value          
 | ------------------------------------ | --------------------------------------------------------

--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -21,9 +21,9 @@ Here's a collection of build-in gatherers, with information about how to use the
 | name                             | implementation                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`corosync.conf`](#corosyncconf) | [trento-project/agent/../gatherers/corosyncconf.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/corosyncconf.go) |
+| [`hosts`](#hosts-etchosts)       | [trento-project/agent/../gatherers/hostsfile.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/hostsfile.go)       |
 | [`sbd_config`](#sbd_config)      | [trento-project/agent/../gatherers/sbd.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/sbd.go)                   |
-| [`systemd`](#systemd)            | [trento-project/agent/../gatherers/systemd.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/systemd.go) |
-
+| [`systemd`](#systemd)            | [trento-project/agent/../gatherers/systemd.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/systemd.go)           |
 
 ### corosync.conf
 
@@ -67,6 +67,39 @@ facts:
 ```
 
 For extra information refer to [trento-project/agent/../gatherers/corosyncconf_test.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/corosyncconf_test.go)
+
+### hosts (/etc/hosts)
+
+This gatherer allows accessing the hostnames that are resolvable through `/etc/hosts`. It
+does **not** use domain resolution in any way but instead directly parses the file.
+
+It accepts only one parameter which is the hostname to attempt to resolve.
+
+```
+hosts_related_fact = hosts(example.com)
+```
+
+Sample arguments
+| name                                 | Return value          
+| ------------------------------------ | --------------------------------------------------------
+| `localhost`                          | list of IPs resolving `localhost` e.g. ["127.0.0.1", "::1"]
+| `node1`                              | list of IPs resolving `node1` e.g. ["172.22.0.1"]
+| `...`                                | `...`
+
+Specification examples:
+```yaml
+facts:
+  - name: hosts_node1
+    gatherer: hosts
+    argument: node1
+  
+  - name: hosts_node2
+    gatherer: hosts
+    argument: node2
+
+```
+
+For more information refer to [trento-project/agent/../gatherers/hostsfile_test.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/hostsfile_test.go)
 
 ### sbd_config
 
@@ -114,3 +147,4 @@ facts:
 ```
 
 For extra information refer to [trento-project/agent/../gatherers/systemd_test.go](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/systemd_test.go)
+

--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -73,7 +73,9 @@ For extra information refer to [trento-project/agent/../gatherers/corosyncconf_t
 This gatherer allows accessing the hostnames that are resolvable through `/etc/hosts`. It
 does **not** use domain resolution in any way but instead directly parses the file.
 
-It accepts only one parameter which is the hostname to attempt to resolve.
+It allows one argument to be specified or none at all:
+ - When a hostname is provided as an argument, the gatherer will return an array of IPv4 and/or IPv6 addresses.
+ - When no argument is provided, the gatherer will return a map with hostname as keys and arrays with IPv4 and/or IPv6 addresses.
 
 ```
 hosts_related_fact = hosts(example.com)
@@ -82,9 +84,9 @@ hosts_related_fact = hosts(example.com)
 Sample arguments
 | name                                 | Return value          
 | ------------------------------------ | --------------------------------------------------------
-| `localhost`                          | list of IPs resolving `localhost` e.g. ["127.0.0.1", "::1"]
-| `node1`                              | list of IPs resolving `node1` e.g. ["172.22.0.1"]
-| `...`                                | `...`
+| `localhost`                          | list of IPs resolving `localhost` e.g. `["127.0.0.1", "::1"]`
+| `node1`                              | list of IPs resolving `node1` e.g. `["172.22.0.1"]`
+| `nil` or `""`                        | map with hostnames and IP addresses e.g. `{"localhost": ["127.0.0.1", "::1"], "node1": ["172.22.0.1"]}`
 
 Specification examples:
 ```yaml
@@ -96,6 +98,9 @@ facts:
   - name: hosts_node2
     gatherer: hosts
     argument: node2
+
+  - name: hsots_all
+    gatherer: hosts
 
 ```
 


### PR DESCRIPTION
This PR simply adds a bit of documentation to the newly merged `hosts` gatherer.