### PR TITLE
Enforce `target_type` in Check's metadata

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -1,202 +1,202 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Trento Check Definition Schema",
-    "additionalProperties": false,
-    "properties": {
-      "id": {
-        "type": "string"
-      },
-      "severity": {
-        "type": "string"
-      },
-      "name": {
-        "type": "string"
-      },
-      "group": {
-        "type": "string"
-      },
-      "when": {
-        "type": "string"
-      },
-      "metadata": {
-        "$ref": "#/definitions/Metadata"
-      },
-      "description": {
-        "type": "string"
-      },
-      "remediation": {
-        "type": "string"
-      },
-      "premium": {
-        "type": "boolean"
-      },
-      "facts": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/Fact"
-        }
-      },
-      "values": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/Value"
-        }
-      },
-      "expectations": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/Expectation"
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Trento Check Definition Schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "severity": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "group": {
+      "type": "string"
+    },
+    "when": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/definitions/Metadata"
+    },
+    "description": {
+      "type": "string"
+    },
+    "remediation": {
+      "type": "string"
+    },
+    "premium": {
+      "type": "boolean"
+    },
+    "facts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Fact"
       }
     },
-    "required": [
-      "id",
-      "name",
-      "group",
-      "description",
-      "remediation",
-      "facts",
-      "expectations"
-    ],
-    "definitions": {
-      "Fact": {
-        "title": "Fact",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "gatherer": {
-            "type": "string"
-          },
-          "argument": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "gatherer",
-          "name"
-        ]
-      },
-      "Value": {
-        "title": "Value",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "default": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "conditions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Condition"
-            }
-          }
-        },
-        "required": [
-          "name",
-          "default"
-        ]
-      },
-      "Condition": {
-        "title": "Condition",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "value": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "when": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "value",
-          "when"
-        ]
-      },
-      "Expectation": {
-        "title": "Expectation",
-        "type": "object",
-        "additionalProperties": false,
-        "minProperties": 2,
-        "maxProperties": 3,
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "failure_message": {
-            "type": "string"
-          }
-        },
-        "patternProperties": {
-          "^expect$|^expect_same$": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "Metadata": {
-        "title": "Metadata",
-        "type": "object",
-        "minProperties": 1,
-        "additionalProperties": false,
-        "properties": {
-          "target_type": {
-            "type": "string"
-          }
-        },
-        "patternProperties": {
-          "[a-zA-Z0-9]+.*$": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "required": [
-          "target_type"
-        ]
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Value"
+      }
+    },
+    "expectations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Expectation"
       }
     }
+  },
+  "required": [
+    "id",
+    "name",
+    "group",
+    "description",
+    "remediation",
+    "facts",
+    "expectations"
+  ],
+  "definitions": {
+    "Fact": {
+      "title": "Fact",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "gatherer": {
+          "type": "string"
+        },
+        "argument": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "gatherer",
+        "name"
+      ]
+    },
+    "Value": {
+      "title": "Value",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "default": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Condition"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "default"
+      ]
+    },
+    "Condition": {
+      "title": "Condition",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "when": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "when"
+      ]
+    },
+    "Expectation": {
+      "title": "Expectation",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 2,
+      "maxProperties": 3,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "failure_message": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^expect$|^expect_same$": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Metadata": {
+      "title": "Metadata",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "target_type": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "[a-zA-Z0-9]+.*$": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "target_type"
+      ]
+    }
+  }
 }

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -163,7 +163,8 @@
       "additionalProperties": false,
       "properties": {
         "target_type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["host", "cluster"]
         }
       },
       "patternProperties": {

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -161,6 +161,11 @@
         "type": "object",
         "minProperties": 1,
         "additionalProperties": false,
+        "properties": {
+          "target_type": {
+            "type": "string"
+          }
+        },
         "patternProperties": {
           "[a-zA-Z0-9]+.*$": {
             "anyOf": [
@@ -188,7 +193,10 @@
               }
             ]
           }
-        }
+        },
+        "required": [
+          "target_type"
+        ]
       }
     }
 }

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -163,8 +163,7 @@
       "additionalProperties": false,
       "properties": {
         "target_type": {
-          "type": "string",
-          "enum": ["host", "cluster"]
+          "type": "string"
         }
       },
       "patternProperties": {

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -250,13 +250,13 @@ A key-value map that enriches the Check being declared by providing extra inform
 
 - keys must be non empty strings (`foo`, `bar`, `foo_bar`, `qux1`)
 - values can be any of the following types `string`, `number`, `boolean`, `string[]` (list of strings)
-- `target_type` is a **required** key of the `metadata` map. It's value can be either a `host` or `cluster`.
+- `target_type` is a **required** key of the `metadata` map. It's value is  a `string`.
 
 Example:
 
 ```yaml
 metadata:
-  target_type: host
+  target_type: example_target
   foo: bar
   bar: 42
   baz: true

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -250,11 +250,13 @@ A key-value map that enriches the Check being declared by providing extra inform
 
 - keys must be non empty strings (`foo`, `bar`, `foo_bar`, `qux1`)
 - values can be any of the following types `string`, `number`, `boolean`, `string[]` (list of strings)
+- `target_type` is a **required** key of the `metadata` map. It's value can be either a `host` or `cluster`.
 
 Example:
 
 ```yaml
 metadata:
+  target_type: host
   foo: bar
   bar: 42
   baz: true


### PR DESCRIPTION
This change adds the `target_type` as a required key in the `metadata` map.

`target_type` has type `string`.

Updated `specification.md` documentation to reflect this.

Also the indentation in `check_definition.schema.json` was out, so it was corrected.