### PR TITLE
Add targets execution view

### DIFF
--- a/lib/wanda/executions/execution.ex
+++ b/lib/wanda/executions/execution.ex
@@ -10,7 +10,6 @@ defmodule Wanda.Executions.Execution do
   @type t :: %__MODULE__{}
 
   @fields ~w(execution_id group_id result status started_at completed_at)a
-  @target_fields ~w(agent_id checks)a
 
   @derive {Jason.Encoder, [except: [:__meta__]]}
   @primary_key false
@@ -20,10 +19,7 @@ defmodule Wanda.Executions.Execution do
     field :result, :map, default: %{}
     field :status, Ecto.Enum, values: [:running, :completed]
 
-    embeds_many :targets, Target do
-      field :agent_id, Ecto.UUID
-      field :checks, {:array, :string}
-    end
+    embeds_many :targets, Wanda.Executions.Execution.Target
 
     timestamps(type: :utc_datetime_usec, inserted_at: :started_at, updated_at: false)
     field :completed_at, :utc_datetime_usec
@@ -33,10 +29,28 @@ defmodule Wanda.Executions.Execution do
   def changeset(execution, params) do
     execution
     |> cast(params, @fields)
-    |> cast_embed(:targets, with: &target_changeset/2)
+    |> cast_embed(:targets)
+  end
+end
+
+defmodule Wanda.Executions.Execution.Target do
+  @moduledoc """
+  Schema of target within an execution.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @fields ~w(agent_id checks)a
+
+  @derive {Jason.Encoder, [except: [:id]]}
+  embedded_schema do
+    field :agent_id, Ecto.UUID
+    field :checks, {:array, :string}
   end
 
-  defp target_changeset(target, params) do
-    cast(target, params, @target_fields)
+  def changeset(target, params) do
+    cast(target, params, @fields)
   end
 end

--- a/lib/wanda_web/schemas/execution/target.ex
+++ b/lib/wanda_web/schemas/execution/target.ex
@@ -1,0 +1,21 @@
+defmodule WandaWeb.Schemas.ExecutionResponse.Target do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "Target",
+    description: "Target where execution facts are gathered",
+    type: :object,
+    properties: %{
+      agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+      checks: %Schema{
+        type: :array,
+        items: %Schema{type: :string, description: "Check ID"}
+      }
+    },
+    required: [:agent_id, :checks]
+  })
+end

--- a/lib/wanda_web/schemas/execution_response.ex
+++ b/lib/wanda_web/schemas/execution_response.ex
@@ -5,7 +5,10 @@ defmodule WandaWeb.Schemas.ExecutionResponse do
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.CheckResult
+  alias WandaWeb.Schemas.ExecutionResponse.{
+    CheckResult,
+    Target
+  }
 
   require OpenApiSpex
 
@@ -38,6 +41,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse do
         enum: ["passing", "warning", "critical"],
         description: "Aggregated result of the execution, unknown for running ones"
       },
+      targets: %Schema{type: :array, items: Target},
       critical_count: %Schema{
         type: :integer,
         nullable: true,
@@ -68,6 +72,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse do
       :started_at,
       :completed_at,
       :result,
+      :targets,
       :critical_count,
       :warning_count,
       :passing_count,

--- a/lib/wanda_web/views/execution_view.ex
+++ b/lib/wanda_web/views/execution_view.ex
@@ -22,6 +22,7 @@ defmodule WandaWeb.ExecutionView do
           group_id: group_id,
           status: status,
           result: result,
+          targets: targets,
           started_at: started_at,
           completed_at: completed_at
         }
@@ -34,6 +35,7 @@ defmodule WandaWeb.ExecutionView do
       execution_id: execution_id,
       group_id: group_id,
       result: map_result(status, result),
+      targets: targets,
       critical_count: count_results(status, result, "critical"),
       warning_count: count_results(status, result, "warning"),
       passing_count: count_results(status, result, "passing"),

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,6 +8,7 @@ defmodule Wanda.Factory do
   alias Wanda.Executions.{
     AgentCheckResult,
     CheckResult,
+    Execution,
     ExpectationEvaluation,
     ExpectationEvaluationError,
     ExpectationResult,
@@ -16,8 +17,6 @@ defmodule Wanda.Factory do
     Result,
     Target
   }
-
-  alias Wanda.Executions.Execution
 
   def check_factory(attrs) do
     %Catalog.Check{
@@ -151,7 +150,7 @@ defmodule Wanda.Factory do
       execution_id: Faker.UUID.v4(),
       group_id: Faker.UUID.v4(),
       status: :running,
-      targets: [],
+      targets: Enum.map(build_list(2, :target), &Map.from_struct(&1)),
       started_at: DateTime.utc_now()
     }
   end

--- a/test/wanda_web/views/execution_view_test.exs
+++ b/test/wanda_web/views/execution_view_test.exs
@@ -45,7 +45,7 @@ defmodule WandaWeb.ExecutionViewTest do
     test "renders show.json for a running execution" do
       started_at = DateTime.utc_now()
 
-      %Execution{execution_id: execution_id, group_id: group_id} =
+      %Execution{execution_id: execution_id, group_id: group_id, targets: targets} =
         execution =
         :execution
         |> build(started_at: started_at)
@@ -62,6 +62,7 @@ defmodule WandaWeb.ExecutionViewTest do
                warning_count: nil,
                passing_count: nil,
                timeout: nil,
+               targets: ^targets,
                check_results: nil
              } = render(WandaWeb.ExecutionView, "show.json", execution: execution)
     end


### PR DESCRIPTION
As we were already storing the targets for each execution, this change exposes them in the executions view.
This is needed in order to know which are the targets and their checks on the FE execution view, when the execution is on running state.

![image](https://user-images.githubusercontent.com/36370954/204322186-ea769ecb-23e8-45ba-ae00-79cee691ea40.png)
