### PR TITLE
Implement when condition

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -15,6 +15,9 @@
       "group": {
         "type": "string"
       },
+      "when": {
+        "type": "string"
+      },
       "description": {
         "type": "string"
       },

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -18,13 +18,14 @@ defmodule Wanda.Catalog do
   @doc """
   Get the checks catalog with all checks
   """
-  @spec get_catalog() :: [Check.t()]
-  def get_catalog do
+  @spec get_catalog(map()) :: [Check.t()]
+  def get_catalog(env \\ %{}) do
     get_catalog_path()
     |> Path.join("/*")
     |> Path.wildcard()
     |> Enum.map(&Path.basename(&1, ".yaml"))
     |> get_checks()
+    |> Enum.filter(&when_condition(&1, env))
   end
 
   @doc """
@@ -63,6 +64,17 @@ defmodule Wanda.Catalog do
     end)
   end
 
+  defp when_condition(%Check{when: nil}, _), do: true
+
+  defp when_condition(%Check{when: when_clause}, env) do
+    scope = %{"env" => env}
+
+    case Rhai.eval(when_clause, scope) do
+      {:ok, true} -> true
+      _ -> false
+    end
+  end
+
   defp get_catalog_path do
     Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
   end
@@ -85,6 +97,7 @@ defmodule Wanda.Catalog do
        group: group,
        description: description,
        remediation: remediation,
+       when: Map.get(check, "when"),
        severity: map_severity(check),
        facts: Enum.map(facts, &map_fact/1),
        values: map_values(check),

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -18,7 +18,7 @@ defmodule Wanda.Catalog do
   @doc """
   Get the checks catalog with all checks
   """
-  @spec get_catalog(map()) :: [Check.t()]
+  @spec get_catalog(%{String.t() => String.t()}) :: [Check.t()]
   def get_catalog(env \\ %{}) do
     get_catalog_path()
     |> Path.join("/*")
@@ -65,12 +65,12 @@ defmodule Wanda.Catalog do
     |> Enum.filter(&when_condition(&1, env))
   end
 
+  defp when_condition(_, env) when env == %{}, do: true
+
   defp when_condition(%Check{when: nil}, _), do: true
 
   defp when_condition(%Check{when: when_clause}, env) do
-    scope = %{"env" => env}
-
-    case Rhai.eval(when_clause, scope) do
+    case Rhai.eval(when_clause, %{"env" => env}) do
       {:ok, true} -> true
       _ -> false
     end

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -24,8 +24,7 @@ defmodule Wanda.Catalog do
     |> Path.join("/*")
     |> Path.wildcard()
     |> Enum.map(&Path.basename(&1, ".yaml"))
-    |> get_checks()
-    |> Enum.filter(&when_condition(&1, env))
+    |> get_checks(env)
   end
 
   @doc """
@@ -54,14 +53,16 @@ defmodule Wanda.Catalog do
   @doc """
   Get specific checks from the catalog.
   """
-  @spec get_checks([String.t()]) :: [Check.t()]
-  def get_checks(checks_id) do
-    Enum.flat_map(checks_id, fn check_id ->
+  @spec get_checks([String.t()], map()) :: [Check.t()]
+  def get_checks(checks_id, env) do
+    checks_id
+    |> Enum.flat_map(fn check_id ->
       case get_check(check_id) do
         {:ok, check} -> [check]
         {:error, _} -> []
       end
     end)
+    |> Enum.filter(&when_condition(&1, env))
   end
 
   defp when_condition(%Check{when: nil}, _), do: true

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -15,7 +15,8 @@ defmodule Wanda.Catalog.Check do
     :severity,
     :facts,
     :values,
-    :expectations
+    :expectations,
+    :when
   ]
 
   @type t :: %__MODULE__{
@@ -27,6 +28,7 @@ defmodule Wanda.Catalog.Check do
           severity: :warning | :critical,
           facts: [Fact.t()],
           values: [Value.t()],
-          expectations: [Expectation.t()]
+          expectations: [Expectation.t()],
+          when: String.t()
         }
 end

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -27,6 +27,12 @@ defmodule Wanda.Executions.Server do
 
   @default_timeout 5 * 60 * 1_000
 
+  @doc """
+  Starts a check execution.
+
+  The checks are filtered leveraging the `env` and evaluating the `when` condition using a best-effort approach.
+  If non-existing check IDs are provided inside a target, they will get filtered away.
+  """
   @impl true
   def start_execution(execution_id, group_id, targets, env, config \\ []) do
     checks =

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -32,7 +32,7 @@ defmodule Wanda.Executions.Server do
     checks =
       targets
       |> Target.get_checks_from_targets()
-      |> Catalog.get_checks()
+      |> Catalog.get_checks(env)
 
     checks_ids = Enum.map(checks, & &1.id)
 

