### PR TITLE
Add check DA114A: Corosync has at least 2 rings configured

### DIFF
--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -40,5 +40,8 @@ values:
         when: env.provider == "azure" || env.provider == "gcp"
 
 expectations:
+  - name: has_some_nodes_configured
+    expect: facts.corosync_nodes.len() > 0
+
   - name: expected_number_of_rings_per_node
     expect: facts.corosync_nodes.all(|node| node.keys().filter(|prop| prop.starts_with("ring")).len() >= values.expected_corosync_rings_per_node)

--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -1,0 +1,44 @@
+id: DA114A
+name: Corosync rings
+group: Corosync
+description: |
+  Corosync has at least 2 rings configured
+remediation: |
+  ## Abstract
+  It is strongly recommended to add a second ring to the corosync communication.
+
+  ## References
+  Azure:
+
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
+
+  AWS:
+
+    - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html
+
+  GCP:
+
+    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
+
+  SUSE / KVM:
+
+   - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-example-for-etccorosynccorosync-conf
+   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-checking-and-adapting-the-corosync-and-sbd-configuration
+
+severity: warning
+
+facts:
+  - name: corosync_nodes
+    gatherer: corosync.conf
+    argument: nodelist.node
+
+values:
+  - name: expected_corosync_rings_per_node
+    default: 2
+    conditions:
+      - value: 1
+        when: env.provider == "azure" || env.provider == "gcp"
+
+expectations:
+  - name: expected_number_of_rings_per_node
+    expect: facts.corosync_nodes.all(|node| node.keys().filter(|prop| prop.starts_with("ring")).len() >= values.expected_corosync_rings_per_node)


### PR DESCRIPTION
Ports [current check 1.1.9 DA114A](https://github.com/trento-project/runner/blob/main/runner/ansible/roles/checks/1.1.9/tasks/main.yml).

Leverages the [`corosync.conf` gatherer](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/corosyncconf.go) that when provided the argument `nodelist.node` as follows
```yaml
facts:
  - name: corosync_nodes
    gatherer: corosync.conf
    argument: nodelist.node
```
returns the following [data structure](https://github.com/trento-project/agent/blob/main/internal/factsengine/gatherers/corosyncconf_test.go#L101): a list of configured node and their relevant information.

```rust
[
  {
    "nodeid" => 1,
    "ring0_addr" => "10.0.0.119",
    "ring1_addr" => "10.0.0.120",
  },
  {
    "nodeid" => 2,
    "ring0_addr" => "10.0.1.153",
    "ring1_addr" => "10.0.1.154",
  }
]
```

allowing us to write the following
```yaml
expectations:
  - name: expected_number_of_rings_per_node
    expect: facts.corosync_nodes.all(|node| node.keys().filter(|prop| prop.starts_with("ring")).len() >= values.expected_corosync_rings_per_node)
```
---

Decided to rescope this check to only _the number of configured rings per node_.