### PR TITLE
Fix execution of SBD related checks  (jsc#CFSA-1961)

### DIFF
--- a/priv/catalog/0B6DB2.yaml
+++ b/priv/catalog/0B6DB2.yaml
@@ -48,7 +48,7 @@ remediation: |
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html#pro-ha-storage-protect-sbd-config
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-sbd-configuration
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: sbd_pacemaker

--- a/priv/catalog/0B6DB2.yaml
+++ b/priv/catalog/0B6DB2.yaml
@@ -48,7 +48,7 @@ remediation: |
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html#pro-ha-storage-protect-sbd-config
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-sbd-configuration
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_pacemaker

--- a/priv/catalog/222A57.yaml
+++ b/priv/catalog/222A57.yaml
@@ -13,7 +13,7 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: package_sbd

--- a/priv/catalog/222A57.yaml
+++ b/priv/catalog/222A57.yaml
@@ -13,7 +13,7 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: package_sbd

--- a/priv/catalog/49591F.yaml
+++ b/priv/catalog/49591F.yaml
@@ -46,7 +46,7 @@ remediation: |
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-sbd-configuration
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_startmode

--- a/priv/catalog/49591F.yaml
+++ b/priv/catalog/49591F.yaml
@@ -46,7 +46,7 @@ remediation: |
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-sbd-configuration
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: sbd_startmode

--- a/priv/catalog/61451E.yaml
+++ b/priv/catalog/61451E.yaml
@@ -28,7 +28,7 @@ remediation: |
 
 severity: warning
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: sbd_multiple_sbd_device

--- a/priv/catalog/61451E.yaml
+++ b/priv/catalog/61451E.yaml
@@ -28,7 +28,7 @@ remediation: |
 
 severity: warning
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_multiple_sbd_device

--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -26,7 +26,7 @@ remediation: |
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-verifying-the-sbd-device
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: dump_sbd_devices

--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -26,7 +26,7 @@ remediation: |
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-verifying-the-sbd-device
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: dump_sbd_devices

--- a/priv/catalog/816815.yaml
+++ b/priv/catalog/816815.yaml
@@ -31,7 +31,7 @@ remediation: |
 
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html#pro-ha-storage-protect-sbd-services
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: sbd_service_state

--- a/priv/catalog/816815.yaml
+++ b/priv/catalog/816815.yaml
@@ -31,7 +31,7 @@ remediation: |
 
     - https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-storage-protect.html#pro-ha-storage-protect-sbd-services
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_service_state

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -26,7 +26,7 @@ remediation: |
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: dump_sbd_devices

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -26,7 +26,7 @@ remediation: |
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-cluster-bootstrap-and-more
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: dump_sbd_devices

--- a/priv/catalog/C3166E.yaml
+++ b/priv/catalog/C3166E.yaml
@@ -13,7 +13,7 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 
-when: env.provider != "gcp" & env.provider != "aws"
+when: env.provider !in ["gcp", "aws"]
 
 facts:
   - name: exclude_package_sbd

--- a/priv/catalog/C3166E.yaml
+++ b/priv/catalog/C3166E.yaml
@@ -13,7 +13,7 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 
-when: env.provider in ["azure", "nutanix", "kvm"]
+when: env.provider != "gcp" & env.provider != "aws"
 
 facts:
   - name: exclude_package_sbd


### PR DESCRIPTION
Skip the SBD related checks on the providers 'aws' and 'gcp' instead of executing the checks ONLY on the provider 'azure', 'kvm' or 'nutanix' as we do today. This gives us the possibility to run the SBD related checks on a (for trento) currently 'unknown' provider too.