### PR TITLE
Use new `trento-wanda` image name for check development environment

### DIFF
--- a/docker-compose.checks.yaml
+++ b/docker-compose.checks.yaml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   wanda:
-    image: ghcr.io/trento-project/wanda:rolling
+    image: ghcr.io/trento-project/trento-wanda:rolling
     environment:
       DATABASE_URL: ecto://postgres:postgres@postgres/postgres
       SECRET_KEY_BASE: dummyS3cr3t


### PR DESCRIPTION
As per the title. We changed the name of the built image from `wanda` to `trento-wanda`