### PR TITLE
Add list & map examples for `corosync-cmapctl` docs

### DIFF
--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -159,15 +159,15 @@ This gatherer allows accessing the output of the `corosync-cmapctl` tool. It sup
 
 Example arguments:
 
-| Name                         | Return value                     |
-| :--------------------------- | :------------------------------- |
-| `totem.token`                | extracted value from the command |
-| `runtime.config.totem.token` | extracted value from the command |
-| `totem.transport`            | extracted value from the command |
-| `totem.transport`            | extracted value from the command |
-| `nodelist.node.0.ring0_addr` | extracted value from the command |
-| `nodelist.node`              | extracted value from the command |
-| `nodelist.node.1`            | extracted value from the command |
+| Name                                | Return value                     |
+| :---------------------------------- | :------------------------------- |
+| `totem.token`                       | extracted value from the command |
+| `runtime.config.totem.token`        | extracted value from the command |
+| `totem.transport`                   | extracted value from the command |
+| `runtime.config.totem.max_messages` | extracted value from the command |
+| `nodelist.node.0.ring0_addr`        | extracted value from the command |
+| `nodelist.node`                     | extracted value from the command |
+| `nodelist.node.1`                   | extracted value from the command |
 
 Example specification:
 
@@ -212,22 +212,28 @@ Example output (in Rhai):
 30000;
 
 // totem_transport
-("udpu");
+"udpu";
 
 // totem_max_messages
 20;
 
 // node_0_ring0addr
-20;
+"10.80.1.11";
 
 // node_list
 #{
-  "0": #{ "nodeid": 1, "ring0_addr": "10.80.1.11" },
-  "1": #{ "nodeid": 2, "ring0_addr": "10.80.1.12" }
-}
+  "0": #{
+    nodeid: 1,
+    ring0_addr: "10.80.1.11"
+  },
+  "1": #{
+    nodeid: 2,
+    ring0_addr: "10.80.1.12"
+  }
+};
 
 // second_node
-#{ "nodeid": 2, "ring0_addr": "10.80.1.12" }
+#{ nodeid: 2, ring0_addr: "10.80.1.12" };
 ```
 
 ### hosts (/etc/hosts)

--- a/guides/gatherers.md
+++ b/guides/gatherers.md
@@ -166,6 +166,8 @@ Example arguments:
 | `totem.transport`            | extracted value from the command |
 | `totem.transport`            | extracted value from the command |
 | `nodelist.node.0.ring0_addr` | extracted value from the command |
+| `nodelist.node`              | extracted value from the command |
+| `nodelist.node.1`            | extracted value from the command |
 
 Example specification:
 
@@ -190,6 +192,14 @@ facts:
   - name: node_0_ring0addr
     gatherer: corosync-cmapctl
     argument: nodelist.node.0.ring0_addr
+
+  - name: node_list
+    gatherer: corosync-cmapctl
+    argument: nodelist.node
+
+  - name: second_node
+    gatherer: corosync-cmapctl
+    argument: nodelist.node.1
 ```
 
 Example output (in Rhai):
@@ -209,6 +219,15 @@ Example output (in Rhai):
 
 // node_0_ring0addr
 20;
+
+// node_list
+#{
+  "0": #{ "nodeid": 1, "ring0_addr": "10.80.1.11" },
+  "1": #{ "nodeid": 2, "ring0_addr": "10.80.1.12" }
+}
+
+// second_node
+#{ "nodeid": 2, "ring0_addr": "10.80.1.12" }
 ```
 
 ### hosts (/etc/hosts)


### PR DESCRIPTION
Adds some non-trivial examples to the documentation of requesting and returning lists and maps from the `corosync-cmapctl` gatherer.