### PR TITLE
Document best practices

### DIFF
--- a/guides/specification.md
+++ b/guides/specification.md
@@ -595,12 +595,12 @@ Available entries in scope
 
 ## Best practices and conventions
 
-In order to have a standardized format of writting checks, follow the next best practices and conventions as much as possible:
+To have a standardized format for writing checks, follow the next best practices and conventions as much as possible:
 
-- The `id` field must go wrapped in double quotes to avoid any type ambiguity, as this field must be of string format. 
-- The remaining `name`, `description`, `group` and `remediation` fields must not be wrapped in quotes, as they are text based values always.
-- Take advantage of markdown tags in the `name`, `description` and `remediation` fields to make the text easy and compelling to read.
-- The `name` field of `facts`, `values` and `expectations` must follow `camel_case` format.  
+- The `id` field must be wrapped in double quotes to avoid any type of ambiguity, as this field must be of string format.
+- The remaining `name`, `description`, `group`, and `remediation` fields must not be wrapped in quotes, as they are text-based values always.
+- Take advantage of markdown tags in the `name`, `description`, and `remediation` fields to make the text easy and compelling to read.
+- The `name` field of `facts`, `values`, and `expectations` must follow `camel_case` format.  
   For example:
   ```
   facts:
@@ -626,12 +626,12 @@ In order to have a standardized format of writting checks, follow the next best 
   values:
     - name: expected_foo
       default: 30
-
+  
   expectations:
     - name: some_expectation
       expect: facts.foo == values.expected_foo
   ```
-- If the gathered fact is plainly compared to a value, using a `value` and `expected_value` names for facts and values respectively is recommended, as it improves the meaning of the comparison.  
+- If the gathered fact is compared to a value, using `value` and `expected_value` names for facts and values respectively is recommended, as it improves the meaning of the comparison.  
   For example:
   ```
   facts:
@@ -641,7 +641,7 @@ In order to have a standardized format of writting checks, follow the next best 
     - name: expected_some_fact
   ...
   ```
-- Avoid adding prefixes as `facts` or `values` to the entries of these sections, as they already use this as a namespace.
+- Avoid adding prefixes such as `facts` or `values` to the entries of these sections, as they already use this as a namespace.
 For example, the next example should be avoided, as the `facts` prefix would be redundant in the expectation expression:
   ```
   facts:
@@ -678,4 +678,4 @@ For example, the next example should be avoided, as the `facts` prefix would be 
         .find(|item| item.id == "super").properties
         .find(|prop| prop.name == "good").value
   ```
-  > Note: Keep in mind that some functions as `sort` and `drain` run in-place modifications, so they cannot be piped.
+  > Note: Keep in mind that some functions such as `sort` and `drain` run in-place modifications, so they cannot be piped.

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -63,7 +63,7 @@ A Check declaration comes in the form of a `yaml` file and all the Checks togeth
 Here's an example:
 
 ```yaml
-id: 156F64
+id: "156F64"
 name: Corosync `token` timeout
 group: Corosync
 description: Corosync `token` timeout is set to the correct value
@@ -121,9 +121,9 @@ Uniquely identifies a Check in the Catalog
 ie:
 
 ```yaml
