### PR TITLE
Make cors optional on production

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,8 +37,7 @@ config :wanda, WandaWeb.Endpoint,
   live_view: [signing_salt: "j6kcshS4"]
 
 config :cors_plug,
-  origin: [System.get_env("CORS_ORIGIN", "http://localhost:4000")],
-  enabled: true
+  origin: [System.get_env("CORS_ORIGIN", "http://localhost:4000")]
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -51,7 +50,9 @@ config :phoenix, :json_library, Jason
 # Disable rustler precompiled NIFs
 config :rustler_precompiled, :force_build, rhai_rustler: true
 
-config :wanda, :jwt_authentication, enabled: true
+config :wanda,
+  cors_enabled: true,
+  jwt_authentication_enabled: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,8 @@ config :wanda, WandaWeb.Endpoint,
   live_view: [signing_salt: "j6kcshS4"]
 
 config :cors_plug,
-  origin: [System.get_env("CORS_ORIGIN", "http://localhost:4000")]
+  origin: [System.get_env("CORS_ORIGIN", "http://localhost:4000")],
+  enabled: true
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -71,3 +71,5 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k"
+
+config :unplug, :init_mode, :runtime

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -62,15 +62,22 @@ if config_env() in [:prod, :demo] do
       connection: amqp_url
     ]
 
-  cors_origin =
-    System.get_env("CORS_ORIGIN") ||
-      raise """
-      environment variable CORS_ORIGIN is missing.
-      For example: http://your-domain.com
-      """
+  cors_enabled = System.get_env("CORS_ENABLED", "true") == "true"
 
   config :cors_plug,
-    origin: [cors_origin]
+    enabled: cors_enabled
+
+  if cors_enabled do
+    cors_origin =
+      System.get_env("CORS_ORIGIN") ||
+        raise """
+        environment variable CORS_ORIGIN is missing.
+        For example: http://your-domain.com
+        """
+
+    config :cors_plug,
+      origin: [cors_origin]
+  end
 
   jwt_authentication_enabled = System.get_env("JWT_AUTHENTICATION_ENABLED", "true") == "true"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -64,8 +64,8 @@ if config_env() in [:prod, :demo] do
 
   cors_enabled = System.get_env("CORS_ENABLED", "true") == "true"
 
-  config :cors_plug,
-    enabled: cors_enabled
+  config :wanda,
+    cors_enabled: cors_enabled
 
   if cors_enabled do
     cors_origin =
@@ -81,7 +81,8 @@ if config_env() in [:prod, :demo] do
 
   jwt_authentication_enabled = System.get_env("JWT_AUTHENTICATION_ENABLED", "true") == "true"
 
-  config :wanda, :jwt_authentication, enabled: jwt_authentication_enabled
+  config :wanda,
+    jwt_authentication_enabled: jwt_authentication_enabled
 
   if jwt_authentication_enabled do
     config :joken,

--- a/config/test.exs
+++ b/config/test.exs
@@ -59,4 +59,5 @@ config :wanda,
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k"
 
-config :wanda, :jwt_authentication, enabled: false
+config :wanda,
+  jwt_authentication_enabled: false

--- a/docker-compose.checks.yaml
+++ b/docker-compose.checks.yaml
@@ -8,9 +8,9 @@ services:
       DATABASE_URL: ecto://postgres:postgres@postgres/postgres
       SECRET_KEY_BASE: dummyS3cr3t
       AMQP_URL: amqp://wanda:wanda@rabbitmq
-      CORS_ORIGIN: http://localhost:4000
+      CORS_ENABLED: "false"
       CATALOG_PATH: /app/catalog
-      JWT_AUTHENTICATION_ENABLED: false
+      JWT_AUTHENTICATION_ENABLED: "false"
     depends_on:
       - postgres
       - rabbitmq

