### PR TITLE
Enrich the faker by using catalog data

### DIFF
--- a/demo/fake_evaluation.ex
+++ b/demo/fake_evaluation.ex
@@ -5,24 +5,6 @@ defmodule Wanda.Executions.FakeEvaluation do
 
   import Wanda.Factory
 
-  alias Wanda.Executions
-
-  @spec create_fake_execution(
-          String.t(),
-          String.t(),
-          [Wanda.Executions.Target.t()]
-        ) :: Wanda.Executions.Execution.t()
-  def create_fake_execution(execution_id, group_id, targets) do
-    insert(:execution,
-      status: :running,
-      execution_id: execution_id,
-      group_id: group_id,
-      targets: Enum.map(targets, &Map.from_struct/1)
-    )
-
-    Executions.create_execution!(execution_id, group_id, targets)
-  end
-
   @spec complete_fake_execution(
           String.t(),
           String.t(),
@@ -33,20 +15,12 @@ defmodule Wanda.Executions.FakeEvaluation do
     result = Enum.random([:passing, :warning, :critical])
     check_results = build_check_results_from_targets(targets, result, checks)
 
-    build_result =
-      build(:result,
-        check_results: check_results,
-        execution_id: execution_id,
-        group_id: group_id,
-        result: result
-      )
-
-    Executions.complete_execution!(
-      execution_id,
-      build_result
+    build(:result,
+      check_results: check_results,
+      execution_id: execution_id,
+      group_id: group_id,
+      result: result
     )
-
-    build_result
   end
 
   defp build_check_results_from_targets(targets, result, checks) do

--- a/demo/fake_evaluation.ex
+++ b/demo/fake_evaluation.ex
@@ -35,13 +35,6 @@ defmodule Wanda.Executions.FakeEvaluation do
 
   defp build_check_result_from_target(check_id, check_targets, result, checks) do
     check = Enum.find(checks, &(&1.id == check_id))
-    expectation_evaluations = expectation_evaluations_from_check(check, result)
-
-    expectation_results =
-      Enum.map(
-        expectation_evaluations,
-        &build(:expectation_result, name: &1.name, type: &1.type, result: result == :passing)
-      )
 
     build(:check_result,
       check_id: check_id,
@@ -53,14 +46,18 @@ defmodule Wanda.Executions.FakeEvaluation do
               Enum.map(check.facts, fn %{name: name} ->
                 build(:fact, check_id: check_id, name: name)
               end),
-            expectation_evaluations: expectation_evaluations,
+            expectation_evaluations: expectation_evaluations_from_check(check, result),
             values:
               Enum.map(check.values, fn %{name: name, default: value} ->
                 %{name: name, value: value}
               end)
           )
         end),
-      expectation_results: expectation_results,
+      expectation_results:
+        Enum.map(
+          expectation_evaluations_from_check(check, result),
+          &build(:expectation_result, name: &1.name, type: &1.type, result: result == :passing)
+        ),
       result: result
     )
   end
@@ -83,7 +80,7 @@ defmodule Wanda.Executions.FakeEvaluation do
               if result == :passing do
                 "same_value"
               else
-                Faker.StarWars.quote()
+                Faker.StarWars.character()
               end
           )
       end

