### PR TITLE
Bump BCI base image to 15.4 for dev Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV MIX_ENV=$MIX_ENV
 RUN mix phx.digest
 RUN mix release
 
-FROM registry.suse.com/bci/bci-base:15.3 AS wanda
+FROM registry.suse.com/bci/bci-base:15.4 AS wanda
 LABEL org.opencontainers.image.source="https://github.com/trento-project/wanda"
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV


### PR DESCRIPTION
Bumping BCI base image to 15.4 also in Dockerfile used by GH