### PR TITLE
Use specific compose ports for wanda dev/test docker-compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
           RABBITMQ_DEFAULT_USER: wanda
           RABBITMQ_DEFAULT_PASS: wanda
         ports:
-          - 5672:5672
+          - 5674:5672
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -20,12 +20,20 @@ config :wanda, Wanda.Repo,
 config :wanda, WandaWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {127, 0, 0, 1}, port: 4001],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,
   secret_key_base: "TDBhePnJFAJxgjzgZAckntbWeD89nTA16RUratDYpzsZyqIyP5gXz1qjGFu2uV4P",
   watchers: []
+
+config :wanda, Wanda.Messaging.Adapters.AMQP,
+  consumer: [
+    connection: "amqp://wanda:wanda@localhost:5674"
+  ],
+  publisher: [
+    connection: "amqp://wanda:wanda@localhost:5674"
+  ]
 
 # ## SSL Support
 #

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,6 +17,15 @@ config :wanda, WandaWeb.Endpoint,
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :wanda, Wanda.Messaging.Adapters.AMQP,
+  consumer: [
+    connection: "amqp://wanda:wanda@localhost:5672"
+  ],
+  publisher: [
+    connection: "amqp://wanda:wanda@localhost:5672"
+  ],
+  processor: Wanda.Messaging.Adapters.AMQP.Processor
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,7 @@ config :wanda, Wanda.Repo,
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :wanda, WandaWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4002],
+  http: [ip: {127, 0, 0, 1}, port: 4001],
   secret_key_base: "HipLWaSCDXUy5NYo9pu2D4cv9utZCdrmF00nHGN9maeDOxyricNSH7dUz+RNFLBY",
   server: false
 
@@ -37,7 +37,7 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
     exchange: "trento.test.checks",
     routing_key: "executions",
     prefetch_count: "10",
-    connection: "amqp://wanda:wanda@localhost:5672",
+    connection: "amqp://wanda:wanda@localhost:5674",
     queue_options: [
       durable: false,
       auto_delete: true
@@ -49,7 +49,7 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   ],
   publisher: [
     exchange: "trento.test.checks",
-    connection: "amqp://wanda:wanda@localhost:5672"
+    connection: "amqp://wanda:wanda@localhost:5674"
   ],
   processor: GenRMQ.Processor.Mock
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.10.5-management-alpine
     ports:
-      - 5672:5672
-      - 15672:15672
+      - 5674:5672
+      - 15674:15672
     environment:
       RABBITMQ_DEFAULT_USER: wanda
       RABBITMQ_DEFAULT_PASS: wanda


### PR DESCRIPTION
This PR assigns specific docker-compose forwarded ports to services so they don't clash with the web compose.

It also moves the development phoenix endpoint from 4000 to 4001.

This way, both web and Wanda can be started at the same time.

The checks dev docker-compose remain unchanged.