### PR TITLE
Fix execution flaky test

### DIFF
--- a/test/wanda/executions_test.exs
+++ b/test/wanda/executions_test.exs
@@ -51,7 +51,10 @@ defmodule Wanda.ExecutionsTest do
                    }
                  ]
                }
-             ] = Repo.all(Execution)
+             ] =
+               Execution
+               |> order_by(asc: :started_at)
+               |> Repo.all()
     end
   end
 


### PR DESCRIPTION
Fix execution code flaky test. It fails sporadically as it doesn't respect the `started_time` column
Fix for: https://github.com/trento-project/wanda/actions/runs/4133494870/jobs/7143692582
