### PR TITLE
rewrite trento community checks regarding 'cibadmin' configuration

### DIFF
--- a/priv/catalog/205AF7.yaml
+++ b/priv/catalog/205AF7.yaml
@@ -38,14 +38,13 @@ remediation: |
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-fencing.html#sec-ha-fencing-recommend
 
 facts:
-  - name: fencing_enabled
+  - name: crm_config_properties
     gatherer: cibadmin
     argument: cib.configuration.crm_config.cluster_property_set
 
-#expected value: true
 
 expectations:
   - name: expectations_fencing_enabled
-    expect: facts.fencing_enabled[facts.fencing_enabled.index_of(|item| item.id == "cib-bootstrap-options")].nvpair.filter(|prop| prop.name == "stonith-enabled")[0].value
+    expect: facts.crm_config_properties.find(|item| item.id == "cib-bootstrap-options").nvpair.find(|prop| prop.name == "stonith-enabled").value
 
 

--- a/priv/catalog/205AF7.yaml
+++ b/priv/catalog/205AF7.yaml
@@ -42,9 +42,9 @@ facts:
     gatherer: cibadmin
     argument: cib.configuration.crm_config.cluster_property_set
 
-
 expectations:
   - name: expectations_fencing_enabled
-    expect: facts.crm_config_properties.find(|item| item.id == "cib-bootstrap-options").nvpair.find(|prop| prop.name == "stonith-enabled").value
-
-
+    expect: |
+      facts.crm_config_properties
+           .find(|item| item.id == "cib-bootstrap-options").nvpair
+           .find(|prop| prop.name == "stonith-enabled").value

--- a/priv/catalog/205AF7.yaml
+++ b/priv/catalog/205AF7.yaml
@@ -1,0 +1,51 @@
+id: "205AF7"
+name: fencing enabled
+group: Pacemaker
+description: |
+  Fencing is enabled in the cluster properties 'cib-bootstrap-options': stonith-enabled
+remediation: |
+  ## Abstract
+  Fencing is mandatory to guarantee data integrity for your SAP Applications.
+  Running a HA Cluster without fencing is not supported and might cause data loss.
+
+  ## Remediation
+  Execute the following command to enable it:
+  ```
+  crm configure property stonith-enabled=true
+  ```
+
+  ## References
+  AZURE:
+
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#create-a-stonith-device-on-the-pacemaker-cluster
+
+  AWS:
+
+    - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-resources.html
+
+  GCP:
+
+    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
+
+  Nutanix:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+    - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-fencing.html#sec-ha-fencing-recommend
+
+  SUSE / KVM:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+    - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-fencing.html#sec-ha-fencing-recommend
+
+facts:
+  - name: fencing_enabled
+    gatherer: cibadmin
+    argument: cib.configuration.crm_config.cluster_property_set
+
+#expected value: true
+
+expectations:
+  - name: expectations_fencing_enabled
+    expect: facts.fencing_enabled[facts.fencing_enabled.index_of(|item| item.id == "cib-bootstrap-options")].nvpair.filter(|prop| prop.name == "stonith-enabled")[0].value
+
+

--- a/priv/catalog/373DB8.yaml
+++ b/priv/catalog/373DB8.yaml
@@ -36,10 +36,10 @@ remediation: |
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
 
 facts:
-  - name: fencing_timeout
+  - name: crm_config_properties
     gatherer: cibadmin
     argument: cib.configuration.crm_config.cluster_property_set
-  - name: fence_azure_arm
+  - name: resources_primitives
     gatherer: cibadmin
     argument: cib.configuration.resources.primitive
 
@@ -57,8 +57,15 @@ values:
 expectations:
   - name: expectations_fencing_timeout
     expect: |
