### PR TITLE
Pin all the gatherer version in checks to v1

### DIFF
--- a/priv/catalog/00081D.yaml
+++ b/priv/catalog/00081D.yaml
@@ -50,7 +50,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: max_messages
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.config.totem.max_messages
 
 values:

--- a/priv/catalog/0B6DB2.yaml
+++ b/priv/catalog/0B6DB2.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_pacemaker
-    gatherer: sbd_config
+    gatherer: sbd_config@v1
     argument: SBD_PACEMAKER
 
 values:

--- a/priv/catalog/156F64.yaml
+++ b/priv/catalog/156F64.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_token_timeout
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.token
 
 values:

--- a/priv/catalog/15F7A8.yaml
+++ b/priv/catalog/15F7A8.yaml
@@ -50,7 +50,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: token_retransmits
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.config.totem.token_retransmits_before_loss_const
 
 values:

--- a/priv/catalog/205AF7.yaml
+++ b/priv/catalog/205AF7.yaml
@@ -46,7 +46,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: crm_config_properties
-    gatherer: cibadmin
+    gatherer: cibadmin@v1
     argument: cib.configuration.crm_config.cluster_property_set
 
 expectations:

--- a/priv/catalog/21FCA6.yaml
+++ b/priv/catalog/21FCA6.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_token_retransmits_before_loss_const
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.token_retransmits_before_loss_const
 
 values:

--- a/priv/catalog/222A57.yaml
+++ b/priv/catalog/222A57.yaml
@@ -17,7 +17,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: compare_sbd_version
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: sbd,1.4.0
 
 expectations:

--- a/priv/catalog/24ABCB.yaml
+++ b/priv/catalog/24ABCB.yaml
@@ -46,7 +46,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_join_timeout
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.join
 
 values:

--- a/priv/catalog/32CFC6.yaml
+++ b/priv/catalog/32CFC6.yaml
@@ -41,7 +41,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: totem_interfaces
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: totem.interface
 
 values:

--- a/priv/catalog/33403D.yaml
+++ b/priv/catalog/33403D.yaml
@@ -69,7 +69,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_transport_protocol
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.transport
 
 values:

--- a/priv/catalog/373DB8.yaml
+++ b/priv/catalog/373DB8.yaml
@@ -46,10 +46,10 @@ when: env.target_type == "cluster"
 
 facts:
   - name: crm_config_properties
-    gatherer: cibadmin
+    gatherer: cibadmin@v1
     argument: cib.configuration.crm_config.cluster_property_set
   - name: resources_primitives
-    gatherer: cibadmin
+    gatherer: cibadmin@v1
     argument: cib.configuration.resources.primitive
 
 values:

--- a/priv/catalog/49591F.yaml
+++ b/priv/catalog/49591F.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_startmode
-    gatherer: sbd_config
+    gatherer: sbd_config@v1
     argument: SBD_STARTMODE
 
 values:

--- a/priv/catalog/53D035.yaml
+++ b/priv/catalog/53D035.yaml
@@ -52,7 +52,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: token_timeout
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.config.totem.token
 
 values:

--- a/priv/catalog/61451E.yaml
+++ b/priv/catalog/61451E.yaml
@@ -32,7 +32,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_multiple_sbd_device
-    gatherer: sbd_config
+    gatherer: sbd_config@v1
     argument: SBD_DEVICE
 
 values:

--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -29,7 +29,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: dump_sbd_devices
-    gatherer: sbd_dump
+    gatherer: sbd_dump@v1
 
 expectations:
   - name: expectations_sbd_msgwait_timeout

--- a/priv/catalog/6E9B82.yaml
+++ b/priv/catalog/6E9B82.yaml
@@ -50,7 +50,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_twonode
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: quorum.two_node
 
 values:

--- a/priv/catalog/790926.yaml
+++ b/priv/catalog/790926.yaml
@@ -41,7 +41,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: hacluster_has_default_password
-    gatherer: verify_password
+    gatherer: verify_password@v1
     argument: hacluster
 
 expectations:

