### PR TITLE
Check A1244C spec: Corosync consensus timeout is set to expected value

### DIFF
--- a/priv/catalog/A1244C.yaml
+++ b/priv/catalog/A1244C.yaml
@@ -1,0 +1,43 @@
+id: A1244C
+name: Corosync `consensus` timeout
+group: Corosync
+description: |
+  Corosync `consensus` timeout is set to expected value
+remediation: |
+  ## Remediation
+  Adjust the Corosync `consensus` timeout as recommended by the Azure best practices.
+
+  ## References
+  Azure:
+
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
+
+  AWS:
+
+    - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html
+
+  GCP:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-example-for-etccorosynccorosync-conf
+
+  SUSE / KVM:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-example-for-etccorosynccorosync-conf
+
+facts:
+  - name: corosync_consensus_timeout
+    gatherer: corosync.conf
+    argument: totem.consensus
+
+values:
+  - name: expected_consensus_timeout
+    default: 6000
+    conditions:
+      - value: 36000
+        when: env.provider == "azure" || env.provider == "aws"
+      - value: 24000
+        when: env.provider == "gcp"
+
+expectations:
+  - name: consensus_timeout
+    expect: facts.corosync_consensus_timeout == values.expected_consensus_timeout


### PR DESCRIPTION
Adds Check A1244C Spec.