### PR TITLE
Add ability to handle non-existent & malformed Checks supplied to catalog

### DIFF
--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -34,8 +34,7 @@ defmodule Wanda.Catalog do
   def get_check(check_id) do
     with path <- Path.join(get_catalog_path(), "#{check_id}.yaml"),
          {:ok, file_content} <- YamlElixir.read_from_file(path),
-         {:ok, check} <-
-           map_check(file_content) do
+         {:ok, check} <- map_check(file_content) do
       {:ok, check}
     else
       {:error, :malformed_check} = error ->
@@ -93,9 +92,7 @@ defmodule Wanda.Catalog do
      }}
   end
 
-  defp map_check(_) do
-    {:error, :malformed_check}
-  end
+  defp map_check(_), do: {:error, :malformed_check}
 
   defp map_severity(%{"severity" => "critical"}), do: :critical
   defp map_severity(%{"severity" => "warning"}), do: :warning

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -38,7 +38,7 @@ defmodule Wanda.Executions.Server do
 
     targets =
       Enum.map(targets, fn %{checks: target_checks} = target ->
-        %Target{target | checks: intersection(target_checks, checks_ids)}
+        %Target{target | checks: Enum.filter(target_checks, fn check -> check in checks_ids end)}
       end)
 
     maybe_start_execution(execution_id, group_id, targets, checks, env, config)
@@ -151,8 +151,6 @@ defmodule Wanda.Executions.Server do
 
     {:stop, :normal, state}
   end
