### PR TITLE
Fix default value when getting system env for JWT_AUTHENTICATION_ENABLED

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -72,7 +72,7 @@ if config_env() == :prod do
   config :cors_plug,
     origin: [cors_origin]
 
-  jwt_authentication_enabled = System.get_env("JWT_AUTHENTICATION_ENABLED", true)
+  jwt_authentication_enabled = System.get_env("JWT_AUTHENTICATION_ENABLED", "true") == "true"
 
   config :wanda, :jwt_authentication, enabled: jwt_authentication_enabled
 


### PR DESCRIPTION
`System.get_env/2` expects a string as a second argument.

Caught while working on building wanda in OBS.