### PR TITLE
Restrict SUSE Dockerfile target arch to x86_64

### DIFF
--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -3,6 +3,7 @@
 #!BuildTag: trento/trento-wanda:%%VERSION%%
 #!BuildTag: trento/trento-wanda:%%VERSION%%-build%RELEASE%
 #!UseOBSRepositories
+#!ExclusiveArch: x86_64
 
 FROM bci/rust:1.66 AS release
 ADD wanda.tar.gz premium-checks.tar.gz* /build/


### PR DESCRIPTION
This PR just avoids building non-x86_64 images in OBS which are not supported anyways and can cause issues during releases
