### PR TITLE
Update rabbitmq image in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   rabbitmq:
-    image: rabbitmq:3.10.5-management-alpine
+    image: rabbitmq:3.12.6-management-alpine
     ports:
       - 5674:5672
       - 15674:15672


### PR DESCRIPTION
Just updating RabbitMQ inside docker-compose because it has better support for OTP 26 clients