### PR TITLE
Add new demo env that uses faked execution server

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -29,7 +29,8 @@
           "apps/*/lib/",
           "apps/*/src/",
           "apps/*/test/",
-          "apps/*/web/"
+          "apps/*/web/",
+          "demo"
         ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 /deps/
 /doc/
 /test/
+!/test/support/factory.ex
 /tmp/

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 # Used by "mix format"
 [
   import_deps: [:ecto, :phoenix, :open_api_spex],
-  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test,demo}/**/*.{ex,exs}"],
   subdirectories: ["priv/*/migrations"]
 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,6 +213,45 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-demo-img:
+    name: Build the docker image for the demo environment
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    needs: [static-code-analysis, test, test-e2e]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      MIX_ENV: demo
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-wanda
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
+      - name: Build and push container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_REPOSITORY }}:demo
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: MIX_ENV=demo
+
   generate-docs:
     name: Generate project documentation
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,9 +215,9 @@ jobs:
 
   build-demo-img:
     name: Build the docker image for the demo environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
-    needs: [static-code-analysis, test, test-e2e]
+    needs: [static-code-analysis, test]
     permissions:
       contents: read
       packages: write
@@ -246,11 +246,11 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_REPOSITORY }}:demo
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.MIX_ENV }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: MIX_ENV=demo
+          build-args: MIX_ENV=${{ env.MIX_ENV }}
 
   generate-docs:
     name: Generate project documentation

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -9,15 +9,6 @@ config :wanda, WandaWeb.Endpoint,
 
 config :logger, level: :debug
 