--- a/priv/catalog/7E0221.yaml
+++ b/priv/catalog/7E0221.yaml
@@ -71,7 +71,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: runtime_transport
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: totem.transport
 
 values:

--- a/priv/catalog/816815.yaml
+++ b/priv/catalog/816815.yaml
@@ -35,7 +35,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: sbd_service_state
-    gatherer: systemd
+    gatherer: systemd@v1
     argument: sbd
 
 values:

--- a/priv/catalog/822E47.yaml
+++ b/priv/catalog/822E47.yaml
@@ -50,7 +50,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: runtime_join
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.config.totem.join
 
 values:

--- a/priv/catalog/845CC9.yaml
+++ b/priv/catalog/845CC9.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_max_messages
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.max_messages
 
 values:

--- a/priv/catalog/9FAAD0.yaml
+++ b/priv/catalog/9FAAD0.yaml
@@ -17,7 +17,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: exclude_package_pacemaker
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: pacemaker,2.0.3+20200511.2b248d828
 
 expectations:

--- a/priv/catalog/9FEFB0.yaml
+++ b/priv/catalog/9FEFB0.yaml
@@ -17,7 +17,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: compare_pacemaker_version
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: pacemaker,2.0.1
 
 expectations:

--- a/priv/catalog/A1244C.yaml
+++ b/priv/catalog/A1244C.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_consensus_timeout
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: totem.consensus
 
 values:

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -30,7 +30,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: dump_sbd_devices
-    gatherer: sbd_dump
+    gatherer: sbd_dump@v1
 
 values:
   - name: expected_watchdog_timeout

--- a/priv/catalog/C3166E.yaml
+++ b/priv/catalog/C3166E.yaml
@@ -17,7 +17,7 @@ when: env.target_type == "cluster" && env.provider !in ["gcp", "aws"]
 
 facts:
   - name: exclude_package_sbd
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: sbd,1.4.0+20190326.c38c5e6
 
 expectations:

--- a/priv/catalog/C620DC.yaml
+++ b/priv/catalog/C620DC.yaml
@@ -49,7 +49,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_expected_votes
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: quorum.expected_votes
 
 values:

--- a/priv/catalog/CAEFF1.yaml
+++ b/priv/catalog/CAEFF1.yaml
@@ -40,7 +40,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: os_flavor
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: SLES_SAP-release
 
 expectations:

--- a/priv/catalog/D028B9.yaml
+++ b/priv/catalog/D028B9.yaml
@@ -17,7 +17,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: compare_sles_sap_version
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: SLES_SAP-release,15.1
 
 expectations:

--- a/priv/catalog/D78671.yaml
+++ b/priv/catalog/D78671.yaml
@@ -51,7 +51,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: runtime_two_node
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.votequorum.two_node
 
 values:

--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -36,7 +36,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: corosync_nodes
-    gatherer: corosync.conf
+    gatherer: corosync.conf@v1
     argument: nodelist.node
 
 values:

--- a/priv/catalog/DC5429.yaml
+++ b/priv/catalog/DC5429.yaml
@@ -19,7 +19,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: compare_corosync_version
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: corosync,2.4.5
 
 expectations:

--- a/priv/catalog/F50AF5.yaml
+++ b/priv/catalog/F50AF5.yaml
@@ -18,7 +18,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: compare_python3_version
-    gatherer: package_version
+    gatherer: package_version@v1
     argument: python3,3.6.5
 
 expectations:

--- a/priv/catalog/FB0E0D.yaml
+++ b/priv/catalog/FB0E0D.yaml
@@ -50,7 +50,7 @@ when: env.target_type == "cluster"
 
 facts:
   - name: consensus_timeout
-    gatherer: corosync-cmapctl
+    gatherer: corosync-cmapctl@v1
     argument: runtime.config.totem.consensus
 
 values:


### PR DESCRIPTION
Pin all the gatherers name to v1 version to match the new versioning feature in trento-agent

DEPENDS ON: https://github.com/trento-project/agent/pull/277