### PR TITLE
Add default failure message for expect_same expectations

### DIFF
--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -212,6 +212,14 @@ defmodule Wanda.Executions.Evaluation do
 
   defp maybe_add_failure_message(
          %ExpectationResult{type: :expect_same, result: false} = expectation_result,
+         nil,
+         _evaluation_scope
+       ) do
+    %ExpectationResult{expectation_result | failure_message: @default_failure_message}
+  end
+
+  defp maybe_add_failure_message(
+         %ExpectationResult{type: :expect_same, result: false} = expectation_result,
          failure_message,
          _evaluation_scope
        ) do


### PR DESCRIPTION
This PR takes care of providing a default failure message for failing expect_same statements.