### PR TITLE
Use Kernel.-- instead of Enum.filter

### DIFF
--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -38,7 +38,7 @@ defmodule Wanda.Executions.Server do
 
     targets =
       Enum.map(targets, fn %{checks: target_checks} = target ->
-        %Target{target | checks: Enum.filter(target_checks, fn check -> check in checks_ids end)}
+        %Target{target | checks: target_checks -- target_checks -- checks_ids}
       end)
 
     maybe_start_execution(execution_id, group_id, targets, checks, env, config)


### PR DESCRIPTION
Based on this: https://github.com/prodis/miss-elixir/blob/8b3a0a24114877aad4fe191fb0c60a0788827cb5/lib/miss/list.ex#L9

using @jamie-suse proposed solution to intersect the existing checks 