### PR TITLE
Improve Execution open api doc

### DIFF
--- a/lib/wanda/executions/agent_check_error.ex
+++ b/lib/wanda/executions/agent_check_error.ex
@@ -18,8 +18,8 @@ defmodule Wanda.Executions.AgentCheckError do
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          facts: [Fact.t() | FactError.t()],
-          type: :timeout,
+          facts: [Fact.t() | FactError.t()] | nil,
+          type: :fact_gathering_error | :timeout,
           message: String.t()
         }
 end

--- a/lib/wanda_web/schemas/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/execution/agent_check_error.ex
@@ -22,11 +22,12 @@ defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckError do
             Fact,
             FactError
           ]
-        }
+        },
+        nullable: true
       },
       type: %Schema{type: :string, description: "Error type"},
       message: %Schema{type: :string, description: "Error message"}
     },
-    required: [:agent_id, :facts, :type, :message]
+    required: [:agent_id, :type, :message]
   })
 end

--- a/lib/wanda_web/schemas/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/execution/agent_check_error.ex
@@ -3,23 +3,30 @@ defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckError do
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{ExpectationEvaluation, Fact}
+  alias WandaWeb.Schemas.ExecutionResponse.{Fact, FactError}
 
   require OpenApiSpex
 
   OpenApiSpex.schema(%{
     title: "AgentCheckError",
-    description: "The result of check on a specific agent",
+    description:
+      "An error describing that some of the facts could not be gathered on a specific agent eg. gathering failure or timeout",
     type: :object,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
-      facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
-      expectation_evaluations: %Schema{
+      facts: %Schema{
+        description: "Facts gathered, possibly with errors, from the target",
         type: :array,
-        items: ExpectationEvaluation,
-        description: "Expectation evaluated during the check execution"
-      }
+        items: %Schema{
+          oneOf: [
+            Fact,
+            FactError
+          ]
+        }
+      },
+      type: %Schema{type: :string, description: "Error type"},
+      message: %Schema{type: :string, description: "Error message"}
     },
-    required: [:agent_id, :facts, :expectation_evaluations]
+    required: [:agent_id, :facts, :type, :message]
   })
 end

--- a/lib/wanda_web/schemas/execution/check_result.ex
+++ b/lib/wanda_web/schemas/execution/check_result.ex
@@ -3,7 +3,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse.CheckResult do
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{AgentCheckResult, ExpectationResult}
+  alias WandaWeb.Schemas.ExecutionResponse.{AgentCheckError, AgentCheckResult, ExpectationResult}
 
   require OpenApiSpex
 
@@ -14,7 +14,15 @@ defmodule WandaWeb.Schemas.ExecutionResponse.CheckResult do
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       expectation_results: %Schema{type: :array, items: ExpectationResult},
-      agents_check_results: %Schema{type: :array, items: AgentCheckResult},
+      agents_check_results: %Schema{
+        type: :array,
+        items: %Schema{
+          oneOf: [
+            AgentCheckResult,
+            AgentCheckError
+          ]
+        }
+      },
       result: %Schema{
         type: :string,
         enum: ["passing", "warning", "critical"],

--- a/lib/wanda_web/schemas/execution/fact_error.ex
+++ b/lib/wanda_web/schemas/execution/fact_error.ex
@@ -1,0 +1,20 @@
+defmodule WandaWeb.Schemas.ExecutionResponse.FactError do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "FactError",
+    description: "An error describing that a fact could not be gathered",
+    type: :object,
+    properties: %{
+      check_id: %Schema{type: :string, description: "Check ID"},
+      name: %Schema{type: :string, description: "Fact name"},
+      type: %Schema{type: :string, description: "Error type"},
+      message: %Schema{type: :string, description: "Error message"}
+    },
+    required: [:check_id, :name, :type, :message]
+  })
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,6 +6,7 @@ defmodule Wanda.Factory do
   alias Wanda.Catalog
 
   alias Wanda.Executions.{
+    AgentCheckError,
     AgentCheckResult,
     CheckResult,
     Execution,
@@ -130,7 +131,17 @@ defmodule Wanda.Factory do
   def agent_check_result_factory do
     %AgentCheckResult{
       agent_id: UUID.uuid4(),
+      facts: build_list(2, :fact),
       expectation_evaluations: build_list(2, :expectation_evaluation)
+    }
+  end
+
+  def agent_check_error_factory do
+    %AgentCheckError{
+      agent_id: UUID.uuid4(),
+      facts: build_list(2, :fact_error),
+      type: :fact_gathering_error,
+      message: Faker.StarWars.quote()
     }
   end
 


### PR DESCRIPTION
This PR aims to improve the api doc by adjusting `ChecksResult` to support `AgentCheckError`