### PR TITLE
Add failure message

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -135,9 +135,12 @@
         "type": "object",
         "additionalProperties": false,
         "minProperties": 2,
-        "maxProperties": 2,
+        "maxProperties": 3,
         "properties": {
           "name": {
+            "type": "string"
+          },
+          "failure_message": {
             "type": "string"
           }
         },

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -13,6 +13,7 @@ defmodule Wanda.Catalog do
 
   require Logger
 
+  @default_failure_message "Expectation not met"
   @default_severity :critical
 
   @doc """
@@ -113,19 +114,21 @@ defmodule Wanda.Catalog do
   defp map_severity(%{"severity" => "warning"}), do: :warning
   defp map_severity(_), do: @default_severity
 
-  defp map_expectation(%{"name" => name, "expect" => expression}) do
+  defp map_expectation(%{"name" => name, "expect" => expression} = expectation) do
     %Expectation{
       name: name,
       type: :expect,
-      expression: expression
+      expression: expression,
+      failure_message: Map.get(expectation, "failure_message", @default_failure_message)
     }
   end
 
-  defp map_expectation(%{"name" => name, "expect_same" => expression}) do
+  defp map_expectation(%{"name" => name, "expect_same" => expression} = expectation) do
     %Expectation{
       name: name,
       type: :expect_same,
-      expression: expression
+      expression: expression,
+      failure_message: Map.get(expectation, "failure_message", @default_failure_message)
     }
   end
 

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -13,7 +13,6 @@ defmodule Wanda.Catalog do
 
   require Logger
 
-  @default_failure_message "Expectation not met"
   @default_severity :critical
 
   @doc """
@@ -119,7 +118,7 @@ defmodule Wanda.Catalog do
       name: name,
       type: :expect,
       expression: expression,
-      failure_message: Map.get(expectation, "failure_message", @default_failure_message)
+      failure_message: Map.get(expectation, "failure_message")
     }
   end
 
@@ -128,7 +127,7 @@ defmodule Wanda.Catalog do
       name: name,
       type: :expect_same,
       expression: expression,
-      failure_message: Map.get(expectation, "failure_message", @default_failure_message)
+      failure_message: Map.get(expectation, "failure_message")
     }
   end
 

