### PR TITLE
Fix protobuf message mapping

### DIFF
--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -41,6 +41,12 @@ defmodule Wanda.Messaging.Mapper do
     )
   end
 
+  @spec from_execution_requested(ExecutionRequested.t()) :: %{
+          execution_id: String.t(),
+          group_id: String.t(),
+          targets: [Target.t()],
+          env: %{String.t() => boolean() | number() | String.t()}
+        }
   def from_execution_requested(%ExecutionRequested{
         execution_id: execution_id,
         group_id: group_id,
@@ -55,6 +61,12 @@ defmodule Wanda.Messaging.Mapper do
     }
   end
 
+  @spec from_facts_gathererd(FactsGathered.t()) :: %{
+          execution_id: String.t(),
+          group_id: String.t(),
+          agent_id: String.t(),
+          facts_gathered: [Fact.t() | FactError.t()]
+        }
   def from_facts_gathererd(%FactsGathered{
         execution_id: execution_id,
         group_id: group_id,

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -3,16 +3,20 @@ defmodule Wanda.Messaging.Mapper do
   Maps domain structures to integration events.
   """
 
-  alias Wanda.Catalog.{Check, Fact}
+  alias Wanda.Catalog
 
   alias Wanda.Executions.{
+    Fact,
+    FactError,
     Result,
     Target
   }
 
   alias Trento.Checks.V1.{
     ExecutionCompleted,
+    ExecutionRequested,
     FactRequest,
+    FactsGathered,
     FactsGatheringRequested,
     FactsGatheringRequestedTarget
   }
@@ -33,13 +37,40 @@ defmodule Wanda.Messaging.Mapper do
     ExecutionCompleted.new!(
       execution_id: execution_id,
       group_id: group_id,
-      result: to_result(result)
+      result: map_result(result)
     )
   end
 
-  defp to_result(:passing), do: :PASSING
-  defp to_result(:warning), do: :WARNING
-  defp to_result(:critical), do: :CRITICAL
+  def from_execution_requested(%ExecutionRequested{
+        execution_id: execution_id,
+        group_id: group_id,
+        targets: targets,
+        env: env
+      }) do
+    %{
+      execution_id: execution_id,
+      group_id: group_id,
+      targets: Target.map_targets(targets),
+      env: Map.new(env, fn {key, %{kind: {_, value}}} -> {key, value} end)
+    }
+  end
+
+  def from_facts_gathererd(%FactsGathered{
+        execution_id: execution_id,
+        group_id: group_id,
+        agent_id: agent_id,
+        facts_gathered: facts_gathered
+      }) do
+    %{
+      execution_id: execution_id,
+      group_id: group_id,
+      agent_id: agent_id,
+      facts_gathered:
+        Enum.map(facts_gathered, fn %{check_id: check_id, name: name, fact_value: fact_value} ->
+          map_gathered_fact(check_id, name, fact_value)
+        end)
+    }
+  end
 
   defp to_facts_gathering_requested_target(
          %Target{agent_id: agent_id, checks: target_checks},
@@ -48,16 +79,38 @@ defmodule Wanda.Messaging.Mapper do
     fact_requests =
       checks
       |> Enum.filter(&(&1.id in target_checks))
-      |> Enum.flat_map(fn %Check{id: check_id, facts: facts} ->
-        to_fact_requests(check_id, facts)
+      |> Enum.flat_map(fn %Catalog.Check{id: check_id, facts: facts} ->
+        map_fact_requests(check_id, facts)
       end)
 
     FactsGatheringRequestedTarget.new!(agent_id: agent_id, fact_requests: fact_requests)
   end
 
-  defp to_fact_requests(check_id, facts) do
-    Enum.map(facts, fn %Fact{name: name, gatherer: gatherer, argument: argument} ->
+  defp map_fact_requests(check_id, facts) do
+    Enum.map(facts, fn %Catalog.Fact{name: name, gatherer: gatherer, argument: argument} ->
       FactRequest.new!(check_id: check_id, name: name, gatherer: gatherer, argument: argument)
     end)
+  end
+
+  defp map_result(:passing), do: :PASSING
+  defp map_result(:warning), do: :WARNING
+  defp map_result(:critical), do: :CRITICAL
+
+  defp map_gathered_fact(check_id, name, {:error_value, %{type: type, message: message}}),
+    do: %FactError{check_id: check_id, name: name, type: type, message: message}
+
+  defp map_gathered_fact(check_id, name, {:value, value}),
+    do: %Fact{check_id: check_id, name: name, value: map_value(value)}
+
+  defp map_value(%{kind: {:list_value, %{values: values}}}) do
+    Enum.map(values, &map_value/1)
+  end
+
+  defp map_value(%{kind: {:struct_value, %{fields: fields}}}) do
+    Enum.into(fields, %{}, fn {key, value} -> {key, map_value(value)} end)
+  end
+
+  defp map_value(%{kind: {_, value}}) do
+    value
   end
 end

--- a/test/messaging/mapper_test.exs
+++ b/test/messaging/mapper_test.exs
@@ -8,10 +8,12 @@ defmodule Wanda.Messaging.MapperTest do
   alias Wanda.Messaging.Mapper
 
   alias Wanda.Catalog.{Check, Fact}
-  alias Wanda.Executions.Target
+  alias Wanda.Executions
 
   alias Trento.Checks.V1.{
     ExecutionCompleted,
+    ExecutionRequested,
+    FactsGathered,
     FactsGatheringRequested
   }
 
@@ -20,8 +22,8 @@ defmodule Wanda.Messaging.MapperTest do
     group_id = UUID.uuid4()
 
     targets = [
-      %Target{agent_id: "agent_1", checks: ["check_1", "check_2"]},
-      %Target{agent_id: "agent_2", checks: ["check_3"]}
+      %Executions.Target{agent_id: "agent_1", checks: ["check_1", "check_2"]},
+      %Executions.Target{agent_id: "agent_2", checks: ["check_3"]}
     ]
 
     checks = [
@@ -111,5 +113,152 @@ defmodule Wanda.Messaging.MapperTest do
                result: ^event_result
              } = Mapper.to_execution_completed(execution)
     end)
+  end
+
+  test "should map from ExecutionRequestedV1 event" do
+    execution_id = UUID.uuid4()
+    group_id = UUID.uuid4()
+
+    execution =
+      ExecutionRequested.new!(
+        execution_id: execution_id,
+        group_id: group_id,
+        targets: [
+          %{
+            agent_id: "agent1",
+            checks: ["check_1", "check_2"]
+          },
+          %{
+            agent_id: "agent3",
+            checks: ["check_3", "check_4"]
+          }
+        ],
+        env: %{
+          some_string: %{
+            kind: {:string_value, "some_string"}
+          },
+          some_number: %{
+            kind: {:number_value, 10}
+          },
+          some_boolean: %{
+            kind: {:boolean_value, true}
+          }
+        }
+      )
+
+    assert %{
+             execution_id: ^execution_id,
+             group_id: ^group_id,
+             targets: [
+               %Executions.Target{
+                 agent_id: "agent1",
+                 checks: ["check_1", "check_2"]
+               },
+               %Executions.Target{
+                 agent_id: "agent3",
+                 checks: ["check_3", "check_4"]
+               }
+             ],
+             env: %{
+               some_string: "some_string",
+               some_number: 10,
+               some_boolean: true
+             }
+           } = Mapper.from_execution_requested(execution)
+  end
+
+  test "should map from FactsGathered event" do
+    execution_id = UUID.uuid4()
+    group_id = UUID.uuid4()
+    agent_id = UUID.uuid4()
+
+    facts =
+      FactsGathered.new!(
+        execution_id: execution_id,
+        group_id: group_id,
+        agent_id: agent_id,
+        facts_gathered: [
+          %{
+            check_id: "check1",
+            name: "string_value",
+            fact_value: {:value, %{kind: {:string_value, "some_string"}}}
+          },
+          %{
+            check_id: "check2",
+            name: "number_value",
+            fact_value: {:value, %{kind: {:number_value, 10}}}
+          },
+          %{
+            check_id: "check3",
+            name: "boolean_value",
+            fact_value: {:value, %{kind: {:boolean_value, true}}}
+          },
+          %{
+            check_id: "check4",
+            name: "list_value",
+            fact_value:
+              {:value,
+               %{
+                 kind:
+                   {:list_value,
+                    %{
+                      values: [
+                        %{kind: {:number_value, 10}},
+                        %{
+                          kind:
+                            {:list_value,
+                             %{
+                               values: [
+                                 %{kind: {:boolean_value, true}}
+                               ]
+                             }}
+                        }
+                      ]
+                    }}
+               }}
+          },
+          %{
+            check_id: "check5",
+            name: "struct_value",
+            fact_value:
+              {:value,
+               %{
+                 kind:
+                   {:struct_value,
+                    %{
+                      fields: %{
+                        some_key: %{
+                          kind:
+                            {:struct_value,
+                             %{
+                               fields: %{
+                                 other_key: %{kind: {:number_value, 10}},
+                                 third_key: %{kind: {:number_value, 15}}
+                               }
+                             }}
+                        }
+                      }
+                    }}
+               }}
+          }
+        ]
+      )
+
+    assert %{
+             execution_id: ^execution_id,
+             group_id: ^group_id,
+             agent_id: ^agent_id,
+             facts_gathered: [
+               %Executions.Fact{check_id: "check1", name: "string_value", value: "some_string"},
+               %Executions.Fact{check_id: "check2", name: "number_value", value: 10},
+               %Executions.Fact{check_id: "check3", name: "boolean_value", value: true},
+               %Executions.Fact{check_id: "check4", name: "list_value", value: [10, [true]]},
+               %Executions.Fact{
+                 check_id: "check5",
+                 name: "struct_value",
+                 value: %{some_key: %{other_key: 10, third_key: 15}}
+               }
+             ]
+           } = Mapper.from_facts_gathererd(facts)
   end
 end

--- a/test/messaging/mapper_test.exs
+++ b/test/messaging/mapper_test.exs
@@ -240,6 +240,11 @@ defmodule Wanda.Messaging.MapperTest do
                       }
                     }}
                }}
+          },
+          %{
+            check_id: "check6",
+            name: "fact_error",
+            fact_value: {:error_value, %{type: "error_type", message: "Error!"}}
           }
         ]
       )
@@ -257,6 +262,12 @@ defmodule Wanda.Messaging.MapperTest do
                  check_id: "check5",
                  name: "struct_value",
                  value: %{some_key: %{other_key: 10, third_key: 15}}
+               },
+               %Executions.FactError{
+                 check_id: "check6",
+                 name: "fact_error",
+                 type: "error_type",
+                 message: "Error!"
                }
              ]
            } = Mapper.from_facts_gathererd(facts)

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -8,7 +8,7 @@ defmodule Wanda.PolicyTest do
     FactsGathered
   }
 
-  alias Wanda.Executions.{Fact, FactError, Target}
+  alias Wanda.Executions.{Fact, Target}
 
   setup :verify_on_exit!
 
@@ -59,12 +59,6 @@ defmodule Wanda.PolicyTest do
                                                                check_id: "check_id",
                                                                name: "name",
                                                                value: "value"
-                                                             },
-                                                             %FactError{
-                                                               check_id: "check_id_error",
-                                                               name: "name_error",
-                                                               type: "error_type",
-                                                               message: "Error!"
                                                              }
                                                            ] ->
       :ok
@@ -80,11 +74,6 @@ defmodule Wanda.PolicyTest do
                    check_id: "check_id",
                    name: "name",
                    fact_value: {:value, %{kind: {:string_value, "value"}}}
-                 },
-                 %{
-                   check_id: "check_id_error",
-                   name: "name_error",
-                   fact_value: {:error_value, %{type: "error_type", message: "Error!"}}
                  }
                ]
              }


### PR DESCRIPTION
Implement the protobug complex types (list/structs) mapping.
I have doutbts whether the `from_` functions should return defined modules types instead of plain maps