### PR TITLE
Add unknown expect type in openapi schemas

### DIFF
--- a/lib/wanda_web/schemas/catalog/check.ex
+++ b/lib/wanda_web/schemas/catalog/check.ex
@@ -84,7 +84,7 @@ defmodule WandaWeb.Schemas.CatalogResponse.Check do
             type: %Schema{
               type: :string,
               description: "Expectation type",
-              enum: [:expect, :expect_same]
+              enum: [:unknown, :expect, :expect_same]
             },
             expression: %Schema{
               type: :string,

--- a/lib/wanda_web/schemas/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/execution/expectation_evaluation.ex
@@ -17,7 +17,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluation do
       },
       type: %Schema{
         type: :string,
-        enum: ["expect", "expect_same"],
+        enum: [:unknown, :expect, :expect_same],
         description: "Evaluation type"
       },
       failure_message: %Schema{

--- a/lib/wanda_web/schemas/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/execution/expectation_result.ex
@@ -14,7 +14,7 @@ defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationResult do
       result: %Schema{type: :boolean, description: "Result of the expectation condition"},
       type: %Schema{
         type: :string,
-        enum: ["expect", "expect_same"],
+        enum: [:unknown, :expect, :expect_same],
         description: "Evaluation type"
       },
       failure_message: %Schema{


### PR DESCRIPTION
Add unknown expect type in openapi schemas.
This allows us to avoid "complex/strange" renderization of old views for these responses.
Otherwise, everytime we add a new expect time, we need to deal with those checks, removing them, etc, which is pretty annoying.

I know that this is breaking change, but it is pretty small, and honestly, I don't think anybody will notice it.