--- a/lib/wanda_web/controllers/catalog_controller.ex
+++ b/lib/wanda_web/controllers/catalog_controller.ex
@@ -5,14 +5,19 @@ defmodule WandaWeb.CatalogController do
   alias Wanda.Catalog
   alias WandaWeb.Schemas.CatalogResponse
 
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+
   operation :catalog,
     summary: "List checks catalog",
+    parameters: [
+      provider: [in: :query, type: :string, description: "cloud provider"]
+    ],
     responses: [
       ok: {"Check catalog response", "application/json", CatalogResponse}
     ]
 
-  def catalog(conn, _) do
-    catalog = Catalog.get_catalog()
+  def catalog(conn, params) do
+    catalog = Catalog.get_catalog(params)
     render(conn, catalog: catalog)
   end
 end

--- a/lib/wanda_web/controllers/catalog_controller.ex
+++ b/lib/wanda_web/controllers/catalog_controller.ex
@@ -4,13 +4,20 @@ defmodule WandaWeb.CatalogController do
 
   alias Wanda.Catalog
   alias WandaWeb.Schemas.CatalogResponse
+  alias WandaWeb.Schemas.Env
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   operation :catalog,
     summary: "List checks catalog",
     parameters: [
-      provider: [in: :query, type: :string, description: "cloud provider"]
+      env: [
+        in: :query,
+        description: "env variables",
+        explode: true,
+        style: :form,
+        schema: Env
+      ]
     ],
     responses: [
       ok: {"Check catalog response", "application/json", CatalogResponse}

--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -14,6 +14,11 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
     properties: %{
       id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Check name"},
+      when: %Schema{
+        type: :string,
+        description: "When clause used to filter checks",
+        nullable: true
+      },
       severity: %Schema{
         type: :string,
         description: "Check severity: critical|warning",

--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -16,7 +16,7 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
       name: %Schema{type: :string, description: "Check name"},
       when: %Schema{
         type: :string,
-        description: "When clause used to filter checks",
+        description: "Expression to determine whether a check should run",
         nullable: true
       },
       severity: %Schema{

--- a/lib/wanda_web/schemas/env.ex
+++ b/lib/wanda_web/schemas/env.ex
@@ -1,0 +1,23 @@
+defmodule WandaWeb.Schemas.Env do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "ExecutionEnv",
+      description: "Contextual Environment for the current execution",
+      type: :object,
+      additionalProperties: %Schema{
+        oneOf: [
+          %Schema{type: :string},
+          %Schema{type: :integer},
+          %Schema{type: :boolean}
+        ]
+      }
+    },
+    struct?: false
+  )
+end

--- a/lib/wanda_web/schemas/env.ex
+++ b/lib/wanda_web/schemas/env.ex
@@ -14,7 +14,8 @@ defmodule WandaWeb.Schemas.Env do
         oneOf: [
           %Schema{type: :string},
           %Schema{type: :integer},
-          %Schema{type: :boolean}
+          %Schema{type: :boolean},
+          %Schema{type: :array, items: __MODULE__}
         ]
       }
     },

