### PR TITLE
Add last execution by group

### DIFF
--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -31,11 +31,21 @@ defmodule Wanda.Executions do
   end
 
   @doc """
-  Get a result by execution_id.
+  Get an execution by execution_id.
   """
   @spec get_execution!(String.t()) :: Execution.t()
   def get_execution!(execution_id) do
     Repo.get!(Execution, execution_id)
+  end
+
+  @doc """
+  Get the last execution of a group by group_id.
+  """
+  @spec get_last_execution_by_group_id!(String.t()) :: Execution.t()
+  def get_last_execution_by_group_id!(group_id) do
+    Execution
+    |> last(:started_at)
+    |> Repo.one!(group_id: group_id)
   end
 
   @doc """

--- a/lib/wanda_web/controllers/execution_controller.ex
+++ b/lib/wanda_web/controllers/execution_controller.ex
@@ -54,6 +54,24 @@ defmodule WandaWeb.ExecutionController do
       404 => OpenApiSpex.JsonErrorResponse.response()
     }
 
+  operation :last,
+    summary: "Get the last execution of a group",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Group ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ]
+    ],
+    responses: %{
+      200 => {"Execution", "application/json", ExecutionResponse},
+      404 => OpenApiSpex.JsonErrorResponse.response()
+    }
+
   operation :start,
     summary: "Start a Checks Execution",
     description: "Start a Checks Execution on the target infrastructure",
@@ -74,6 +92,12 @@ defmodule WandaWeb.ExecutionController do
     execution = Executions.get_execution!(execution_id)
 
     render(conn, execution: execution)
+  end
+
+  def last(conn, %{id: group_id}) do
+    execution = Executions.get_last_execution_by_group_id!(group_id)
+
+    render(conn, :show, execution: execution)
   end
 
   def start(

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Router do
     pipe_through :api
 
     resources "/executions", ExecutionController, only: [:index, :show]
+    get "/groups/:id/executions/last", ExecutionController, :last
     post "/executions/start", ExecutionController, :start
     get "/catalog", CatalogController, :catalog
   end

--- a/test/executions_test.exs
+++ b/test/executions_test.exs
@@ -7,7 +7,7 @@ defmodule Wanda.ExecutionsTest do
   alias Wanda.Executions
   alias Wanda.Executions.{Execution, Target}
 
-  describe "Creating an Execution" do
+  describe "create an execution" do
     test "should correctly create a running execution" do
       [
         %Execution{execution_id: execution_1, group_id: group_1},
@@ -55,7 +55,7 @@ defmodule Wanda.ExecutionsTest do
     end
   end
 
-  describe "Completing an Execution" do
+  describe "complete an execution" do
     test "should complete a running execution" do
       %Execution{
         execution_id: execution_id,
@@ -85,7 +85,7 @@ defmodule Wanda.ExecutionsTest do
     end
   end
 
-  describe "Getting Execution" do
+  describe "get an execution" do
     test "no filter or pagination applied" do
       [
         %Execution{execution_id: execution_1, group_id: group_1},
@@ -125,6 +125,16 @@ defmodule Wanda.ExecutionsTest do
                %Execution{execution_id: ^execution_2, group_id: ^group_2},
                %Execution{execution_id: ^execution_1, group_id: ^group_1}
              ] = Executions.list_executions(%{page: 2, items_per_page: 3})
+    end
+  end
+
+  describe "get the last execution of group" do
+    test "should return the last execution of a group" do
+      %Execution{execution_id: last_execution_id, group_id: group_id} =
+        10 |> insert_list(:execution) |> List.last()
+
+      assert %Execution{execution_id: ^last_execution_id} =
+               Executions.get_last_execution_by_group_id!(group_id)
     end
   end
 end

--- a/test/wanda_web/controllers/execution_controller_test.exs
+++ b/test/wanda_web/controllers/execution_controller_test.exs
@@ -67,6 +67,26 @@ defmodule WandaWeb.ExecutionControllerTest do
     end
   end
 
+  describe "get last execution by group id" do
+    test "should return the last execution", %{conn: conn} do
+      %{group_id: group_id} = 10 |> insert_list(:execution) |> List.last()
+
+      json =
+        conn
+        |> get("/api/checks/groups/#{group_id}/executions/last")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ExecutionResponse", api_spec)
+    end
+
+    test "should return a 404", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get(conn, "/api/checks/groups/#{UUID.uuid4()}/executions/last")
+      end
+    end
+  end
+
   describe "start execution" do
     test "should start an execution", %{conn: conn} do
       execution_id = UUID.uuid4()


### PR DESCRIPTION
This PR adds an API endpoint to retrieve the last execution by `group_id`.
We need this in the FE to get the last executions in the components instead of fetching a list with an artificial pagination.