-      let fencing_timeout=facts.fencing_timeout[facts.fencing_timeout.index_of(|item| item.id == "cib-bootstrap-options")].nvpair.filter(|prop| prop.name == "stonith-timeout")[0].value;
-      let fence_azure_arm_detected=facts.fence_azure_arm.filter(|item| item.type == "fence_azure_arm").len() != 0;
+      let fencing_timeout=
+          facts.crm_config_properties
+               .find(|item| item.id == "cib-bootstrap-options").nvpair
+               .find(|prop| prop.name == "stonith-timeout").value;
+
+      let fence_azure_arm_detected=
+          facts.resources_primitives
+               .filter(|item| item.type == "fence_azure_arm").len() != 0;
+
       if fence_azure_arm_detected {
         fencing_timeout == 900;
       } else {

--- a/priv/catalog/373DB8.yaml
+++ b/priv/catalog/373DB8.yaml
@@ -1,0 +1,67 @@
+id: "373DB8"
+name: fencing timeout
+group: Pacemaker
+description: |
+  Cluster fencing timeout is configured correctly in the cluster properties 'cib-bootstrap-options': stonith-timeout
+remediation: |
+  ## Abstract
+  The fencing timeout (`stonith-timeout`) determines the time Pacemaker will wait for fencing to succeed.
+  The recommended values on Azure are `144` seconds for SBD only or `900` seconds when using SBD combined with the Azure Fence agent.
+
+  ## Remediation
+  Execute the following command to adjust the timeout for your usecase:
+  ```crm configure property stonith-timeout=144```
+  or
+  ```crm configure property stonith-timeout=900```
+
+  ## References
+  Azure:
+
+    - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#create-a-stonith-device-on-the-pacemaker-cluster
+
+  AWS:
+
+    - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-resources.html
+
+  GCP:
+
+    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
+
+  Nutanix:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+
+  SUSE / KVM:
+
+    - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
+
+facts:
+  - name: fencing_timeout
+    gatherer: cibadmin
+    argument: cib.configuration.crm_config.cluster_property_set
+  - name: fence_azure_arm
+    gatherer: cibadmin
+    argument: cib.configuration.resources.primitive
+
+values:
+  - name: expected_fencing_timeout
+    default: 150
+    conditions:
+      - value: 600
+        when: env.provider == "aws"
+      - value: 300
+        when: env.provider == "gcp"
+      - value: 144
+        when: env.provider == "azure"
+
+expectations:
+  - name: expectations_fencing_timeout
+    expect: |
+      let fencing_timeout=facts.fencing_timeout[facts.fencing_timeout.index_of(|item| item.id == "cib-bootstrap-options")].nvpair.filter(|prop| prop.name == "stonith-timeout")[0].value;
+      let fence_azure_arm_detected=facts.fence_azure_arm.filter(|item| item.type == "fence_azure_arm").len() != 0;
+      if fence_azure_arm_detected {
+        fencing_timeout == 900;
+      } else {
+        fencing_timeout >= values.expected_fencing_timeout;
+      }
+

--- a/priv/catalog/373DB8.yaml
+++ b/priv/catalog/373DB8.yaml
@@ -54,6 +54,9 @@ values:
       - value: 144
         when: env.provider == "azure"
 
+  - name: expected_azure_fencing_timeout
+    default: 900
+
 expectations:
   - name: expectations_fencing_timeout
     expect: |
@@ -67,8 +70,7 @@ expectations:
                .filter(|item| item.type == "fence_azure_arm").len() != 0;
 
       if fence_azure_arm_detected {
-        fencing_timeout == 900;
+        fencing_timeout == values.expected_azure_fencing_timeout;
       } else {
         fencing_timeout >= values.expected_fencing_timeout;
       }
-


### PR DESCRIPTION
fixing jsc#CFSA-1065, jsc#CFSA-1078
check 1.2.1/205AF7 and 1.2.2/373DB8
tested against trento-agent-1.2.0+git.dev31.1671807562.9159f09-150300.1.1.x86_64.rpm
As I do not have access to an azure environment for now, I could not test the 'fencing_azure_arm' condition with real data.

Just found out that 'is_empty()' is working (sadly NOT in the playground, so I skipped it in the first try)
So check "373DB8" can use
`let fence_azure_arm_detected=!facts.fence_azure_arm.filter(|item| item.type == "fence_azure_arm").is_empty();`
instead of` .len() != 0`
Preferences?