--- a/lib/wanda_web/schemas/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/execution/start_execution_request.ex
@@ -4,6 +4,7 @@ defmodule WandaWeb.Schemas.StartExecutionRequest do
   """
 
   alias OpenApiSpex.Schema
+  alias WandaWeb.Schemas.Env
 
   require OpenApiSpex
 
@@ -30,26 +31,6 @@ defmodule WandaWeb.Schemas.StartExecutionRequest do
       },
       required: [:agent_id, :checks]
     })
-  end
-
-  defmodule Env do
-    @moduledoc false
-
-    OpenApiSpex.schema(
-      %{
-        title: "ExecutionEnv",
-        description: "Contextual Environment for the current execution",
-        type: :object,
-        additionalProperties: %Schema{
-          oneOf: [
-            %Schema{type: :string},
-            %Schema{type: :integer},
-            %Schema{type: :boolean}
-          ]
-        }
-      },
-      struct?: false
-    )
   end
 
   OpenApiSpex.schema(%{

--- a/test/catalog_test.exs
+++ b/test/catalog_test.exs
@@ -21,7 +21,7 @@ defmodule Wanda.CatalogTest do
         |> Enum.sort()
         |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
 
-      catalog = Catalog.get_catalog()
+      catalog = Catalog.get_catalog(%{"provider" => "azure"})
       assert length(valid_files) == length(catalog)
 
       Enum.with_index(catalog, fn check, index ->
@@ -32,6 +32,21 @@ defmodule Wanda.CatalogTest do
 
         assert %Check{id: ^file_name} = check
       end)
+    end
+
+    test "should return the whole catalog but the check with the when clause" do
+      catalog_path = Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
+
+      valid_files =
+        catalog_path
+        |> File.ls!()
+        |> Enum.sort()
+        |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
+
+      catalog = Catalog.get_catalog(%{"provider" => "aws"})
+      assert length(valid_files) - 1 == length(catalog)
+
+      assert Enum.any?(catalog, fn %Check{id: id} -> id == "when_condition_check" end) == false
     end
 
     test "should load a check from a yaml file properly" do

--- a/test/catalog_test.exs
+++ b/test/catalog_test.exs
@@ -21,7 +21,7 @@ defmodule Wanda.CatalogTest do
         |> Enum.sort()
         |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
 
-      catalog = Catalog.get_catalog(%{"provider" => "azure"})
+      catalog = Catalog.get_catalog()
       assert length(valid_files) == length(catalog)
 
       Enum.with_index(catalog, fn check, index ->
@@ -34,19 +34,13 @@ defmodule Wanda.CatalogTest do
       end)
     end
 
-    test "should return the whole catalog but the check with the when clause" do
-      catalog_path = Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
-
-      valid_files =
-        catalog_path
-        |> File.ls!()
-        |> Enum.sort()
-        |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
-
+    test "should filter out checks if the when clause doesn't match" do
+      complete_catalog = Catalog.get_catalog(%{"provider" => "azure"})
       catalog = Catalog.get_catalog(%{"provider" => "aws"})
-      assert length(valid_files) - 1 == length(catalog)
 
-      assert Enum.any?(catalog, fn %Check{id: id} -> id == "when_condition_check" end) == false
+      assert length(complete_catalog) - 1 == length(catalog)
+
+      refute Enum.any?(catalog, fn %Check{id: id} -> id == "when_condition_check" end)
     end
 
     test "should load a check from a yaml file properly" do

--- a/test/catalog_test.exs
+++ b/test/catalog_test.exs
@@ -130,7 +130,10 @@ defmodule Wanda.CatalogTest do
 
     test "should load multiple checks" do
       assert [%Check{id: "expect_check"}, %Check{id: "expect_same_check"}] =
-               Catalog.get_checks(["expect_check", "non_existent_check", "expect_same_check"])
+               Catalog.get_checks(
+                 ["expect_check", "non_existent_check", "expect_same_check"],
+                 %{}
+               )
     end
   end
 end

--- a/test/fixtures/catalog/when_condition_check.yaml
+++ b/test/fixtures/catalog/when_condition_check.yaml
@@ -1,0 +1,33 @@
+id: when_condition_check
+name: When condition check
+group: Test
+when: env.provider == "azure"
+description: |
+  Just a check
+remediation: |
+  ## Remediation
+  Remediation text
+facts:
+  - name: jedi
+    gatherer: wandalorian
+    argument: -o
+  - name: other_fact
+    gatherer: no_args_gatherer
+values:
+  - name: expected_value
+    default: 5
+    conditions:
+      - value: 10
+        when: some_expression
+      - value: 15
+        when: some_other_expression
+  - name: expected_higher_value
+    default: 10
+    conditions:
+      - value: 5
+        when: some_third_expression
+expectations:
+  - name: some_expectation
+    expect: facts.jedi == values.expected_value
+  - name: some_other_expectation
+    expect: facts.jedi > values.expected_higher_value

--- a/test/wanda_web/controllers/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/catalog_controller_test.exs
@@ -14,5 +14,15 @@ defmodule WandaWeb.CatalogControllerTest do
       api_spec = ApiSpec.spec()
       assert_schema(json, "CatalogResponse", api_spec)
     end
+
+    test "listing the checks catalog produces a CatalogResponse when filtered", %{conn: conn} do
+      json =
+        conn
+        |> get("/api/checks/catalog?provider=azure&foo=bar")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "CatalogResponse", api_spec)
+    end
   end
 end

--- a/test/wanda_web/controllers/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/catalog_controller_test.exs
@@ -21,6 +21,15 @@ defmodule WandaWeb.CatalogControllerTest do
         |> get("/api/checks/catalog?provider=azure&foo=bar")
         |> json_response(200)
 
+      assert %{
+               "items" => [
+                 %{"id" => "expect_check"},
+                 %{"id" => "expect_same_check"},
+                 %{"id" => "warning_severity_check"},
+                 %{"id" => "when_condition_check"}
+               ]
+             } = json
+
       api_spec = ApiSpec.spec()
       assert_schema(json, "CatalogResponse", api_spec)
     end


### PR DESCRIPTION
This PR implements a `when` clause inside the YAML specification. `env` variables can be provided while retrieving the catalog. The checks then are matched against the `when` clause. If a `when` clause doesn't evaluate truthy, the check gets filtered away.

Example:

```yml
when: env.provider == "azure"
```