### PR TITLE
Expectation results result to false when some agent evaluation is missing

### DIFF
--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -53,7 +53,7 @@ defmodule Wanda.Executions.Evaluation do
       check_id: check_id
     }
     |> add_agents_results(expectations, agents_facts, env, values)
-    |> add_expectation_evaluations(expectations)
+    |> add_expectation_results(expectations)
     |> aggregate_check_result(severity)
   end
 
@@ -115,6 +115,14 @@ defmodule Wanda.Executions.Evaluation do
     end)
   end
 
+  defp add_scope(scope, namespace, namespaced_scope) do
+    Map.put(
+      scope,
+      namespace,
+      Enum.into(namespaced_scope, %{}, fn %{name: name, value: value} -> {name, value} end)
+    )
+  end
+
   defp eval_value(
          %CatalogValue{
            name: name,
@@ -127,14 +135,6 @@ defmodule Wanda.Executions.Evaluation do
       name: name,
       value: find_value(conditions, default, evaluation_scope)
     }
-  end
-
-  defp add_scope(scope, namespace, namespaced_scope) do
-    Map.put(
-      scope,
-      namespace,
-      Enum.into(namespaced_scope, %{}, fn %{name: name, value: value} -> {name, value} end)
-    )
   end
 
   defp find_value(conditions, default, evaluation_scope) do
@@ -173,7 +173,7 @@ defmodule Wanda.Executions.Evaluation do
     end
   end
 
-  defp add_expectation_evaluations(
+  defp add_expectation_results(
          %CheckResult{agents_check_results: agents_check_results} = result,
          expectations
        ) do
@@ -251,6 +251,13 @@ defmodule Wanda.Executions.Evaluation do
     %CheckResult{check_result | result: result}
   end
 
+  defp errors?(agents_check_results),
+    do:
+      Enum.any?(agents_check_results, fn
+        %AgentCheckError{} -> true
+        _ -> false
+      end)
+
   defp aggregate_execution_result(%Result{check_results: check_results} = execution) do
     result =
       check_results
@@ -261,13 +268,6 @@ defmodule Wanda.Executions.Evaluation do
 
     %Result{execution | result: result}
   end
-
-  defp errors?(agents_check_results),
-    do:
-      Enum.any?(agents_check_results, fn
-        %AgentCheckError{} -> true
-        _ -> false
-      end)
 
   # TODO: is unknown needed?
   # defp result_weight(:unknown), do: 3

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -198,15 +198,17 @@ defmodule Wanda.Executions.Evaluation do
         %ExpectationResult{
           name: name,
           type: type,
-          result: eval_expectation_result_or_error(type, expectation_evaluations)
+          result:
+            eval_expectation_result_or_error(type, expectation_evaluations, agents_check_results)
         }
       end)
 
     %CheckResult{result | expectation_results: expectation_results}
   end
 
-  defp eval_expectation_result_or_error(type, expectation_evaluations) do
-    if has_error?(expectation_evaluations) do
+  defp eval_expectation_result_or_error(type, expectation_evaluations, agents_check_results) do
+    if has_error?(expectation_evaluations) or
+         length(agents_check_results) != length(expectation_evaluations) do
       false
     else
       eval_expectation_result(type, expectation_evaluations)

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -232,7 +232,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    expectation_results: [
                      %ExpectationResult{
                        name: ^expectation_name,
-                       result: true,
+                       result: false,
                        type: :expect
                      }
                    ],
@@ -318,7 +318,7 @@ defmodule Wanda.Executions.EvaluationTest do
              } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{})
     end
 
-    test "should return a passing result when not all the agents fullfill the expectations with an expect_same condition" do
+    test "should return a critical result when some of the agents expect_same condition return value is different" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()
       fact_value = Enum.random(1..10)
@@ -578,7 +578,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    expectation_results: [
                      %ExpectationResult{
                        name: ^expectation_name,
-                       result: true,
+                       result: false,
                        type: :expect
                      }
                    ],


### PR DESCRIPTION
Set the `expectation_results` `result` value to false if some of the agents evaluation is missing.

Before this, the `result` value was true if any of the agents evaluation was correct, even in agent error scenarios. This gave an incorrect information in the moment to check how many expectations failed in the return payload.

This is specially needed in `expect_same` scenario, where the `evaluation_results` is the unique place where the number of passing/failling expectations data is available.

No need to add new tests as adapting the old ones with the correct values is sufficient.

PD: Only the 2nd commit is relevant. The 1st simply changes some names and orders to have a more meaningful code.