### PR TITLE
Make metadata required in a check

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -55,6 +55,7 @@
     "group",
     "description",
     "remediation",
+    "metadata",
     "facts",
     "expectations"
   ],

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -116,7 +116,7 @@ Following are listed the top level properties of a Check definition yaml.
 | `description`  | required              | [see more](#description)  |
 | `remediation`  | required              | [see more](#remediation)  |
 | `severity`     | not required          | [see more](#severity)     |
-| `metadata`     | not required          | [see more](#metadata)     |
+| `metadata`     | required              | [see more](#metadata)     |
 | `facts`        | required              | [see more](#facts)        |
 | `values`       | not required          | [see more](#values)       |
 | `expectations` | required              | [see more](#expectations) |


### PR DESCRIPTION
Making `metadata` required since we have made `target_type` required here https://github.com/trento-project/wanda/pull/347

Just for consistency until we decide how to evolve check validation.