### PR TITLE
Fix JWT plug runtime config

### DIFF
--- a/lib/wanda_web/auth/jwt_auth_plug.ex
+++ b/lib/wanda_web/auth/jwt_auth_plug.ex
@@ -20,7 +20,15 @@ defmodule WandaWeb.Auth.JWTAuthPlug do
   @doc """
     Read, validate and decode the JWT from authorization header at each call
   """
-  def call(conn, _config) do
+  def call(conn, _) do
+    if Application.get_env(:wanda, :jwt_authentication)[:enabled] do
+      authenticate(conn)
+    else
+      conn
+    end
+  end
+
+  defp authenticate(conn) do
     with {:ok, jwt_token} <- read_token(conn),
          {:ok, claims} <- AccessToken.verify_and_validate(jwt_token) do
       put_private(conn, :user_id, claims["sub"])

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -8,9 +8,7 @@ defmodule WandaWeb.Router do
   end
 
   pipeline :protected_api do
-    if Application.get_env(:wanda, :jwt_authentication)[:enabled] do
-      plug WandaWeb.Auth.JWTAuthPlug
-    end
+    plug WandaWeb.Auth.JWTAuthPlug
   end
 
   scope "/api/checks", WandaWeb do


### PR DESCRIPTION
This PR fixes the JWT runtime config that was not read since the router uses compile-time macros, by properly utilizing the Plug `init` callback.

It also adds a test for the disabled scenario