### PR TITLE
Fix redirection when a query string is involved

### DIFF
--- a/lib/wanda_web/plugs/api_redirector.ex
+++ b/lib/wanda_web/plugs/api_redirector.ex
@@ -70,7 +70,7 @@ defmodule WandaWeb.Plugs.ApiRedirector do
   end
 
   defp redirect(conn, to) do
-    Controller.redirect(conn, to: to <> conn.query_string)
+    Controller.redirect(conn, to: maybe_add_query_string(to, conn.query_string))
   end
 
   defp route_exists?(router, path, verb) do
@@ -80,4 +80,7 @@ defmodule WandaWeb.Plugs.ApiRedirector do
       _ -> true
     end
   end
+
+  defp maybe_add_query_string(path, ""), do: path
+  defp maybe_add_query_string(path, query_string), do: "#{path}?#{query_string}"
 end

--- a/test/wanda_web/plugs/api_redirector_test.exs
+++ b/test/wanda_web/plugs/api_redirector_test.exs
@@ -90,6 +90,21 @@ defmodule WandaWeb.Plugs.ApiRedirectorTest do
       assert ["/api/v2/test"] == location_header
     end
 
+    test "should redirect to the correctly versioned path with also a query string",
+         %{conn: conn} do
+      conn =
+        conn
+        |> Map.put(:path_info, ["api", "test"])
+        |> Map.put(:query_string, "foo=bar&bar=baz&qux=42&baz=true")
+        |> ApiRedirector.call(available_api_versions: ["v2", "v1"], router: FoundRouter)
+
+      assert 307 == conn.status
+
+      location_header = get_resp_header(conn, "location")
+
+      assert ["/api/v2/test?foo=bar&bar=baz&qux=42&baz=true"] == location_header
+    end
+
     test "should redirect to the next available version path if the newest version is not available",
          %{conn: conn} do
       defmodule V1FoundRouter do


### PR DESCRIPTION
# Description

Fixes redirection when also a query string is involved in the initial request.
Needs to go after https://github.com/trento-project/wanda/pull/326
## How was this tested?

Automated test added.
