### PR TITLE
Start amqp consumer and publisher only if needed in tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -54,7 +54,7 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   processor: GenRMQ.Processor.Mock
 
 config :wanda,
-  children: [Wanda.Messaging.Adapters.AMQP.Publisher, Wanda.Messaging.Adapters.AMQP.Consumer]
+  children: []
 
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k"

--- a/test/support/messaging/amqp_event_handler.ex
+++ b/test/support/messaging/amqp_event_handler.ex
@@ -1,0 +1,7 @@
+defmodule Wanda.Support.Messaging.AMQPEventHandler do
+  @moduledoc false
+
+  def handle_event([:gen_rmq, type, _, _], _, _, %{pid: pid}) do
+    send(pid, {:connected, type})
+  end
+end


### PR DESCRIPTION
Start AMQP consumer and publisher only in the needed tests. The code waits to a amqp telemetry message to know that the connection of the consumer/publisher is open, and we need to wait some milliseconds as the usage of the queue is not instantaneous even once the connection is open.

Created a new module as recommended in the docs instead of an anonymous function: https://hexdocs.pm/telemetry/telemetry.html#attach/4

PD: 
Here how the telemetry modules works:
https://github.com/beam-telemetry/telemetry
And specifically for the amqp module:
https://github.com/meltwater/gen_rmq/blob/master/lib/gen_rmq/consumer/telemetry.ex


