### PR TITLE
rewrite trento community checks regarding 'sbd dump' configuration

### DIFF
--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -1,0 +1,36 @@
+id: "68626E"
+name: "SBD msgwait timeout"
+group: "SBD"
+description: |
+  SBD msgwait timeout value is at least two times the watchdog timeout
+remediation: |
+  ## Remediation
+  Make sure you configure your the SBD msgwait to 2 * (SBD Watchdog Timeout) as recommended on the best practices.
+
+  The SBD is not used in GCP or AWS environments.
+  ## References
+  Azure:
+
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-the-iscsi-target-server-sbd-device
+
+  AWS:
+
+  GCP:
+
+  Nutanix:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-verifying-the-sbd-device
+
+  SUSE / KVM:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-verifying-the-sbd-device
+
+facts:
+  - name: dump_sbd_devices
+    gatherer: sbd_dump
+    #should only run on 'azure', 'nutanix' or 'kvm', NOT on 'gcp' or 'aws'
+
+expectations:
+  - name: expectations_sbd_msgwait_timeout
+    expect: facts.dump_sbd_devices.values().all(|sbddev| sbddev.timeout_msgwait >= 2 * sbddev.timeout_watchdog)

--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -1,6 +1,6 @@
 id: "68626E"
-name: "SBD msgwait timeout"
-group: "SBD"
+name: SBD msgwait timeout
+group: SBD
 description: |
   SBD msgwait timeout value is at least two times the watchdog timeout
 remediation: |

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -1,0 +1,44 @@
+id: "B089BE"
+name: "SBD watchdog timeout"
+group: "SBD"
+description: |
+  SBD watchdog timeout is set to the recommended value
+remediation: |
+  ## Remediation
+  Make sure you configure your SBD Watchdog Timeout to `the recommended value` seconds as recommended on the best practices.
+
+  The SBD is not used in GCP or AWS environments.
+
+  ## References
+  Azure:
+
+    -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
+
+  AWS:
+
+  GCP:
+
+  Nutanix:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+
+  SUSE / KVM:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+
+facts:
+  - name: dump_sbd_devices
+    gatherer: sbd_dump
+
+values:
+  - name: expected_watchdog_timeout
+    #should only run on 'azure', 'nutanix' or 'kvm', NOT on 'gcp' or 'aws'
+    default: 15
+    conditions:
+      - value: 60
+        when: env.provider == "azure"
+
+expectations:
+  - name: expectations_watchdog_timeout
+    expect: facts.dump_sbd_devices.values().all(|sbddev| sbddev.timeout_watchdog == values.expected_watchdog_timeout)
+

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -1,6 +1,6 @@
 id: "B089BE"
-name: "SBD watchdog timeout"
-group: "SBD"
+name: SBD watchdog timeout
+group: SBD
 description: |
   SBD watchdog timeout is set to the recommended value
 remediation: |


### PR DESCRIPTION
fixing (jsc#CFSA-1093, jsc#CFSA-1121)
check 1.3.5/B089BE and 1.3.6/68626E
tested against trento-agent-1.2.0+git.dev26.1671616226.7701513-150300.1.1.x86_64.rpm with one and 2 sbd devices