### PR TITLE
Generate and push swagger-ui to gh-pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           mix dialyzer --plt
 
   tlint:
-    name: Run TLint over checks
+    name: Lint checks
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/trento-project/tlint:latest
@@ -209,6 +209,13 @@ jobs:
           key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
       - name: Build docs
         uses: lee-dohm/generate-elixir-docs@v1
+      - name: Generate openapi.json
+        run: mix openapi.spec.json --start-app=false --spec WandaWeb.ApiSpec
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: ./doc/swaggerui
+          spec-file: openapi.json
       - name: Publish to Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ wanda-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Generated OpenAPI spec.
+openapi.json

--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@
 
 A service responsible to orchestrate Checks executions on a target infrastructure.
 
+# Documentation
+
+The documentation is available at [trento-project.io/wanda](https://trento-project.io/wanda/).
+Swagger UI is available at [trento-project.io/wanda/swagger](https://trento-project.io/wanda/swaggerui).
+
 ## Developing Checks
 
 Wanda architecture aims to simplify [testing Checks Executions](#testing-executions) and [adding new ones](#adding-new-checks).
 
 ### Infrastructure
 
-A docker-compose setup is provided to enable seamless experience with the system.
+For development purposes, a [docker-compose file](./docker-compose.yaml) is provided.
+The [docker-compose.checks.yaml](./docker-compose.checks.yaml) provides additional configuration to start an environment for Checks development.
 
 #### Starting a local environment
 
-Start the required infrastructure (see [docker-compose.checks.yaml](./docker-compose.checks.yaml))
+Start the environment with:
 
 ```bash
 $ docker-compose -f docker-compose.checks.yaml up -d
@@ -24,15 +30,15 @@ $ docker-compose -f docker-compose.checks.yaml up -d
 
 Wanda is exposed on port `4000` and the API documentation is available at http://localhost:4000/swaggerui
 
-**Note** that the [message broker](https://www.rabbitmq.com/) **must** be reachable by wanda and all the targets.
+**Note** that the [message broker](https://www.rabbitmq.com/) **must** be reachable by Wanda and all the targets.
 
 ### Testing Executions
 
-With a runnig setup it is possible to easily test Checks and their Execution by:
+With a running setup, it is possible to easily test Checks and their Execution by:
 
 - consulting the catalog
 - starting a Checks Execution
-- checking up the state of the started execution
+- checking the state of an execution
 
 #### **Consulting the catalog**
 
@@ -77,7 +83,7 @@ curl --request POST 'http://localhost:4000/api/checks/executions/start' \
 
 > **execution_id** must be new and unique for every new execution. If an already used **execution_id** is provided, starting the execution fails.
 
-In order to get the detailed information for an execution see [Getting Execution details](#getting-execution-details).
+In order to get detailed information for an execution, see [Getting Execution details](#getting-execution-details).
 
 > Please note that execution is _eventually started_, meaning that a successful response to the previous API call does not guarantee that the execution is running, but that it has been accepted by the system to start.
 
@@ -101,7 +107,7 @@ Refer to the [API doc](http://localhost:4000/swaggerui) for more information abo
 
 Built-in Checks can be found in the Catalog directory at `./priv/catalog/`
 
-In order to implement new checks and test them:
+To implement new checks and test them:
 
 - write a new [Check Specification](./guides/specification.md) file
 - locate the newly created Check in the Catalog directory `./priv/catalog/`

--- a/lib/wanda_web/api_spec.ex
+++ b/lib/wanda_web/api_spec.ex
@@ -11,8 +11,7 @@ defmodule WandaWeb.ApiSpec do
     # Discover request/response schemas from path specs
     OpenApiSpex.resolve_schema_modules(%OpenApi{
       servers: [
-        # Populate the Server info from a phoenix endpoint
-        Server.from_endpoint(Endpoint)
+        endpoint()
       ],
       info: %Info{
         title: "Wanda",
@@ -21,5 +20,17 @@ defmodule WandaWeb.ApiSpec do
       # Populate the paths from a phoenix router
       paths: Paths.from_router(Router)
     })
+  end
+
+  defp endpoint do
+    if Process.whereis(Endpoint) do
+      # Populate the Server info from a phoenix endpoint
+      Server.from_endpoint(Endpoint)
+    else
+      # If the endpoint is not running, use a placeholder
+      # this happens when generarting openapi.json with --start-app=false
+      # e.g. mix openapi.spec.json --start-app=false --spec WandaWeb.ApiSpec
+      %OpenApiSpex.Server{url: "https://trento-project.io/wanda"}
+    end
   end
 end


### PR DESCRIPTION
This PR adds the Swagger UI to gh pages

The documentation will be accessible at https://trento-project.io/wanda/swagger-ui