### PR TITLE
Add healthcheck and readiness endpoints

### DIFF
--- a/lib/wanda_web/controllers/health_controller.ex
+++ b/lib/wanda_web/controllers/health_controller.ex
@@ -1,0 +1,47 @@
+defmodule WandaWeb.HealthController do
+  use WandaWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Ecto.Adapters.SQL
+
+  alias WandaWeb.Schemas.{
+    Health,
+    Ready
+  }
+
+  operation :ready,
+    summary: "Wanda ready",
+    tags: ["Platform"],
+    description: "Check if Wanda is ready",
+    security: [],
+    responses: [
+      ok: {"Wanda is ready", "application/json", Ready}
+    ]
+
+  def ready(conn, _) do
+    conn
+    |> put_status(200)
+    |> json(%{ready: true})
+  end
+
+  operation :health,
+    summary: "Wanda health",
+    tags: ["Platform"],
+    description: "Get the health status of the Wanda platform",
+    security: [],
+    responses: [
+      ok: {"Wanda health status", "application/json", Health}
+    ]
+
+  def health(conn, _) do
+    db_status =
+      case SQL.query(Wanda.Repo, "SELECT 1", []) do
+        {:ok, _} -> :pass
+        {:error, _} -> :fail
+      end
+
+    conn
+    |> put_status(if db_status == :pass, do: 200, else: 500)
+    |> render("health.json", health: %{database: db_status})
+  end
+end

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -32,6 +32,12 @@ defmodule WandaWeb.Router do
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
   end
 
+  scope "/api", WandaWeb do
+    pipe_through :api
+    get "/healthz", HealthController, :health
+    get "/readyz", HealthController, :ready
+  end
+
   scope "/api" do
     pipe_through :api
 

--- a/lib/wanda_web/schemas/health.ex
+++ b/lib/wanda_web/schemas/health.ex
@@ -1,0 +1,32 @@
+defmodule WandaWeb.Schemas.Health do
+  @moduledoc """
+  Healthcheck
+  """
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%Schema{
+    title: "Health",
+    type: :object,
+    example: %{
+      database: "pass"
+    },
+    properties: %{
+      database: %Schema{
+        description: "The status of the database connection",
+        type: :string,
+        enum: ["pass", "fail"]
+      }
+    }
+  })
+
+  def response do
+    Operation.response(
+      "Health",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/wanda_web/schemas/ready.ex
+++ b/lib/wanda_web/schemas/ready.ex
@@ -1,0 +1,31 @@
+defmodule WandaWeb.Schemas.Ready do
+  @moduledoc """
+  Ready
+  """
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%Schema{
+    title: "Ready",
+    type: :object,
+    example: %{
+      ready: true
+    },
+    properties: %{
+      ready: %Schema{
+        description: "Wanda platform ready",
+        type: :boolean
+      }
+    }
+  })
+
+  def response do
+    Operation.response(
+      "Ready",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/wanda_web/views/health_view.ex
+++ b/lib/wanda_web/views/health_view.ex
@@ -1,0 +1,5 @@
+defmodule WandaWeb.HealthView do
+  use WandaWeb, :view
+
+  def render("health.json", %{health: health}), do: health
+end

--- a/test/wanda_web/controllers/health_test.exs
+++ b/test/wanda_web/controllers/health_test.exs
@@ -1,0 +1,39 @@
+defmodule WandaWeb.HealthTest do
+  @moduledoc false
+
+  use WandaWeb.ConnCase, async: true
+
+  import OpenApiSpex.TestAssertions
+
+  alias WandaWeb.ApiSpec
+
+  setup do
+    %{api_spec: ApiSpec.spec()}
+  end
+
+  describe "Health" do
+    test "report healthy state when database is up for /healthz endpoint", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      response =
+        conn
+        |> get("/api/healthz")
+        |> json_response(200)
+
+      assert_schema(response, "Health", api_spec)
+    end
+
+    test "report healthy state for /readyz endpoint", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      response =
+        conn
+        |> get("/api/readyz")
+        |> json_response(200)
+
+      assert_schema(response, "Ready", api_spec)
+    end
+  end
+end

--- a/test/wanda_web/views/health_view_test.exs
+++ b/test/wanda_web/views/health_view_test.exs
@@ -1,0 +1,15 @@
+defmodule WandaWeb.HealthcheckViewTest do
+  use ExUnit.Case
+
+  import Phoenix.View
+
+  test "should render data indicating that the database is in a healthy state" do
+    assert %{database: "pass"} ==
+             render(WandaWeb.HealthView, "health.json", health: %{database: "pass"})
+  end
+
+  test "should render data indicating that the database is in an unhealthy state" do
+    assert %{database: "fail"} ==
+             render(WandaWeb.HealthView, "health.json", health: %{database: "fail"})
+  end
+end


### PR DESCRIPTION
Related to https://github.com/trento-project/web/pull/1286

# Description

Adds `/api/healthz` and `/api/readyz` endpoints to get the health status and readiness of the Trento Web server respectively.

In this PR, the healthcheck only checks that the database/Repo is online and responding. A follow up PR will add a check for the RabbitMQ Consumer and Publishers.

## How was this tested?

By adding integration tests for each endpoint
