### PR TITLE
Fix flaky evaluation test

### DIFF
--- a/test/executions/evaluation_test.exs
+++ b/test/executions/evaluation_test.exs
@@ -631,7 +631,11 @@ defmodule Wanda.Executions.EvaluationTest do
   describe "expressions with arrays" do
     test "should return a passing result" do
       [value | _] =
-        array = 1..10 |> Enum.random() |> Faker.Util.list(fn _ -> Faker.StarWars.character() end)
+        array =
+        1..10
+        |> Enum.random()
+        |> Faker.Util.list(fn _ -> Faker.StarWars.character() end)
+        |> Enum.uniq()
 
       [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
 


### PR DESCRIPTION
Fix a flaky evaluation test. It happens super rarely, but...
This is the error: https://github.com/trento-project/wanda/actions/runs/3496341979/jobs/5854146511
It happens because the list can be populated with duped start wars characters (too small dataset XD)
Adding the `Uniq` fixes the thing