--- a/demo/fake_evaluation.ex
+++ b/demo/fake_evaluation.ex
@@ -1,0 +1,119 @@
+defmodule Wanda.Executions.FakeEvaluation do
+  @moduledoc """
+  Fake evaluation functional core.
+  """
+
+  import Wanda.Factory
+
+  alias Wanda.{
+    Executions,
+    Messaging
+  }
+
+  def create_complete_fake_execution(execution_id, group_id, targets, checks) do
+    create_fake_execution(execution_id, group_id, targets)
+    Process.sleep(2_000)
+    :ok = complete_fake_execution(execution_id, group_id, targets, checks)
+  end
+
+  defp create_fake_execution(execution_id, group_id, targets) do
+    insert(:execution,
+      status: :running,
+      execution_id: execution_id,
+      group_id: group_id,
+      targets: Enum.map(targets, &Map.from_struct/1)
+    )
+
+    Executions.create_execution!(execution_id, group_id, targets)
+    execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
+    :ok = Messaging.publish("results", execution_started)
+  end
+
+  defp complete_fake_execution(execution_id, group_id, targets, checks) do
+    result = Enum.random([:passing, :warning, :critical])
+    check_results = build_check_results_from_targets(targets, result, checks)
+
+    build_result =
+      build(:result,
+        check_results: check_results,
+        execution_id: execution_id,
+        group_id: group_id,
+        result: result
+      )
+
+    Executions.complete_execution!(
+      execution_id,
+      build_result
+    )
+
+    execution_completed = Messaging.Mapper.to_execution_completed(build_result)
+    :ok = Messaging.publish("results", execution_completed)
+  end
+
+  defp build_check_results_from_targets(targets, result, checks) do
+    targets
+    |> Enum.flat_map(& &1.checks)
+    |> Enum.uniq()
+    |> Enum.map(fn check_id ->
+      check_targets = Enum.filter(targets, &(check_id in &1.checks))
+      build_check_result_from_target(check_id, check_targets, result, checks)
+    end)
+  end
+
+  defp build_check_result_from_target(check_id, check_targets, result, checks) do
+    check = Enum.find(checks, &(&1.id == check_id))
+    expectation_evaluations = expectation_evaluations_from_check(check, result)
+
+    expectation_results =
+      Enum.map(
+        expectation_evaluations,
+        &build(:expectation_result, name: &1.name, type: &1.type, result: result == :passing)
+      )
+
+    build(:check_result,
+      check_id: check_id,
+      agents_check_results:
+        Enum.map(check_targets, fn %{agent_id: agent_id} ->
+          build(:agent_check_result,
+            agent_id: agent_id,
+            facts:
+              Enum.map(check.facts, fn %{name: name} ->
+                build(:fact, check_id: check_id, name: name)
+              end),
+            expectation_evaluations: expectation_evaluations,
+            values:
+              Enum.map(check.values, fn %{name: name, default: value} ->
+                %{name: name, value: value}
+              end)
+          )
+        end),
+      expectation_results: expectation_results,
+      result: result
+    )
+  end
+
+  defp expectation_evaluations_from_check(check, result) do
+    Enum.map(check.expectations, fn %{type: type, name: name} ->
+      case type do
+        :expect ->
+          build(:expectation_evaluation,
+            type: :expect,
+            name: name,
+            return_value: result == :passing
+          )
+
+        :expect_same ->
+          build(:expectation_evaluation,
+            type: :expect_same,
+            name: name,
+            return_value:
+              if result == :passing do
+                "same_value"
+              else
+                Faker.StarWars.quote()
+              end
+          )
+      end
+    end)
+  end
+end

--- a/demo/fake_evaluation.ex
+++ b/demo/fake_evaluation.ex
@@ -5,9 +5,7 @@ defmodule Wanda.Executions.FakeEvaluation do
 
   import Wanda.Factory
 
