### PR TITLE
Init before start

### DIFF
--- a/docker-compose.checks.yaml
+++ b/docker-compose.checks.yaml
@@ -15,7 +15,7 @@ services:
       - rabbitmq
     ports:
       - 4000:4000
-    command: start
+    entrypoint: /bin/sh -c "/app/bin/wanda eval \"Wanda.Release.init()\" && /app/bin/wanda start"
     volumes:
       - ./priv/catalog/:/app/catalog:rw
 


### PR DESCRIPTION
This is a leftover from https://github.com/trento-project/wanda/pull/73 and adds a call to `Wanda.Release.init()` before starting Wanda, allowing to have everything set up (e.g. migrations).

I noticed that even if we have wanda container depending on postgres one, at a certain point during startup an error occurs
```
Postgrex.Protocol (#PID<0.135.0>) failed to connect: ** (DBConnection.ConnectionError) tcp connect (postgres:5432): connection refused - :econnrefused
```
However, wanda retries and it connects correctly immediately after, so I thought this being good enough.

If you think it is not enough we could leverage something like https://github.com/vishnubob/wait-for-it as mentioned in https://docs.docker.com/compose/startup-order/