### PR TITLE
Document cluster type support

### DIFF
--- a/guides/specification.md
+++ b/guides/specification.md
@@ -583,10 +583,11 @@ Scopes are namespaced and access to items in the scope is name based.
 
 `env` is a map of information about the context of the running execution, it is set by the system on each execution/check compilation.
 
-Examples of entries in the scope. What is actually available during the execution depends on the scenario.
-| name | Type  
-| ----------------------------- | -------------------------------------------------------
-| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `unknown`
+Examples of entries in the scope. What is actually available during the execution depends on the scenario. Find the updated values in the reference column link.
+| name | Type | Reference
+| ---- | -----| ----------
+| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/domain/enums/provider.ex)
+| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/domain/enums/cluster_type.ex)
 
 #### **facts**
 

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -55,7 +55,7 @@ defmodule Wanda.Messaging.Mapper do
           execution_id: String.t(),
           group_id: String.t(),
           targets: [Target.t()],
-          env: %{String.t() => boolean() | number() | String.t()}
+          env: %{String.t() => boolean() | number() | String.t() | nil}
         }
   def from_execution_requested(%ExecutionRequested{
         execution_id: execution_id,
@@ -67,7 +67,7 @@ defmodule Wanda.Messaging.Mapper do
       execution_id: execution_id,
       group_id: group_id,
       targets: Target.map_targets(targets),
-      env: Map.new(env, fn {key, %{kind: {_, value}}} -> {key, value} end)
+      env: Map.new(env, fn {key, %{kind: value}} -> {key, map_env_entry(value)} end)
     }
   end
 
@@ -144,4 +144,7 @@ defmodule Wanda.Messaging.Mapper do
   defp map_value(%{kind: {_, value}}) do
     value
   end
+
+  defp map_env_entry({_, value}), do: value
+  defp map_env_entry({:null_value}), do: nil
 end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -169,6 +169,9 @@ defmodule Wanda.Messaging.MapperTest do
           },
           some_boolean: %{
             kind: {:boolean_value, true}
+          },
+          null: %{
+            kind: {:null_value}
           }
         }
       )
@@ -189,7 +192,8 @@ defmodule Wanda.Messaging.MapperTest do
              env: %{
                some_string: "some_string",
                some_number: 10,
-               some_boolean: true
+               some_boolean: true,
+               null: nil
              }
            } = Mapper.from_execution_requested(execution)
   end


### PR DESCRIPTION
Document `cluster_type` env variable support.

Besides that, I have fixed a corner case issue, if some day we decide to send a `null` value in an env entry (unlikely, but hey, it won't break hehe)