-  alias Wanda.{
-    Executions
-  }
+  alias Wanda.Executions
 
   @spec create_fake_execution(
           String.t(),

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -7,13 +7,13 @@ defmodule Wanda.Executions.FakeServer do
 
   import Wanda.Factory
 
+  alias Wanda.Executions.Result
+
   alias Wanda.{
     Catalog,
     Executions,
     Messaging
   }
-
-  require Logger
 
   @impl true
   def start_execution(execution_id, group_id, targets, env, _config \\ []) do
@@ -56,22 +56,97 @@ defmodule Wanda.Executions.FakeServer do
 
   defp complete_fake_execution(execution_id, group_id, targets) do
     result = Enum.random([:passing, :warning, :critical])
-    check_results = build(:check_results_from_targets, targets: targets, result: result)
+    check_results = check_results_from_targets(targets, result)
 
     build_result =
       build(:result,
         check_results: check_results,
         execution_id: execution_id,
-        group_id: group_id,
-        result: result
+        group_id: group_id
       )
 
     Executions.complete_execution!(
       execution_id,
-      build_result
+      Map.put(build_result, :result, get_result(build_result))
     )
 
     execution_completed = Messaging.Mapper.to_execution_completed(build_result)
     :ok = Messaging.publish("results", execution_completed)
+  end
+
+  defp get_result(%Result{check_results: check_results}) do
+    check_results
+    |> Enum.map(& &1.result)
+    |> Enum.map(&{&1, result_weight(&1)})
+    |> Enum.max_by(fn {_, weight} -> weight end)
+    |> elem(0)
+  end
+
+  defp result_weight(:critical), do: 2
+  defp result_weight(:warning), do: 1
+  defp result_weight(:passing), do: 0
+
+  defp check_results_from_targets(targets, result) do
+    targets
+    |> Enum.flat_map(& &1.checks)
+    |> Enum.uniq()
+    |> Enum.map(fn check_id ->
+      check_targets = Enum.filter(targets, &(check_id in &1.checks))
+      check_result_from_target(check_id, check_targets, result)
+    end)
+  end
+
+  defp expectation_evaluations_from_check(check, result) do
+    Enum.map(check.expectations, fn expectation ->
+      case expectation.type do
+        :expect ->
+          build(:expectation_evaluation,
+            type: :expect,
+            name: expectation.name,
+            return_value: result == :passing
+          )
+
+        :expect_same ->
+          build(:expectation_evaluation,
+            type: :expect_same,
+            name: expectation.name,
+            return_value:
+              if result == :passing do
+                "same_value"
+              else
+                Faker.StarWars.quote()
+              end
+          )
+      end
+    end)
+  end
+
+  defp check_result_from_target(check_id, check_targets, result) do
+    {_, check} = Catalog.get_check(check_id)
+    expectation_evaluations = expectation_evaluations_from_check(check, result)
+
+    expectation_results =
+      Enum.map(
+        expectation_evaluations,
+        &build(:expectation_result, name: &1.name, type: &1.type, result: result == :passing)
+      )
+
+    build(:check_result,
+      check_id: check_id,
+      agents_check_results:
+        Enum.map(check_targets, fn target ->
+          build(:agent_check_result,
+            agent_id: target.agent_id,
+            facts:
+              Enum.map(check.facts, fn fact ->
+                build(:fact, check_id: check_id, name: fact.name)
+              end),
+            expectation_evaluations: expectation_evaluations,
+            values: check.values
+          )
+        end),
+      expectation_results: expectation_results,
+      result: result
+    )
   end
 end

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -9,7 +9,8 @@ defmodule Wanda.Executions.FakeServer do
 
   alias Wanda.{
     Catalog,
-    Executions
+    Executions,
+    Messaging
   }
 
   @impl true
@@ -26,9 +27,15 @@ defmodule Wanda.Executions.FakeServer do
         %Executions.Target{target | checks: target_checks -- target_checks -- checks_ids}
       end)
 
-    FakeEvaluation.create_complete_fake_execution(execution_id, group_id, targets, checks)
+    FakeEvaluation.create_fake_execution(execution_id, group_id, targets)
+    execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
+    :ok = Messaging.publish("results", execution_started)
 
-    :ok
+    Process.sleep(2_000)
+
+    build_result = FakeEvaluation.complete_fake_execution(execution_id, group_id, targets, checks)
+    execution_completed = Messaging.Mapper.to_execution_completed(build_result)
+    :ok = Messaging.publish("results", execution_completed)
   end
 
   @impl true

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -27,13 +27,19 @@ defmodule Wanda.Executions.FakeServer do
         %Executions.Target{target | checks: target_checks -- target_checks -- checks_ids}
       end)
 
-    FakeEvaluation.create_fake_execution(execution_id, group_id, targets)
+    Executions.create_execution!(execution_id, group_id, targets)
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
     :ok = Messaging.publish("results", execution_started)
 
     Process.sleep(2_000)
 
     build_result = FakeEvaluation.complete_fake_execution(execution_id, group_id, targets, checks)
+
+    Executions.complete_execution!(
+      execution_id,
+      build_result
+    )
+
     execution_completed = Messaging.Mapper.to_execution_completed(build_result)
     :ok = Messaging.publish("results", execution_completed)
   end

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -7,8 +7,6 @@ defmodule Wanda.Executions.FakeServer do
 
   import Wanda.Factory
 