-
-  defp intersection(list_a, list_b), do: list_a -- list_a -- list_b
 
   defp continue_or_complete_execution(
          %State{

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -34,6 +34,13 @@ defmodule Wanda.Executions.Server do
       |> Target.get_checks_from_targets()
       |> Catalog.get_checks()
 
+    checks_ids = Enum.map(checks, & &1.id)
+
+    targets =
+      Enum.map(targets, fn %{checks: target_checks} = target ->
+        %Target{target | checks: intersection(target_checks, checks_ids)}
+      end)
+
     maybe_start_execution(execution_id, group_id, targets, checks, env, config)
   end
 
@@ -144,6 +151,8 @@ defmodule Wanda.Executions.Server do
 
     {:stop, :normal, state}
   end
+
+  defp intersection(list_a, list_b), do: list_a -- list_a -- list_b
 
   defp continue_or_complete_execution(
          %State{

--- a/test/catalog_test.exs
+++ b/test/catalog_test.exs
@@ -34,77 +34,83 @@ defmodule Wanda.CatalogTest do
     end
 
     test "should load a check from a yaml file properly" do
-      assert %Check{
-               id: "expect_check",
-               name: "Test check",
-               group: "Test",
-               description: "Just a check\n",
-               remediation: "## Remediation\nRemediation text\n",
-               severity: :critical,
-               facts: [
-                 %Fact{
-                   name: "jedi",
-                   gatherer: "wandalorian",
-                   argument: "-o"
-                 },
-                 %Fact{
-                   name: "other_fact",
-                   gatherer: "no_args_gatherer",
-                   argument: ""
-                 }
-               ],
-               values: [
-                 %Value{
-                   conditions: [
-                     %Condition{expression: "some_expression", value: 10},
-                     %Condition{expression: "some_other_expression", value: 15}
-                   ],
-                   default: 5,
-                   name: "expected_value"
-                 },
-                 %Value{
-                   conditions: [
-                     %Condition{expression: "some_third_expression", value: 5}
-                   ],
-                   default: 10,
-                   name: "expected_higher_value"
-                 }
-               ],
-               expectations: [
-                 %Expectation{
-                   name: "some_expectation",
-                   type: :expect,
-                   expression: "facts.jedi == values.expected_value"
-                 },
-                 %Expectation{
-                   name: "some_other_expectation",
-                   type: :expect,
-                   expression: "facts.jedi > values.expected_higher_value"
-                 }
-               ]
-             } = Catalog.get_check("expect_check")
+      assert {:ok,
+              %Check{
+                id: "expect_check",
+                name: "Test check",
+                group: "Test",
+                description: "Just a check\n",
+                remediation: "## Remediation\nRemediation text\n",
+                severity: :critical,
+                facts: [
+                  %Fact{
+                    name: "jedi",
+                    gatherer: "wandalorian",
+                    argument: "-o"
+                  },
+                  %Fact{
+                    name: "other_fact",
+                    gatherer: "no_args_gatherer",
+                    argument: ""
+                  }
+                ],
+                values: [
+                  %Value{
+                    conditions: [
+                      %Condition{expression: "some_expression", value: 10},
+                      %Condition{expression: "some_other_expression", value: 15}
+                    ],
+                    default: 5,
+                    name: "expected_value"
+                  },
+                  %Value{
+                    conditions: [
+                      %Condition{expression: "some_third_expression", value: 5}
+                    ],
+                    default: 10,
+                    name: "expected_higher_value"
+                  }
+                ],
+                expectations: [
+                  %Expectation{
+                    name: "some_expectation",
+                    type: :expect,
+                    expression: "facts.jedi == values.expected_value"
+                  },
+                  %Expectation{
+                    name: "some_other_expectation",
+                    type: :expect,
+                    expression: "facts.jedi > values.expected_higher_value"
+                  }
+                ]
+              }} = Catalog.get_check("expect_check")
     end
 
     test "should load a expect_same expectation type" do
-      assert %Check{
-               values: [],
-               expectations: [
-                 %Expectation{
-                   name: "some_expectation",
-                   type: :expect_same,
-                   expression: "facts.jedi"
-                 }
-               ]
-             } = Catalog.get_check("expect_same_check")
+      assert {:ok,
+              %Check{
+                values: [],
+                expectations: [
+                  %Expectation{
+                    name: "some_expectation",
+                    type: :expect_same,
+                    expression: "facts.jedi"
+                  }
+                ]
+              }} = Catalog.get_check("expect_same_check")
     end
 
     test "should load a warning severity" do
-      assert %Check{severity: :warning} = Catalog.get_check("warning_severity_check")
+      assert {:ok, %Check{severity: :warning}} = Catalog.get_check("warning_severity_check")
+    end
+
+    test "should return an error for non-existent check" do
+      assert {:error, _} = Catalog.get_check("non_existent_check")
     end
 
     test "should load multiple checks" do
       assert [%Check{id: "expect_check"}, %Check{id: "expect_same_check"}] =
-               Catalog.get_checks(["expect_check", "expect_same_check"])
+               Catalog.get_checks(["expect_check", "non_existent_check", "expect_same_check"])
     end
   end
 end

--- a/test/catalog_test.exs
+++ b/test/catalog_test.exs
@@ -15,17 +15,18 @@ defmodule Wanda.CatalogTest do
     test "should return the whole catalog" do
       catalog_path = Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
 
-      files =
+      valid_files =
         catalog_path
         |> File.ls!()
         |> Enum.sort()
+        |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
 
       catalog = Catalog.get_catalog()
-      assert length(files) == length(catalog)
+      assert length(valid_files) == length(catalog)
 
       Enum.with_index(catalog, fn check, index ->
         file_name =
-          files
+          valid_files
           |> Enum.at(index)
           |> Path.basename(".yaml")
 
@@ -106,6 +107,10 @@ defmodule Wanda.CatalogTest do
 
     test "should return an error for non-existent check" do
       assert {:error, _} = Catalog.get_check("non_existent_check")
+    end
+
+    test "should return an error for malformed check" do
+      assert {:error, :malformed_check} = Catalog.get_check("malformed_check")
     end
 
     test "should load multiple checks" do

--- a/test/fixtures/catalog/malformed_check.yaml
+++ b/test/fixtures/catalog/malformed_check.yaml
@@ -1,0 +1,11 @@
+id: malformed_check
+name: Malformed check
+group: Test
+description: |
+  A malformed check
+remediation: |
+  ## Remediation
+  Remediation text
+expectations:
+  - name: some_expectation
+    expect_same: facts.jedi


### PR DESCRIPTION
Currently, when the user provides a Check that does not exist, _or_ a malformed Check file,  when starting execution via the CLI, the server crashes with an exception.

Current example scenario:

```
iex(1)> execution_id = UUID.uuid4()
"60172c74-26b3-4e54-9870-232668abfb1a"
iex(2)> targets = [%Wanda.Executions.Target{agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6", checks: ["non_existent_check", "156F64"]}]
[
  %Wanda.Executions.Target{
    agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6",
    checks: ["non_existent_check", "156F64"]
  }
]
iex(3)> Wanda.Executions.Server.start_execution(execution_id, UUID.uuid4(), targets, %{})
** (YamlElixir.FileNotFoundError) Failed to open file "priv/catalog/non_existent_check.yaml": no such file or directory
    (yaml_elixir 2.9.0) lib/yaml_elixir.ex:22: YamlElixir.read_from_file!/2
    (wanda 0.1.0) lib/wanda/catalog.ex:35: Wanda.Catalog.get_check/1
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (wanda 0.1.0) lib/wanda/executions/server.ex:35: Wanda.Executions.Server.start_execution/5
```

And similarly for a malformed Check file:

```
iex(1)> execution_id = UUID.uuid4()
"180577b8-fe6c-4f05-be8e-3431e3a28e5f"
iex(2)> targets = [%Wanda.Executions.Target{agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6", checks: ["malformed_check", "non_existent_check", "156F64"]}]
[
  %Wanda.Executions.Target{
    agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6",
    checks: ["malformed_check", "non_existent_check", "156F64"]
  }
]
iex(3)> Wanda.Executions.Server.start_execution(execution_id, UUID.uuid4(), targets, %{})
** (FunctionClauseError) no function clause matching in Wanda.Catalog.map_check/1    
    
    The following arguments were given to Wanda.Catalog.map_check/1:
    
        # 1
        %{
          "description" => "A malformed check\n",
          "expectations" => [
            %{"expect_same" => "facts.jedi", "name" => "some_expectation"}
          ],
          "group" => "Test",
          "id" => "malformed_check",
          "name" => "Malformed check",
          "remediation" => "## Remediation\nRemediation text\n"
        }
    
    Attempted function clauses (showing 1 out of 1):
    
        defp map_check(%{
      "id" => id,
      "name" => name,
      "group" => group,
      "description" => description,
      "remediation" => remediation,
      "facts" => facts,
      "expectations" => expectations
    } = check)
    
    (wanda 0.1.0) lib/wanda/catalog.ex:51: Wanda.Catalog.map_check/1
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (wanda 0.1.0) lib/wanda/executions/server.ex:35: Wanda.Executions.Server.start_execution/5
```

This PR changes the behaviour so that when the catalogue is given a non-existent or malformed Check, it logs an error and continues processing the other checks in the list.

```
iex(1)> execution_id = UUID.uuid4()
"710b8bfd-f2b3-4eb2-b390-b6a3f56e0cad"
iex(2)> targets = [%Wanda.Executions.Target{agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6", checks: ["malformed_check", "non_existent_check", "156F64"]}]
[
  %Wanda.Executions.Target{
    agent_id: "99cf8a3a-48d6-57a4-b302-6e4482227ab6",
    checks: ["malformed_check", "non_existent_check", "156F64"]
  }
]
iex(3)> Wanda.Executions.Server.start_execution(execution_id, UUID.uuid4(), targets, %{})
[error] Check with ID malformed_check is malformed. Check if all the required fields are present.
[error] Error getting Check with ID non_existent_check: %YamlElixir.FileNotFoundError{message: "Failed to open file \"priv/catalog/non_existent_check.yaml\": no such file or directory"}
[debug] Starting execution: 710b8bfd-f2b3-4eb2-b390-b6a3f56e0cad
:ok
```