-id: 156F64
-id: 845CC9
-id: B089BE
+id: "156F64"
+id: "845CC9"
+id: "B089BE"
 ```
 
 #### name
@@ -592,3 +592,90 @@ Available entries in scope
 | ------------------------------- | -------------------------------------------------------
 | `values.expected_token_timeout` | `5000`, `30000`, `20000` based on the conditions
 | `values.another_variable_value` | `blue`, `red` based on the conditions
+
+## Best practices and conventions
+
+In order to have a standardized format of writting checks, follow the next best practices and conventions as much as possible:
+
+- The `id` field must go wrapped in double quotes to avoid any type ambiguity, as this field must be of string format. 
+- The remaining `name`, `description`, `group` and `remediation` fields must not be wrapped in quotes, as they are text based values always.
+- Take advantage of markdown tags in the `name`, `description` and `remediation` fields to make the text easy and compelling to read.
+- The `name` field of `facts`, `values` and `expectations` must follow `camel_case` format.  
+  For example:
+  ```
+  facts:
+    - name: some_fact
+  ...
+  values:
+    - name: expected_some_fact
+  ...
+  expectations:
+    - name: some_expectation
+  ...
+  ```
+- Use 2 spaces to indent multiline expectation expressions.
+- Naming hardcoded values in the `values` section with the `default` field is encouraged instead of putting hardcoded values in the expectation expression itself. This gives some meaning to the expected value and improves potential interaction with the Wanda API.  
+  So this:
+  ```
+  expectations:
+    - name: some_expectation
+      expect: facts.foo == 30
+  ```
+  would be:
+  ```
+  values:
+    - name: expected_foo
+      default: 30
+
+  expectations:
+    - name: some_expectation
+      expect: facts.foo == values.expected_foo
+  ```
+- If the gathered fact is plainly compared to a value, using a `value` and `expected_value` names for facts and values respectively is recommended, as it improves the meaning of the comparison.  
+  For example:
+  ```
+  facts:
+    - name: some_fact
+  ...
+  values:
+    - name: expected_some_fact
+  ...
+  ```
+- Avoid adding prefixes as `facts` or `values` to the entries of these sections, as they already use this as a namespace.
+For example, the next example should be avoided, as the `facts` prefix would be redundant in the expectation expression:
+  ```
+  facts:
+    - name: facts_some_fact
+  ```
+- If the implemented expectation expression contains any kind of `&&` to combine multiple operations, consider adding them as individual expectations, as the final result is the combination of all of them.  
+  So this:
+  ```
+  expectations:
+    - name: some_expectation
+      expect: facts.foo == values.expected_foo && facts.bar == values.expected_bar
+  ```
+  would be:
+  ```
+  expectations:
+    - name: foo_expectation
+      expect: facts.foo == values.expected_foo
+    - name: bar_expectation
+      expect: facts.bar == values.expected_bar
+  ```
+- Pipe the expression language functions vertically in order to provide a better visual output of the code.  
+  So this:
+  ```
+  expectations:
+    - name: some_expectation
+      expect: facts.foo.find(|item| item.id == "super").properties.find(|prop| prop.name == "good").value
+  ```
+  would be:
+  ```
+  expectations:
+    - name: some_expectation
+      expect: |
+        facts.foo
+        .find(|item| item.id == "super").properties
+        .find(|prop| prop.name == "good").value
+  ```
+  > Note: Keep in mind that some functions as `sort` and `drain` run in-place modifications, so they cannot be piped.

--- a/priv/catalog/156F64.yaml
+++ b/priv/catalog/156F64.yaml
@@ -1,4 +1,4 @@
-id: 156F64
+id: "156F64"
 name: Corosync configuration file
 group: Corosync
 description: |

--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -1,4 +1,4 @@
-id: DA114A
+id: "DA114A"
 name: Corosync rings
 group: Corosync
 description: |

--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -44,4 +44,10 @@ expectations:
     expect: facts.corosync_nodes.len() > 0
 
   - name: expected_number_of_rings_per_node
-    expect: facts.corosync_nodes.all(|node| node.keys().filter(|prop| prop.starts_with("ring")).len() >= values.expected_corosync_rings_per_node)
+    expect: |
+      facts.corosync_nodes
+      .all(|node|
+        node
+        .keys()
+        .filter(|prop| prop.starts_with("ring"))
+        .len() >= values.expected_corosync_rings_per_node)


### PR DESCRIPTION
In order to have some "order" in the way checks are written, here some best practices and conventions.
I recommend continuing adding more items as we go, so we have a rich list of things to do and not do.