--- a/lib/wanda_web/auth/jwt_auth_plug.ex
+++ b/lib/wanda_web/auth/jwt_auth_plug.ex
@@ -21,11 +21,7 @@ defmodule WandaWeb.Auth.JWTAuthPlug do
     Read, validate and decode the JWT from authorization header at each call
   """
   def call(conn, _) do
-    if Application.get_env(:wanda, :jwt_authentication)[:enabled] do
-      authenticate(conn)
-    else
-      conn
-    end
+    authenticate(conn)
   end
 
   defp authenticate(conn) do

--- a/lib/wanda_web/endpoint.ex
+++ b/lib/wanda_web/endpoint.ex
@@ -40,7 +40,10 @@ defmodule WandaWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
-  plug CORSPlug
+
+  plug Unplug,
+    if: {Unplug.Predicates.AppConfigEquals, {:cors_plug, :enabled, true}},
+    do: CORSPlug
 
   plug WandaWeb.Router
 end

--- a/lib/wanda_web/endpoint.ex
+++ b/lib/wanda_web/endpoint.ex
@@ -42,7 +42,7 @@ defmodule WandaWeb.Endpoint do
   plug Plug.Session, @session_options
 
   plug Unplug,
-    if: {Unplug.Predicates.AppConfigEquals, {:cors_plug, :enabled, true}},
+    if: {Unplug.Predicates.AppConfigEquals, {:wanda, :cors_enabled, true}},
     do: CORSPlug
 
   plug WandaWeb.Router

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -9,7 +9,9 @@ defmodule WandaWeb.Router do
   end
 
   pipeline :protected_api do
-    plug WandaWeb.Auth.JWTAuthPlug
+    plug Unplug,
+      if: {Unplug.Predicates.AppConfigEquals, {:wanda, :jwt_authentication_enabled, true}},
+      do: WandaWeb.Auth.JWTAuthPlug
   end
 
   scope "/api" do

--- a/mix.exs
+++ b/mix.exs
@@ -122,6 +122,7 @@ defmodule Wanda.MixProject do
        github: "trento-project/contracts",
        sparse: "elixir",
        ref: "b8e1036d0177c029ac40d34f237c366a7fb08bec"},
+      {:unplug, "~> 1.0.0"},
       # test deps
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -65,6 +65,7 @@
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
   "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "b8e1036d0177c029ac40d34f237c366a7fb08bec", [sparse: "elixir", ref: "b8e1036d0177c029ac40d34f237c366a7fb08bec"]},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
+  "unplug": {:hex, :unplug, "1.0.0", "8ec2479de0baa9a6283c04a1cc616c5ca6c5b80b8ff1d857481bb2943368dbbc", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "d171a85758aa412d4e85b809c203e1b1c4c76a4d6ab58e68dc9a8a8acd9b7c3a"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.9.0", "9a256da867b37b8d2c1ffd5d9de373a4fda77a32a45b452f1708508ba7bbcb53", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "0cb0e7d4c56f5e99a6253ed1a670ed0e39c13fc45a6da054033928607ac08dfc"},
 }

--- a/test/wanda_web/auth/jwt_auth_plug_test.exs
+++ b/test/wanda_web/auth/jwt_auth_plug_test.exs
@@ -17,10 +17,10 @@ defmodule WandaWeb.Auth.JWTAuthPlugTest do
         end
       )
 
-      Application.put_env(:wanda, :jwt_authentication, enabled: true)
+      Application.put_env(:wanda, :jwt_authentication_enabled, true)
 
       on_exit(fn ->
-        Application.put_env(:wanda, :jwt_authentication, enabled: false)
+        Application.put_env(:wanda, :jwt_authentication_enabled, false)
       end)
     end
 
@@ -68,15 +68,6 @@ defmodule WandaWeb.Auth.JWTAuthPlugTest do
 
       assert conn.status == 401
       assert conn.halted
-    end
-  end
-
-  describe "call/2 with disabled JWT authentication" do
-    test "should noop if JWT authentication is disabled" do
-      conn = build_conn()
-      new_conn = JWTAuthPlug.call(conn, enabled: false)
-
-      assert conn == new_conn
     end
   end
 end


### PR DESCRIPTION
CORS was mandatory until now, and in many occasions, like our k3s deployment, it is not needed, as the domain url of wanda and web are the same. This PRs makes cors optional based on the `CORS_ENABLED` env variable for production. `CORS` continues being enabled by default (useful in dev, as we all the services have different domain).

I have introduced the `Unplug` dependency, as there is not any straightforward solution to make the `plug` run dynamically based on external input. Unfortunately the `cors_plug` library doesn't have this natively...

Some references:
https://akoutmos.com/post/plug-runtime-config/
https://github.com/akoutmos/unplug