### PR TITLE
Set critical state on agent timeout and warning severity

### DIFF
--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -242,7 +242,10 @@ defmodule Wanda.Executions.Evaluation do
            not errors?(agents_check_results) do
         :passing
       else
-        severity
+        Enum.find_value(agents_check_results, severity, fn
+          %AgentCheckError{type: :timeout} -> :critical
+          _ -> false
+        end)
       end
 
     %CheckResult{check_result | result: result}


### PR DESCRIPTION
When an agent timeout error happens, instead of using the severity field to set the error, critical is set directly.
The timeout is critical scenario, so the code sets this way.

PD: Object to change if at some point we add a new field to store the "errored" checks, to not use the critical state

PD2: The Web frontend representation will be still quite strange, as we don't really use the check results as result (we use the expectations and do some computations), as the code still has a "agent" based visualization. So it can show some results as critical even though they should be warning. It should be fixed once we move to the check based visualization