-config :wanda, Wanda.Messaging.Adapters.AMQP,
-  consumer: [
-    connection: "amqp://wanda:wanda@localhost:5672"
-  ],
-  publisher: [
-    connection: "amqp://wanda:wanda@localhost:5672"
-  ],
-  processor: Wanda.Messaging.Adapters.AMQP.Processor
-
 config :cors_plug,
   origin: [
     "http://localhost:4000",

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -8,11 +8,3 @@ config :wanda, WandaWeb.Endpoint,
   server: true
 
 config :logger, level: :debug
-
-config :cors_plug,
-  origin: [
-    "http://localhost:4000",
-    "http://demo.trento-project.io",
-    "https://demo.trento-project.io"
-  ],
-  allow_credentials: true

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -1,0 +1,27 @@
+import Config
+
+config :wanda, Wanda.Policy, execution_server_impl: Wanda.Executions.FakeServer
+
+config :wanda, WandaWeb.Endpoint,
+  check_origin: :conn,
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  server: true
+
+config :logger, level: :debug
+
+config :wanda, Wanda.Messaging.Adapters.AMQP,
+  consumer: [
+    connection: "amqp://wanda:wanda@localhost:5672"
+  ],
+  publisher: [
+    connection: "amqp://wanda:wanda@localhost:5672"
+  ],
+  processor: Wanda.Messaging.Adapters.AMQP.Processor
+
+config :cors_plug,
+  origin: [
+    "http://localhost:4000",
+    "http://demo.trento-project.io",
+    "https://demo.trento-project.io"
+  ],
+  allow_credentials: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,7 @@ import Config
 # and secrets from environment variables or elsewhere. Do not define
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
-if config_env() == :prod do
+if config_env() in [:prod, :demo] do
   database_url =
     System.get_env("DATABASE_URL") ||
       raise """

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -18,7 +18,7 @@ defmodule Wanda.Executions.FakeServer do
   def start_execution(execution_id, group_id, targets, env, config \\ []) do
     create_fake_execution(execution_id, group_id, targets)
     Process.sleep(2_000)
-    complete_fake_execution(execution_id, group_id, targets, :passing)
+    complete_fake_execution(execution_id, group_id, targets)
 
     :ok
   end
@@ -41,7 +41,7 @@ defmodule Wanda.Executions.FakeServer do
     :ok = Messaging.publish("results", execution_started)
   end
 
-  defp complete_fake_execution(execution_id, group_id, targets, result) do
+  defp complete_fake_execution(execution_id, group_id, targets) do
     check_results = build(:check_results_from_targets, targets: targets)
 
     build_result =
@@ -49,7 +49,7 @@ defmodule Wanda.Executions.FakeServer do
         check_results: check_results,
         execution_id: execution_id,
         group_id: group_id,
-        result: result
+        result: Enum.random([:passing, :warning, :critical])
       )
 
     Executions.complete_execution!(

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -24,7 +24,7 @@ defmodule Wanda.Executions.FakeServer do
   end
 
   @impl true
-  def receive_facts(execution_id, group_id, agent_id, facts) do
+  def receive_facts(_execution_id, _group_id, _agent_id, _facts) do
     :ok
   end
 

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -1,0 +1,63 @@
+defmodule Wanda.Executions.FakeServer do
+  @behaviour Wanda.Executions.ServerBehaviour
+
+  import Wanda.Factory
+
+  require Logger
+
+  alias Wanda.Executions
+
+  alias Wanda.Executions.{
+    Execution,
+    Result
+  }
+
+  alias Wanda.Messaging
+
+  @impl true
+  def start_execution(execution_id, group_id, targets, env, config \\ []) do
+    create_fake_execution(execution_id, group_id, targets)
+    Process.sleep(2_000)
+    complete_fake_execution(execution_id, group_id, targets, :passing)
+
+    :ok
+  end
+
+  @impl true
+  def receive_facts(execution_id, group_id, agent_id, facts) do
+    :ok
+  end
+
+  defp create_fake_execution(execution_id, group_id, targets) do
+    insert(:execution,
+      status: :running,
+      execution_id: execution_id,
+      group_id: group_id,
+      targets: Enum.map(targets, &Map.from_struct/1)
+    )
+
+    Executions.create_execution!(execution_id, group_id, targets)
+    execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
+    :ok = Messaging.publish("results", execution_started)
+  end
+
+  defp complete_fake_execution(execution_id, group_id, targets, result) do
+    check_results = build(:check_results_from_targets, targets: targets)
+
+    build_result =
+      build(:result,
+        check_results: check_results,
+        execution_id: execution_id,
+        group_id: group_id,
+        result: result
+      )
+
+    Executions.complete_execution!(
+      execution_id,
+      build_result
+    )
+
+    execution_completed = Messaging.Mapper.to_execution_completed(build_result)
+    :ok = Messaging.publish("results", execution_completed)
+  end
+end

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -7,15 +7,12 @@ defmodule Wanda.Executions.FakeServer do
 
   alias Wanda.Executions
 
-  alias Wanda.Executions.{
-    Execution,
-    Result
-  }
+  alias Wanda.Executions
 
   alias Wanda.Messaging
 
   @impl true
-  def start_execution(execution_id, group_id, targets, env, config \\ []) do
+  def start_execution(execution_id, group_id, targets, _env, _config \\ []) do
     create_fake_execution(execution_id, group_id, targets)
     Process.sleep(2_000)
     complete_fake_execution(execution_id, group_id, targets)
@@ -42,14 +39,15 @@ defmodule Wanda.Executions.FakeServer do
   end
 
   defp complete_fake_execution(execution_id, group_id, targets) do
-    check_results = build(:check_results_from_targets, targets: targets)
+    result = Enum.random([:passing, :warning, :critical])
+    check_results = build(:check_results_from_targets, targets: targets, result: result)
 
     build_result =
       build(:result,
         check_results: check_results,
         execution_id: execution_id,
         group_id: group_id,
-        result: Enum.random([:passing, :warning, :critical])
+        result: result
       )
 
     Executions.complete_execution!(

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -1,15 +1,18 @@
 defmodule Wanda.Executions.FakeServer do
+  @moduledoc """
+  Execution server implementation that does not actually execute anything and just
+  returns (fake) random results.
+  """
   @behaviour Wanda.Executions.ServerBehaviour
 
   import Wanda.Factory
 
+  alias Wanda.{
+    Executions,
+    Messaging
+  }
+
   require Logger
-
-  alias Wanda.Executions
-
-  alias Wanda.Executions
-
-  alias Wanda.Messaging
 
   @impl true
   def start_execution(execution_id, group_id, targets, _env, _config \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -99,6 +99,13 @@ defmodule Wanda.MixProject do
       "test/support"
     ]
 
+  defp elixirc_paths(:demo),
+    do: [
+      "test/support/factory.ex",
+      "demo/fake_server.ex",
+      "lib"
+    ]
+
   defp elixirc_paths(_), do: ["lib"]
   # Run "mix help deps" to learn about dependencies.
   defp deps do
@@ -120,8 +127,8 @@ defmodule Wanda.MixProject do
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:mox, "~> 1.0", only: :test},
-      {:ex_machina, "~> 2.7.0", only: :test},
-      {:faker, "~> 0.17", only: :test},
+      {:ex_machina, "~> 2.7.0", only: [:demo, :test]},
+      {:faker, "~> 0.17", only: [:demo, :test]},
       {:excoveralls, "~> 0.10", only: :test},
       # phoenix deps
       {:phoenix, "~> 1.6.12"},


### PR DESCRIPTION
Initial implementation of a faker to generate data for the checks execution. 

It achieves this by providing a implementation for the execution server that instead of triggering executions on agents uses the factories from the tests to generate such results.