### PR TITLE
Fix formatting in demo guide

### DIFF
--- a/guides/development/demo.md
+++ b/guides/development/demo.md
@@ -61,9 +61,9 @@ targets:
   <target_reference>: <target_id>
 ```
 
-<target_reference>: A user-defined handle or reference for a target.
+`<target_reference>`: A user-defined handle or reference for a target.
 
-<target_id>: The UUID or identifier of the target.
+`<target_id>`: The UUID or identifier of the target.
 
 Add as many new target entries as required:
 


### PR DESCRIPTION
# Description
The Ci build of wanda docs has a formatting error.

Just a quick fix so the documentation can be build properly

## Before
![image](https://github.com/trento-project/wanda/assets/54111255/6cfc9368-63ee-452f-a6dd-f5bbcd2fc802)

## After
![image](https://github.com/trento-project/wanda/assets/54111255/7e4e1121-752e-4f7d-887a-33c78a516870)