-  alias Wanda.Executions.Result
-
   alias Wanda.{
     Catalog,
     Executions,
@@ -62,29 +60,18 @@ defmodule Wanda.Executions.FakeServer do
       build(:result,
         check_results: check_results,
         execution_id: execution_id,
-        group_id: group_id
+        group_id: group_id,
+        result: result
       )
 
     Executions.complete_execution!(
       execution_id,
-      Map.put(build_result, :result, get_result(build_result))
+      build_result
     )
 
     execution_completed = Messaging.Mapper.to_execution_completed(build_result)
     :ok = Messaging.publish("results", execution_completed)
   end
-
-  defp get_result(%Result{check_results: check_results}) do
-    check_results
-    |> Enum.map(& &1.result)
-    |> Enum.map(&{&1, result_weight(&1)})
-    |> Enum.max_by(fn {_, weight} -> weight end)
-    |> elem(0)
-  end
-
-  defp result_weight(:critical), do: 2
-  defp result_weight(:warning), do: 1
-  defp result_weight(:passing), do: 0
 
   defp build_check_results_from_targets(targets, result) do
     targets

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -5,12 +5,11 @@ defmodule Wanda.Executions.FakeServer do
   """
   @behaviour Wanda.Executions.ServerBehaviour
 
-  import Wanda.Factory
+  alias Wanda.Executions.FakeEvaluation
 
   alias Wanda.{
     Catalog,
-    Executions,
-    Messaging
+    Executions
   }
 
   @impl true
@@ -27,9 +26,7 @@ defmodule Wanda.Executions.FakeServer do
         %Executions.Target{target | checks: target_checks -- target_checks -- checks_ids}
       end)
 
-    create_fake_execution(execution_id, group_id, targets)
-    Process.sleep(2_000)
-    complete_fake_execution(execution_id, group_id, targets)
+    FakeEvaluation.create_complete_fake_execution(execution_id, group_id, targets, checks)
 
     :ok
   end
@@ -37,106 +34,5 @@ defmodule Wanda.Executions.FakeServer do
   @impl true
   def receive_facts(_execution_id, _group_id, _agent_id, _facts) do
     :ok
-  end
-
-  defp create_fake_execution(execution_id, group_id, targets) do
-    insert(:execution,
-      status: :running,
-      execution_id: execution_id,
-      group_id: group_id,
-      targets: Enum.map(targets, &Map.from_struct/1)
-    )
-
-    Executions.create_execution!(execution_id, group_id, targets)
-    execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
-    :ok = Messaging.publish("results", execution_started)
-  end
-
-  defp complete_fake_execution(execution_id, group_id, targets) do
-    result = Enum.random([:passing, :warning, :critical])
-    check_results = build_check_results_from_targets(targets, result)
-
-    build_result =
-      build(:result,
-        check_results: check_results,
-        execution_id: execution_id,
-        group_id: group_id,
-        result: result
-      )
-
-    Executions.complete_execution!(
-      execution_id,
-      build_result
-    )
-
-    execution_completed = Messaging.Mapper.to_execution_completed(build_result)
-    :ok = Messaging.publish("results", execution_completed)
-  end
-
-  defp build_check_results_from_targets(targets, result) do
-    targets
-    |> Enum.flat_map(& &1.checks)
-    |> Enum.uniq()
-    |> Enum.map(fn check_id ->
-      check_targets = Enum.filter(targets, &(check_id in &1.checks))
-      build_check_result_from_target(check_id, check_targets, result)
-    end)
-  end
-
-  defp build_check_result_from_target(check_id, check_targets, result) do
-    {_, check} = Catalog.get_check(check_id)
-    expectation_evaluations = expectation_evaluations_from_check(check, result)
-
-    expectation_results =
-      Enum.map(
-        expectation_evaluations,
-        &build(:expectation_result, name: &1.name, type: &1.type, result: result == :passing)
-      )
-
-    build(:check_result,
-      check_id: check_id,
-      agents_check_results:
-        Enum.map(check_targets, fn %{agent_id: agent_id} ->
-          build(:agent_check_result,
-            agent_id: agent_id,
-            facts:
-              Enum.map(check.facts, fn %{name: name} ->
-                build(:fact, check_id: check_id, name: name)
-              end),
-            expectation_evaluations: expectation_evaluations,
-            values:
-              Enum.map(check.values, fn %{name: name, default: value} ->
-                %{name: name, value: value}
-              end)
-          )
-        end),
-      expectation_results: expectation_results,
-      result: result
-    )
-  end
-
-  defp expectation_evaluations_from_check(check, result) do
-    Enum.map(check.expectations, fn %{type: type, name: name} ->
-      case type do
-        :expect ->
-          build(:expectation_evaluation,
-            type: :expect,
-            name: name,
-            return_value: result == :passing
-          )
-
-        :expect_same ->
-          build(:expectation_evaluation,
-            type: :expect_same,
-            name: name,
-            return_value:
-              if result == :passing do
-                "same_value"
-              else
-                Faker.StarWars.quote()
-              end
-          )
-      end
-    end)
   end
 end

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -14,7 +14,7 @@ defmodule Wanda.Executions.FakeServer do
   }
 
   @impl true
-  def start_execution(execution_id, group_id, targets, env, _config \\ []) do
+  def start_execution(execution_id, group_id, targets, env, config \\ [sleep: 2_000]) do
     checks =
       targets
       |> Executions.Target.get_checks_from_targets()
@@ -31,7 +31,7 @@ defmodule Wanda.Executions.FakeServer do
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
     :ok = Messaging.publish("results", execution_started)
 
-    Process.sleep(2_000)
+    Process.sleep(Keyword.get(config, :sleep, 2_000))
 
     build_result = FakeEvaluation.complete_fake_execution(execution_id, group_id, targets, checks)
 

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -13,8 +13,9 @@ defmodule Wanda.Executions.FakeServer do
     Messaging
   }
 
+  @default_config [sleep: 2_000]
   @impl true
-  def start_execution(execution_id, group_id, targets, env, config \\ [sleep: 2_000]) do
+  def start_execution(execution_id, group_id, targets, env, config \\ @default_config) do
     checks =
       targets
       |> Executions.Target.get_checks_from_targets()

--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,7 @@ defmodule Wanda.MixProject do
   defp elixirc_paths(:demo),
     do: [
       "test/support/factory.ex",
-      "demo/fake_server.ex",
+      "demo",
       "lib"
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,8 @@ defmodule Wanda.MixProject do
   defp elixirc_paths(:test),
     do: [
       "lib",
-      "test/support"
+      "test/support",
+      "demo"
     ]
 
   defp elixirc_paths(:demo),

--- a/test/demo/fake_evaluation_test.exs
+++ b/test/demo/fake_evaluation_test.exs
@@ -4,9 +4,14 @@ defmodule Wanda.Executions.FakeEvaluationTest do
 
   import Wanda.Factory
 
-  alias Wanda.Catalog.Check
+  alias Wanda.Catalog.{
+    Check,
+    Fact,
+    Value
+  }
 
   alias Wanda.Executions.{
+    CheckResult,
     Execution,
     FakeEvaluation,
     Result,
@@ -51,31 +56,102 @@ defmodule Wanda.Executions.FakeEvaluationTest do
   describe "complete_fake_execution/4" do
     test "should complete a running fake execution" do
       [
+        %Fact{
+          name: fact_name_1
+        },
+        %Fact{
+          name: fact_name_2
+        }
+      ] = catalog_facts = build_list(2, :catalog_fact)
+
+      [
+        %Value{
+          name: value_name_1
+        },
+        %Value{
+          name: value_name_2
+        }
+      ] = values = build_list(2, :catalog_value)
+
+      [
         %Check{
           id: check_id_1
         },
         %Check{
           id: check_id_2
         }
-      ] = checks = build_list(2, :check)
+      ] = checks = build_list(2, :check, facts: catalog_facts, values: values)
 
       [
         %Execution.Target{
-          agent_id: agent_id_1
+          agent_id: agent_id
         }
-      ] = execution_targets = build_list(1, :execution_target, checks: [check_id_1, check_id_2])
+      ] = build_list(1, :execution_target, checks: [check_id_1, check_id_2])
 
-      targets = build_list(1, :target, agent_id: agent_id_1, checks: [check_id_1, check_id_2])
+      targets = build_list(1, :target, agent_id: agent_id, checks: [check_id_1, check_id_2])
 
       %Execution{
         execution_id: execution_id,
-        group_id: group_id,
-        targets: execution_targets
+        group_id: group_id
       } = insert(:execution, status: :running)
 
       assert %Result{
                execution_id: ^execution_id,
-               group_id: ^group_id
+               group_id: ^group_id,
+               check_results: [
+                 %CheckResult{
+                   check_id: ^check_id_1,
+                   agents_check_results: [
+                     %Wanda.Executions.AgentCheckResult{
+                       agent_id: ^agent_id,
+                       facts: [
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_1,
+                           check_id: ^check_id_1
+                         },
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_2,
+                           check_id: ^check_id_1
+                         }
+                       ],
+                       values: [
+                         %{
+                           name: ^value_name_1
+                         },
+                         %{
+                           name: ^value_name_2
+                         }
+                       ]
+                     }
+                   ]
+                 },
+                 %CheckResult{
+                   check_id: ^check_id_2,
+                   agents_check_results: [
+                     %Wanda.Executions.AgentCheckResult{
+                       agent_id: ^agent_id,
+                       facts: [
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_1,
+                           check_id: ^check_id_2
+                         },
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_2,
+                           check_id: ^check_id_2
+                         }
+                       ],
+                       values: [
+                         %{
+                           name: ^value_name_1
+                         },
+                         %{
+                           name: ^value_name_2
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               ]
              } =
                FakeEvaluation.complete_fake_execution(
                  execution_id,

--- a/test/demo/fake_evaluation_test.exs
+++ b/test/demo/fake_evaluation_test.exs
@@ -6,7 +6,8 @@ defmodule Wanda.Executions.FakeEvaluationTest do
   alias Wanda.Catalog.{
     Check,
     Fact,
-    Value
+    Value,
+    Expectation
   }
 
   alias Wanda.Executions.{
@@ -37,21 +38,38 @@ defmodule Wanda.Executions.FakeEvaluationTest do
       ] = values = build_list(2, :catalog_value)
 
       [
+        %Expectation{name: expectation_name_1},
+        %Expectation{name: expectation_name_2}
+      ] =
+        expectations = [
+          build(:catalog_expectation, type: :expect),
+          build(:catalog_expectation, type: :expect_same)
+        ]
+
+      [
         %Check{
           id: check_id_1
         },
         %Check{
           id: check_id_2
         }
-      ] = checks = build_list(2, :check, facts: catalog_facts, values: values)
+      ] =
+        checks =
+        build_list(2, :check, facts: catalog_facts, values: values, expectations: expectations)
 
       [
         %Execution.Target{
-          agent_id: agent_id
+          agent_id: agent_id_1
+        },
+        %Execution.Target{
+          agent_id: agent_id_2
         }
-      ] = build_list(1, :execution_target, checks: [check_id_1, check_id_2])
+      ] = build_list(2, :execution_target, checks: [check_id_1, check_id_2])
 
-      targets = build_list(1, :target, agent_id: agent_id, checks: [check_id_1, check_id_2])
+      targets = [
+        build(:target, agent_id: agent_id_1, checks: [check_id_1, check_id_2]),
+        build(:target, agent_id: agent_id_2, checks: [check_id_1, check_id_2])
+      ]
 
       %Execution{
         execution_id: execution_id,
@@ -66,7 +84,48 @@ defmodule Wanda.Executions.FakeEvaluationTest do
                    check_id: ^check_id_1,
                    agents_check_results: [
                      %Wanda.Executions.AgentCheckResult{
-                       agent_id: ^agent_id,
+                       agent_id: ^agent_id_1,
+                       expectation_evaluations: [
+                         %Wanda.Executions.ExpectationEvaluation{
+                           name: ^expectation_name_1,
+                           type: :expect
+                         },
+                         %Wanda.Executions.ExpectationEvaluation{
+                           name: ^expectation_name_2,
+                           type: :expect_same
+                         }
+                       ],
+                       facts: [
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_1,
+                           check_id: ^check_id_1
+                         },
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_2,
+                           check_id: ^check_id_1
+                         }
+                       ],
+                       values: [
+                         %{
+                           name: ^value_name_1
+                         },
+                         %{
+                           name: ^value_name_2
+                         }
+                       ]
+                     },
+                     %Wanda.Executions.AgentCheckResult{
+                       agent_id: ^agent_id_2,
+                       expectation_evaluations: [
+                         %Wanda.Executions.ExpectationEvaluation{
+                           name: ^expectation_name_1,
+                           type: :expect
+                         },
+                         %Wanda.Executions.ExpectationEvaluation{
+                           name: ^expectation_name_2,
+                           type: :expect_same
+                         }
+                       ],
                        facts: [
                          %Wanda.Executions.Fact{
                            name: ^fact_name_1,
@@ -86,13 +145,23 @@ defmodule Wanda.Executions.FakeEvaluationTest do
                          }
                        ]
                      }
+                   ],
+                   expectation_results: [
+                     %Wanda.Executions.ExpectationResult{
+                       name: ^expectation_name_1,
+                       type: :expect
+                     },
+                     %Wanda.Executions.ExpectationResult{
+                       name: ^expectation_name_2,
+                       type: :expect_same
+                     }
                    ]
                  },
                  %CheckResult{
                    check_id: ^check_id_2,
                    agents_check_results: [
                      %Wanda.Executions.AgentCheckResult{
-                       agent_id: ^agent_id,
+                       agent_id: ^agent_id_1,
                        facts: [
                          %Wanda.Executions.Fact{
                            name: ^fact_name_1,
@@ -111,6 +180,37 @@ defmodule Wanda.Executions.FakeEvaluationTest do
                            name: ^value_name_2
                          }
                        ]
+                     },
+                     %Wanda.Executions.AgentCheckResult{
+                       agent_id: ^agent_id_2,
+                       facts: [
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_1,
+                           check_id: ^check_id_2
+                         },
+                         %Wanda.Executions.Fact{
+                           name: ^fact_name_2,
+                           check_id: ^check_id_2
+                         }
+                       ],
+                       values: [
+                         %{
+                           name: ^value_name_1
+                         },
+                         %{
+                           name: ^value_name_2
+                         }
+                       ]
+                     }
+                   ],
+                   expectation_results: [
+                     %Wanda.Executions.ExpectationResult{
+                       name: ^expectation_name_1,
+                       type: :expect
+                     },
+                     %Wanda.Executions.ExpectationResult{
+                       name: ^expectation_name_2,
+                       type: :expect_same
                      }
                    ]
                  }

--- a/test/demo/fake_evaluation_test.exs
+++ b/test/demo/fake_evaluation_test.exs
@@ -1,6 +1,5 @@
 defmodule Wanda.Executions.FakeEvaluationTest do
   use ExUnit.Case
-  use Wanda.DataCase
 
   import Wanda.Factory
 
@@ -14,44 +13,8 @@ defmodule Wanda.Executions.FakeEvaluationTest do
     CheckResult,
     Execution,
     FakeEvaluation,
-    Result,
-    Target
+    Result
   }
-
-  describe "create_fake_execution/3" do
-    test "creates a fake execution" do
-      [
-        %Target{
-          agent_id: agent_id_1,
-          checks: checks_1
-        },
-        %Target{
-          agent_id: agent_id_2,
-          checks: checks_2
-        }
-      ] = targets = build_list(2, :target)
-
-      execution_id = UUID.uuid4()
-      group_id = UUID.uuid4()
-
-      assert %Execution{
-               execution_id: ^execution_id,
-               group_id: ^group_id,
-               status: :running,
-               result: %{},
-               targets: [
-                 %{
-                   agent_id: ^agent_id_1,
-                   checks: ^checks_1
-                 },
-                 %{
-                   agent_id: ^agent_id_2,
-                   checks: ^checks_2
-                 }
-               ]
-             } = FakeEvaluation.create_fake_execution(execution_id, group_id, targets)
-    end
-  end
 
   describe "complete_fake_execution/4" do
     test "should complete a running fake execution" do
@@ -93,7 +56,7 @@ defmodule Wanda.Executions.FakeEvaluationTest do
       %Execution{
         execution_id: execution_id,
         group_id: group_id
-      } = insert(:execution, status: :running)
+      } = build(:execution, status: :running)
 
       assert %Result{
                execution_id: ^execution_id,

--- a/test/demo/fake_evaluation_test.exs
+++ b/test/demo/fake_evaluation_test.exs
@@ -1,0 +1,88 @@
+defmodule Wanda.Executions.FakeEvaluationTest do
+  use ExUnit.Case
+  use Wanda.DataCase
+
+  import Wanda.Factory
+
+  alias Wanda.Catalog.Check
+
+  alias Wanda.Executions.{
+    Execution,
+    FakeEvaluation,
+    Result,
+    Target
+  }
+
+  describe "create_fake_execution/3" do
+    test "creates a fake execution" do
+      [
+        %Target{
+          agent_id: agent_id_1,
+          checks: checks_1
+        },
+        %Target{
+          agent_id: agent_id_2,
+          checks: checks_2
+        }
+      ] = targets = build_list(2, :target)
+
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               group_id: ^group_id,
+               status: :running,
+               result: %{},
+               targets: [
+                 %{
+                   agent_id: ^agent_id_1,
+                   checks: ^checks_1
+                 },
+                 %{
+                   agent_id: ^agent_id_2,
+                   checks: ^checks_2
+                 }
+               ]
+             } = FakeEvaluation.create_fake_execution(execution_id, group_id, targets)
+    end
+  end
+
+  describe "complete_fake_execution/4" do
+    test "should complete a running fake execution" do
+      [
+        %Check{
+          id: check_id_1
+        },
+        %Check{
+          id: check_id_2
+        }
+      ] = checks = build_list(2, :check)
+
+      [
+        %Execution.Target{
+          agent_id: agent_id_1
+        }
+      ] = execution_targets = build_list(1, :execution_target, checks: [check_id_1, check_id_2])
+
+      targets = build_list(1, :target, agent_id: agent_id_1, checks: [check_id_1, check_id_2])
+
+      %Execution{
+        execution_id: execution_id,
+        group_id: group_id,
+        targets: execution_targets
+      } = insert(:execution, status: :running)
+
+      assert %Result{
+               execution_id: ^execution_id,
+               group_id: ^group_id
+             } =
+               FakeEvaluation.complete_fake_execution(
+                 execution_id,
+                 group_id,
+                 targets,
+                 checks
+               )
+    end
+  end
+end

--- a/test/demo/fake_evaluation_test.exs
+++ b/test/demo/fake_evaluation_test.exs
@@ -5,9 +5,9 @@ defmodule Wanda.Executions.FakeEvaluationTest do
 
   alias Wanda.Catalog.{
     Check,
+    Expectation,
     Fact,
-    Value,
-    Expectation
+    Value
   }
 
   alias Wanda.Executions.{
@@ -26,7 +26,7 @@ defmodule Wanda.Executions.FakeEvaluationTest do
         %Fact{
           name: fact_name_2
         }
-      ] = catalog_facts = build_list(2, :catalog_fact)
+      ] = facts = build_list(2, :catalog_fact)
 
       [
         %Value{
@@ -53,9 +53,7 @@ defmodule Wanda.Executions.FakeEvaluationTest do
         %Check{
           id: check_id_2
         }
-      ] =
-        checks =
-        build_list(2, :check, facts: catalog_facts, values: values, expectations: expectations)
+      ] = checks = build_list(2, :check, facts: facts, values: values, expectations: expectations)
 
       [
         %Execution.Target{

--- a/test/demo/fake_server_test.exs
+++ b/test/demo/fake_server_test.exs
@@ -1,0 +1,39 @@
+defmodule Wanda.Executions.FakeServerTest do
+  use Wanda.DataCase
+
+  import Mox
+  import Wanda.Factory
+
+  alias Trento.Checks.V1.{
+    ExecutionCompleted,
+    ExecutionStarted
+  }
+
+  alias Wanda.Catalog
+
+  alias Wanda.Executions.{
+    Execution,
+    FakeServer
+  }
+
+  setup :verify_on_exit!
+
+  test "start_execution publishes execution started and completed messages" do
+    execution_id = UUID.uuid4()
+    group_id = UUID.uuid4()
+    targets = build_list(2, :target)
+    env = build(:env)
+
+    expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+      "results", %ExecutionStarted{execution_id: ^execution_id, group_id: ^group_id} ->
+        :ok
+
+      "results", %ExecutionCompleted{execution_id: ^execution_id, group_id: ^group_id} ->
+        :ok
+    end)
+
+    assert :ok = FakeServer.start_execution(execution_id, group_id, targets, env)
+
+    assert %Execution{execution_id: ^execution_id, status: :completed} = Repo.one!(Execution)
+  end
+end

--- a/test/demo/fake_server_test.exs
+++ b/test/demo/fake_server_test.exs
@@ -30,7 +30,7 @@ defmodule Wanda.Executions.FakeServerTest do
         :ok
     end)
 
-    assert :ok = FakeServer.start_execution(execution_id, group_id, targets, env)
+    assert :ok = FakeServer.start_execution(execution_id, group_id, targets, env, sleep: 0)
 
     assert %Execution{execution_id: ^execution_id, status: :completed} = Repo.one!(Execution)
   end

--- a/test/demo/fake_server_test.exs
+++ b/test/demo/fake_server_test.exs
@@ -9,8 +9,6 @@ defmodule Wanda.Executions.FakeServerTest do
     ExecutionStarted
   }
 
-  alias Wanda.Catalog
-
   alias Wanda.Executions.{
     Execution,
     FakeServer


### PR DESCRIPTION
This PR improves the faker so that it:
 - Facts now have the correct check_id and name from the corresponding check (fact values are still randomly generated though)
 - Expectation evaluation now also features real expectations from the actual check.
 - Values (expected values) are now also fetched from the catalog, assuming always the fallback / default provider.