--- a/lib/wanda/catalog/expectation.ex
+++ b/lib/wanda/catalog/expectation.ex
@@ -4,11 +4,12 @@ defmodule Wanda.Catalog.Expectation do
   """
 
   @derive Jason.Encoder
-  defstruct [:name, :type, :expression]
+  defstruct [:name, :type, :expression, :failure_message]
 
   @type t :: %__MODULE__{
           name: String.t(),
           type: :expect | :expect_same,
-          expression: String.t()
+          expression: String.t(),
+          failure_message: String.t()
         }
 end

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -157,12 +157,25 @@ defmodule Wanda.Executions.Evaluation do
   end
 
   defp eval_expectation(
-         %Expectation{name: name, type: type, expression: expression},
+         %Expectation{
+           name: name,
+           type: type,
+           expression: expression,
+           failure_message: failure_message
+         },
          evaluation_scope
        ) do
     case Rhai.eval(expression, evaluation_scope) do
       {:ok, return_value} ->
-        %ExpectationEvaluation{name: name, type: type, return_value: return_value}
+        maybe_add_failure_message(
+          %ExpectationEvaluation{
+            name: name,
+            type: type,
+            return_value: return_value
+          },
+          failure_message,
+          evaluation_scope
+        )
 
       {:error, {error_type, message}} ->
         %ExpectationEvaluationError{
@@ -172,6 +185,26 @@ defmodule Wanda.Executions.Evaluation do
         }
     end
   end
+
+  defp maybe_add_failure_message(
+         %ExpectationEvaluation{type: :expect, return_value: false} = expectation_evaluation,
+         failure_message,
+         evaluation_scope
+       ) do
+    {:ok, interpolated_failure_message} = Rhai.eval("`#{failure_message}`", evaluation_scope)
+
+    Map.put(expectation_evaluation, :failure_message, interpolated_failure_message)
+  end
+
+  defp maybe_add_failure_message(
+         %ExpectationResult{type: :expect_same, result: false} = expectation_result,
+         failure_message,
+         _evaluation_scope
+       ) do
+    Map.put(expectation_result, :failure_message, failure_message)
+  end
+
+  defp maybe_add_failure_message(expectation, _, _), do: expectation
 
   defp add_expectation_results(
          %CheckResult{agents_check_results: agents_check_results} = result,
@@ -195,12 +228,26 @@ defmodule Wanda.Executions.Evaluation do
             _ -> false
           end)
 
-        %ExpectationResult{
-          name: name,
-          type: type,
-          result:
-            eval_expectation_result_or_error(type, expectation_evaluations, agents_check_results)
-        }
+        failure_message =
+          Enum.find_value(expectations, fn
+            %Expectation{name: ^name, failure_message: failure_message} -> failure_message
+            _ -> false
+          end)
+
+        maybe_add_failure_message(
+          %ExpectationResult{
+            name: name,
+            type: type,
+            result:
+              eval_expectation_result_or_error(
+                type,
+                expectation_evaluations,
+                agents_check_results
+              )
+          },
+          failure_message,
+          %{}
+        )
       end)
 
     %CheckResult{result | expectation_results: expectation_results}

--- a/lib/wanda/executions/expectation_evaluation.ex
+++ b/lib/wanda/executions/expectation_evaluation.ex
@@ -7,12 +7,14 @@ defmodule Wanda.Executions.ExpectationEvaluation do
   defstruct [
     :name,
     :return_value,
-    :type
+    :type,
+    :failure_message
   ]
 
   @type t :: %__MODULE__{
           name: String.t(),
           return_value: number() | boolean() | String.t(),
-          type: :expect | :expect_same
+          type: :expect | :expect_same,
+          failure_message: String.t() | nil
         }
 end

--- a/lib/wanda/executions/expectation_result.ex
+++ b/lib/wanda/executions/expectation_result.ex
@@ -7,12 +7,14 @@ defmodule Wanda.Executions.ExpectationResult do
   defstruct [
     :name,
     :result,
-    :type
+    :type,
+    :failure_message
   ]
 
   @type t :: %__MODULE__{
           name: String.t(),
           result: boolean(),
-          type: :expect | :expect_same
+          type: :expect | :expect_same,
+          failure_message: String.t() | nil
         }
 end

--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -89,6 +89,11 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
             expression: %Schema{
               type: :string,
               description: "Expression to be evaluated to get the expectation result"
+            },
+            failure_message: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Expression to be evaluated in case of failure"
             }
           },
           required: [:name, :type, :expression]

--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -93,7 +93,7 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
             failure_message: %Schema{
               type: :string,
               nullable: true,
-              description: "Expression to be evaluated in case of failure"
+              description: "Message returned when the check fails"
             }
           },
           required: [:name, :type, :expression]

--- a/lib/wanda_web/schemas/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/execution/expectation_evaluation.ex
@@ -23,7 +23,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluation do
       failure_message: %Schema{
         type: :string,
         nullable: true,
-        description: "Failure message"
+        description: "Failure message. Only available for `expect` scenarios"
       }
     },
     required: [:name, :return_value, :type]

--- a/lib/wanda_web/schemas/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/execution/expectation_evaluation.ex
@@ -19,6 +19,11 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluation do
         type: :string,
         enum: ["expect", "expect_same"],
         description: "Evaluation type"
+      },
+      failure_message: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Failure message"
       }
     },
     required: [:name, :return_value, :type]

--- a/lib/wanda_web/schemas/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/execution/expectation_result.ex
@@ -16,6 +16,11 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationResult do
         type: :string,
         enum: ["expect", "expect_same"],
         description: "Evaluation type"
+      },
+      failure_message: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Failure message"
       }
     },
     required: [:name, :result, :type]

--- a/lib/wanda_web/schemas/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/execution/expectation_result.ex
@@ -20,7 +20,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationResult do
       failure_message: %Schema{
         type: :string,
         nullable: true,
-        description: "Failure message"
+        description: "Failure message. Only available for `expect_same` scenarios"
       }
     },
     required: [:name, :result, :type]

--- a/lib/wanda_web/views/v1/execution_view.ex
+++ b/lib/wanda_web/views/v1/execution_view.ex
@@ -71,21 +71,22 @@ defmodule WandaWeb.V1.ExecutionView do
   defp count_results(:completed, %{"check_results" => check_results}, severity),
     do: Enum.count(check_results, &(&1["result"] == severity))
 
-  defp strip_nil_failure_messages(%{"failure_message" => nil} = struct) do
-    struct
-    |> Map.delete("failure_message")
-    |> Enum.map(fn {key, value} -> {key, strip_nil_failure_messages(value)} end)
-    |> Map.new()
-  end
+  defp strip_nil_failure_messages(param) when is_map(param),
+    do:
+      Enum.reduce(
+        param,
+        %{},
+        fn
+          {"failure_message", nil}, acc ->
+            acc
+
+          {key, value}, acc ->
+            Map.put(acc, key, strip_nil_failure_messages(value))
+        end
+      )
 
   defp strip_nil_failure_messages(param) when is_list(param),
     do: Enum.map(param, &strip_nil_failure_messages/1)
-
-  defp strip_nil_failure_messages(param) when is_map(param),
-    do:
-      param
-      |> Enum.map(fn {key, value} -> {key, strip_nil_failure_messages(value)} end)
-      |> Map.new()
 
   defp strip_nil_failure_messages(value), do: value
 end

--- a/lib/wanda_web/views/v1/execution_view.ex
+++ b/lib/wanda_web/views/v1/execution_view.ex
@@ -62,10 +62,30 @@ defmodule WandaWeb.V1.ExecutionView do
   defp map_timeout(:completed, %{"timeout" => timeout}), do: timeout
 
   defp map_check_results(:running, _), do: nil
-  defp map_check_results(:completed, %{"check_results" => check_results}), do: check_results
+
+  defp map_check_results(:completed, %{"check_results" => check_results}),
+    do: Enum.map(check_results, &strip_nil_failure_messages/1)
 
   defp count_results(:running, _, _), do: nil
 
   defp count_results(:completed, %{"check_results" => check_results}, severity),
     do: Enum.count(check_results, &(&1["result"] == severity))
+
+  defp strip_nil_failure_messages(%{"failure_message" => nil} = struct) do
+    struct
+    |> Map.delete("failure_message")
+    |> Enum.map(fn {key, value} -> {key, strip_nil_failure_messages(value)} end)
+    |> Map.new()
+  end
+
+  defp strip_nil_failure_messages(param) when is_list(param),
+    do: Enum.map(param, &strip_nil_failure_messages/1)
+
+  defp strip_nil_failure_messages(param) when is_map(param),
+    do:
+      param
+      |> Enum.map(fn {key, value} -> {key, strip_nil_failure_messages(value)} end)
+      |> Map.new()
+
+  defp strip_nil_failure_messages(value), do: value
 end

--- a/test/fixtures/catalog/expect_check.yaml
+++ b/test/fixtures/catalog/expect_check.yaml
@@ -29,5 +29,6 @@ values:
 expectations:
   - name: some_expectation
     expect: facts.jedi == values.expected_value
+    failure_message: "some failure message ${fact.name}"
   - name: some_other_expectation
     expect: facts.jedi > values.expected_higher_value

--- a/test/fixtures/catalog/expect_check.yaml
+++ b/test/fixtures/catalog/expect_check.yaml
@@ -29,6 +29,6 @@ values:
 expectations:
   - name: some_expectation
     expect: facts.jedi == values.expected_value
-    failure_message: "some failure message ${fact.name}"
+    failure_message: "some failure message ${facts.jedi}"
   - name: some_other_expectation
     expect: facts.jedi > values.expected_higher_value

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -87,13 +87,13 @@ defmodule Wanda.CatalogTest do
                     name: "some_expectation",
                     type: :expect,
                     expression: "facts.jedi == values.expected_value",
-                    failure_message: "some failure message ${fact.name}"
+                    failure_message: "some failure message ${facts.jedi}"
                   },
                   %Expectation{
                     name: "some_other_expectation",
                     type: :expect,
                     expression: "facts.jedi > values.expected_higher_value",
-                    failure_message: "Expectation not met"
+                    failure_message: nil
                   }
                 ]
               }} = Catalog.get_check("expect_check")

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -86,12 +86,14 @@ defmodule Wanda.CatalogTest do
                   %Expectation{
                     name: "some_expectation",
                     type: :expect,
-                    expression: "facts.jedi == values.expected_value"
+                    expression: "facts.jedi == values.expected_value",
+                    failure_message: "some failure message ${fact.name}"
                   },
                   %Expectation{
                     name: "some_other_expectation",
                     type: :expect,
-                    expression: "facts.jedi > values.expected_higher_value"
+                    expression: "facts.jedi > values.expected_higher_value",
+                    failure_message: "Expectation not met"
                   }
                 ]
               }} = Catalog.get_check("expect_check")

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -1362,5 +1362,90 @@ defmodule Wanda.Executions.EvaluationTest do
                result: :critical
              } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{})
     end
+
+    test "should return a default failure message in case of an erroring interpolation" do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      fact_value = Enum.random(1..10)
+      incorrect_fact_value = Enum.random(11..20)
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      [%Catalog.Expectation{name: expectation_name}] =
+        expectations =
+        build_list(1, :catalog_expectation,
+          type: :expect,
+          expression: "facts.#{fact_name} == #{fact_value}",
+          failure_message: "failure checking ${facts.kekw}"
+        )
+
+      [%Catalog.Check{id: check_id}] =
+        checks =
+        build_list(1, :check,
+          severity: :critical,
+          facts: catalog_facts,
+          values: [],
+          expectations: expectations
+        )
+
+      gathered_facts = %{
+        check_id => %{
+          "agent_1" =>
+            incorrect_facts =
+              build_list(1, :fact,
+                name: fact_name,
+                check_id: check_id,
+                value: incorrect_fact_value
+              ),
+          "agent_2" =>
+            facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: fact_value)
+        }
+      }
+
+      assert %Result{
+               execution_id: ^execution_id,
+               group_id: ^group_id,
+               check_results: [
+                 %CheckResult{
+                   agents_check_results: [
+                     %AgentCheckResult{
+                       agent_id: "agent_1",
+                       expectation_evaluations: [
+                         %ExpectationEvaluation{
+                           name: ^expectation_name,
+                           return_value: false,
+                           type: :expect,
+                           failure_message: "Expectation not met"
+                         }
+                       ],
+                       facts: ^incorrect_facts
+                     },
+                     %AgentCheckResult{
+                       agent_id: "agent_2",
+                       expectation_evaluations: [
+                         %ExpectationEvaluation{
+                           name: ^expectation_name,
+                           return_value: true,
+                           type: :expect,
+                           failure_message: nil
+                         }
+                       ],
+                       facts: ^facts
+                     }
+                   ],
+                   check_id: ^check_id,
+                   expectation_results: [
+                     %ExpectationResult{
+                       name: ^expectation_name,
+                       result: false,
+                       type: :expect
+                     }
+                   ],
+                   result: :critical
+                 }
+               ],
+               result: :critical
+             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{})
+    end
   end
 end


### PR DESCRIPTION
Adding a `failure_message` field to expectations and expectation evaluation structs.

The failure message gets evaluated using Rhai and can interpolate facts and values. The failure message is treated as a template string.