### PR TITLE
Add severity to the JSON schema

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -6,6 +6,9 @@
       "id": {
         "type": "string"
       },
+      "severity": {
+        "type": "string"
+      },
       "name": {
         "type": "string"
       },


### PR DESCRIPTION
As above, the JSON schema used to validate the checks was missing the `severity` field