### PR TITLE
Remove installation section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,6 @@
 
 A service responsible to orchestrate Checks executions on a target infrastructure.
 
-## Installation
-
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `wanda` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:wanda, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/wanda>.
-
 ## Developing Checks
 
 Wanda architecture aims to simplify [testing Checks Executions](#testing-executions) and [adding new ones](#adding-new-checks).


### PR DESCRIPTION
Removes the installation section from the readme since we are not publishing to hex.
Tracked debt about documenting the container/development installation