### PR TITLE
Remotely trigger demo deploy on new wanda image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: ${{ github.repository_owner }}/web
-          event-type: demo-deploy
+          event-type: deploy-demo
 
   generate-docs:
     name: Generate project documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,6 +251,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: MIX_ENV=${{ env.MIX_ENV }}
+      - name: Remotely trigger trento-web demo deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.repository_owner }}/web
+          event-type: demo-deploy
 
   generate-docs:
     name: Generate project documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,7 +216,7 @@ jobs:
   build-demo-img:
     name: Build the docker image for the demo environment
     runs-on: ubuntu-20.04
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    if: vars.DEPLOY_DEMO == 'true' && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
     needs: [static-code-analysis, test]
     permissions:
       contents: read


### PR DESCRIPTION
This PR makes uses of [this GH action](https://github.com/peter-evans/repository-dispatch) to remotely trigger a new demo deployment in trento-web.

Should remain as draft:
 - [x] until the web repo includes code to handle such request.
 - [x] until the org (PAT) token has been created and added to the secrets: