### PR TITLE
Update execution endpoint schemas to include `expect_enum` expectation

### DIFF
--- a/lib/wanda_web/controllers/v1/execution_controller.ex
+++ b/lib/wanda_web/controllers/v1/execution_controller.ex
@@ -10,12 +10,14 @@ defmodule WandaWeb.V1.ExecutionController do
   alias WandaWeb.Schemas.{
     AcceptedExecutionResponse,
     BadRequest,
-    ExecutionResponse,
-    ListExecutionsResponse,
     NotFound
   }
 
-  alias WandaWeb.Schemas.V1.StartExecutionRequest
+  alias WandaWeb.Schemas.V1.Execution.{
+    ExecutionResponse,
+    ListExecutionsResponse,
+    StartExecutionRequest
+  }
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback WandaWeb.FallbackController

--- a/lib/wanda_web/controllers/v2/execution_controller.ex
+++ b/lib/wanda_web/controllers/v2/execution_controller.ex
@@ -2,17 +2,102 @@ defmodule WandaWeb.V2.ExecutionController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias OpenApiSpex.Schema
+
+  alias Wanda.Executions
   alias Wanda.Executions.Target
 
   alias WandaWeb.Schemas.{
     AcceptedExecutionResponse,
-    BadRequest
+    BadRequest,
+    NotFound
   }
 
-  alias WandaWeb.Schemas.V2.StartExecutionRequest
+  alias WandaWeb.Schemas.V2.Execution.{
+    ExecutionResponse,
+    ListExecutionsResponse,
+    StartExecutionRequest
+  }
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback WandaWeb.FallbackController
+
+  operation :index,
+    summary: "List executions",
+    parameters: [
+      group_id: [
+        in: :query,
+        description: "Filter by group ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ],
+      page: [in: :query, description: "Page", type: :integer, example: 3],
+      items_per_page: [in: :query, description: "Items per page", type: :integer, example: 20]
+    ],
+    responses: [
+      ok: {"List executions response", "application/json", ListExecutionsResponse},
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def index(conn, params) do
+    executions = Executions.list_executions(params)
+    total_count = Executions.count_executions(params)
+
+    render(conn, executions: executions, total_count: total_count)
+  end
+
+  operation :show,
+    summary: "Get an execution by ID",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Execution ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ]
+    ],
+    responses: [
+      ok: {"Execution", "application/json", ExecutionResponse},
+      not_found: NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def show(conn, %{id: execution_id}) do
+    execution = Executions.get_execution!(execution_id)
+
+    render(conn, execution: execution)
+  end
+
+  operation :last,
+    summary: "Get the last execution of a group",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Group ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ]
+    ],
+    responses: [
+      ok: {"Execution", "application/json", ExecutionResponse},
+      not_found: NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def last(conn, %{id: group_id}) do
+    execution = Executions.get_last_execution_by_group_id!(group_id)
+
+    render(conn, :show, execution: execution)
+  end
 
   operation :start,
     summary: "Start a Checks Execution",

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -58,6 +58,8 @@ defmodule WandaWeb.Router do
       scope "/checks" do
         pipe_through [:api_v2, :protected_api]
 
+        resources "/executions", ExecutionController, only: [:index, :show]
+        get "/groups/:id/executions/last", ExecutionController, :last
         post "/executions/start", ExecutionController, :start
         get "/catalog", CatalogController, :catalog
       end

--- a/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
@@ -1,9 +1,9 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckError do
+defmodule WandaWeb.Schemas.V1.Execution.AgentCheckError do
   @moduledoc false
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{Fact, FactError}
+  alias WandaWeb.Schemas.V1.Execution.{Fact, FactError}
 
   require OpenApiSpex
 

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -1,9 +1,9 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.AgentCheckResult do
+defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
   @moduledoc false
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{
+  alias WandaWeb.Schemas.V1.Execution.{
     ExpectationEvaluation,
     ExpectationEvaluationError,
     Fact

--- a/lib/wanda_web/schemas/v1/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/check_result.ex
@@ -1,9 +1,13 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.CheckResult do
+defmodule WandaWeb.Schemas.V1.Execution.CheckResult do
   @moduledoc false
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{AgentCheckError, AgentCheckResult, ExpectationResult}
+  alias WandaWeb.Schemas.V1.Execution.{
+    AgentCheckError,
+    AgentCheckResult,
+    ExpectationResult
+  }
 
   require OpenApiSpex
 

--- a/lib/wanda_web/schemas/v1/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/execution_response.ex
@@ -1,0 +1,83 @@
+defmodule WandaWeb.Schemas.V1.Execution.ExecutionResponse do
+  @moduledoc """
+  Execution item response API spec
+  """
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Execution.{
+    CheckResult,
+    Target
+  }
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ExecutionResponse",
+    description: "The representation of an execution, it may be a running or completed one",
+    type: :object,
+    properties: %{
+      execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
+      group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},
+      status: %Schema{
+        type: :string,
+        enum: ["running", "completed"],
+        description: "The status of the current execution"
+      },
+      started_at: %Schema{
+        type: :string,
+        format: :"date-time",
+        description: "Execution start time"
+      },
+      completed_at: %Schema{
+        type: :string,
+        nullable: true,
+        format: :"date-time",
+        description: "Execution completion time"
+      },
+      result: %Schema{
+        type: :string,
+        nullable: true,
+        enum: ["passing", "warning", "critical"],
+        description: "Aggregated result of the execution, unknown for running ones"
+      },
+      targets: %Schema{type: :array, items: Target},
+      critical_count: %Schema{
+        type: :integer,
+        nullable: true,
+        description: "Number of checks with critical result"
+      },
+      warning_count: %Schema{
+        type: :integer,
+        nullable: true,
+        description: "Number of checks with warning result"
+      },
+      passing_count: %Schema{
+        type: :integer,
+        nullable: true,
+        description: "Number of checks with passing result"
+      },
+      timeout: %Schema{
+        type: :array,
+        nullable: true,
+        items: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+        description: "Timed out agents"
+      },
+      check_results: %Schema{type: :array, nullable: true, items: CheckResult}
+    },
+    required: [
+      :execution_id,
+      :group_id,
+      :status,
+      :started_at,
+      :completed_at,
+      :result,
+      :targets,
+      :critical_count,
+      :warning_count,
+      :passing_count,
+      :timeout,
+      :check_results
+    ]
+  })
+end

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluation do
+defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluation do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationEvaluationError do
+defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluationError do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_result.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.ExpectationResult do
+defmodule WandaWeb.Schemas.V1.Execution.ExpectationResult do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/fact.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.Fact do
+defmodule WandaWeb.Schemas.V1.Execution.Fact do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/fact_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact_error.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.FactError do
+defmodule WandaWeb.Schemas.V1.Execution.FactError do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
@@ -1,0 +1,21 @@
+defmodule WandaWeb.Schemas.V1.Execution.ListExecutionsResponse do
+  @moduledoc """
+  Execution list response API spec
+  """
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Execution.ExecutionResponse
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ListExecutionsResponse",
+    description: "The paginated list of executions",
+    type: :object,
+    properties: %{
+      items: %Schema{type: :array, items: ExecutionResponse},
+      total_count: %Schema{type: :integer, description: "Total count of executions"}
+    }
+  })
+end

--- a/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.V1.StartExecutionRequest do
+defmodule WandaWeb.Schemas.V1.Execution.StartExecutionRequest do
   @moduledoc """
   The request to be sent to start an execution
   """

--- a/lib/wanda_web/schemas/v1/execution/target.ex
+++ b/lib/wanda_web/schemas/v1/execution/target.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.Target do
+defmodule WandaWeb.Schemas.V1.Execution.Target do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v1/execution/value.ex
+++ b/lib/wanda_web/schemas/v1/execution/value.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.ExecutionResponse.Value do
+defmodule WandaWeb.Schemas.V1.Execution.Value do
   @moduledoc false
 
   alias OpenApiSpex.Schema

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -1,0 +1,35 @@
+defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Execution.{
+    ExpectationEvaluationError,
+    Fact
+  }
+
+  alias WandaWeb.Schemas.V2.Execution.ExpectationEvaluation
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "AgentCheckResult",
+    description: "The result of check on a specific agent",
+    type: :object,
+    properties: %{
+      agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+      facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
+      expectation_evaluations: %Schema{
+        type: :array,
+        items: %Schema{
+          oneOf: [
+            ExpectationEvaluation,
+            ExpectationEvaluationError
+          ]
+        },
+        description: "Result of the single expectation evaluation"
+      }
+    },
+    required: [:agent_id, :facts, :expectation_evaluations]
+  })
+end

--- a/lib/wanda_web/schemas/v2/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/check_result.ex
@@ -1,0 +1,36 @@
+defmodule WandaWeb.Schemas.V2.Execution.CheckResult do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Execution.{AgentCheckError, AgentCheckResult, ExpectationResult}
+
+  alias WandaWeb.Schemas.V2.Execution.ExpectationResult
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "CheckResult",
+    description: "The result of a check",
+    type: :object,
+    properties: %{
+      check_id: %Schema{type: :string, description: "Check ID"},
+      expectation_results: %Schema{type: :array, items: ExpectationResult},
+      agents_check_results: %Schema{
+        type: :array,
+        items: %Schema{
+          oneOf: [
+            AgentCheckResult,
+            AgentCheckError
+          ]
+        }
+      },
+      result: %Schema{
+        type: :string,
+        enum: ["passing", "warning", "critical"],
+        description: "Result of the check"
+      }
+    },
+    required: [:check_id, :expectation_results, :agents_check_results, :result]
+  })
+end

--- a/lib/wanda_web/schemas/v2/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/execution_response.ex
@@ -1,14 +1,13 @@
-defmodule WandaWeb.Schemas.ExecutionResponse do
+defmodule WandaWeb.Schemas.V2.Execution.ExecutionResponse do
   @moduledoc """
   Execution item response API spec
   """
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse.{
-    CheckResult,
-    Target
-  }
+  alias WandaWeb.Schemas.V1.Execution.Target
+
+  alias WandaWeb.Schemas.V2.Execution.CheckResult
 
   require OpenApiSpex
 

--- a/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
@@ -1,0 +1,36 @@
+defmodule WandaWeb.Schemas.V2.Execution.ExpectationEvaluation do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ExpectationEvaluation",
+    description: "Evaluation of an expectation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Name"},
+      return_value: %Schema{
+        oneOf: [
+          %Schema{type: :string},
+          %Schema{type: :number},
+          %Schema{type: :boolean},
+          %Schema{type: :string, enum: [:passing, :warning, :critical]}
+        ],
+        description: "Return value"
+      },
+      type: %Schema{
+        type: :string,
+        enum: [:unknown, :expect, :expect_same, :expect_enum],
+        description: "Evaluation type"
+      },
+      failure_message: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Failure message. Only available for `expect` scenarios"
+      }
+    },
+    required: [:name, :return_value, :type]
+  })
+end

--- a/lib/wanda_web/schemas/v2/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_result.ex
@@ -1,0 +1,36 @@
+defmodule WandaWeb.Schemas.V2.Execution.ExpectationResult do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "ExpectationResult",
+    description: "The result of an expectation",
+    type: :object,
+    properties: %{
+      name: %Schema{type: :string, description: "Expectation name"},
+      result: %Schema{
+        oneOf: [
+          %Schema{type: :string},
+          %Schema{type: :number},
+          %Schema{type: :boolean},
+          %Schema{type: :string, enum: [:passing, :warning, :critical]}
+        ],
+        description: "Result of the expectation condition"
+      },
+      type: %Schema{
+        type: :string,
+        enum: [:unknown, :expect, :expect_same, :expect_enum],
+        description: "Evaluation type"
+      },
+      failure_message: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Failure message. Only available for `expect_same` scenarios"
+      }
+    },
+    required: [:name, :result, :type]
+  })
+end

--- a/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
@@ -1,11 +1,11 @@
-defmodule WandaWeb.Schemas.ListExecutionsResponse do
+defmodule WandaWeb.Schemas.V2.Execution.ListExecutionsResponse do
   @moduledoc """
   Execution list response API spec
   """
 
   alias OpenApiSpex.Schema
 
-  alias WandaWeb.Schemas.ExecutionResponse
+  alias WandaWeb.Schemas.V2.Execution.ExecutionResponse
 
   require OpenApiSpex
 

--- a/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
@@ -1,4 +1,4 @@
-defmodule WandaWeb.Schemas.V2.StartExecutionRequest do
+defmodule WandaWeb.Schemas.V2.Execution.StartExecutionRequest do
   @moduledoc """
   The request to be sent to start an execution
   """

--- a/lib/wanda_web/views/v1/execution_view.ex
+++ b/lib/wanda_web/views/v1/execution_view.ex
@@ -3,8 +3,6 @@ defmodule WandaWeb.V1.ExecutionView do
 
   alias WandaWeb.V1.ExecutionView
 
-  alias Wanda.Executions.Execution
-
   def render("index.json", %{executions: executions, total_count: total_count}) do
     %{
       items: render_many(executions, ExecutionView, "execution.json"),
@@ -16,31 +14,10 @@ defmodule WandaWeb.V1.ExecutionView do
     render_one(execution, ExecutionView, "execution.json")
   end
 
-  def render("execution.json", %{
-        execution: %Execution{
-          execution_id: execution_id,
-          group_id: group_id,
-          status: status,
-          result: result,
-          targets: targets,
-          started_at: started_at,
-          completed_at: completed_at
-        }
-      }) do
-    %{
-      check_results: map_check_results(status, result),
-      status: status,
-      started_at: started_at,
-      completed_at: completed_at,
-      execution_id: execution_id,
-      group_id: group_id,
-      result: map_result(status, result),
-      targets: targets,
-      critical_count: count_results(status, result, "critical"),
-      warning_count: count_results(status, result, "warning"),
-      passing_count: count_results(status, result, "passing"),
-      timeout: map_timeout(status, result)
-    }
+  def render("execution.json", %{execution: execution}) do
+    execution
+    |> render_one(WandaWeb.V2.ExecutionView, "execution.json")
+    |> adapt_v1()
   end
 
   def render("start.json", %{
@@ -55,45 +32,13 @@ defmodule WandaWeb.V1.ExecutionView do
     }
   end
 
-  defp map_result(:running, _), do: nil
-  defp map_result(:completed, %{"result" => result}), do: result
+  defp adapt_v1(%{check_results: nil} = execution), do: execution
 
-  defp map_timeout(:running, _), do: nil
-  defp map_timeout(:completed, %{"timeout" => timeout}), do: timeout
-
-  defp map_check_results(:running, _), do: nil
-
-  defp map_check_results(:completed, %{"check_results" => check_results}) do
-    check_results
-    |> Enum.map(&strip_nil_failure_messages/1)
-    |> Enum.map(&adapt_v1/1)
+  defp adapt_v1(%{check_results: check_results} = execution) do
+    %{execution | check_results: Enum.map(check_results, &adapt_v1_check_results/1)}
   end
 
-  defp count_results(:running, _, _), do: nil
-
-  defp count_results(:completed, %{"check_results" => check_results}, severity),
-    do: Enum.count(check_results, &(&1["result"] == severity))
-
-  defp strip_nil_failure_messages(param) when is_map(param),
-    do:
-      Enum.reduce(
-        param,
-        %{},
-        fn
-          {"failure_message", nil}, acc ->
-            acc
-
-          {key, value}, acc ->
-            Map.put(acc, key, strip_nil_failure_messages(value))
-        end
-      )
-
-  defp strip_nil_failure_messages(param) when is_list(param),
-    do: Enum.map(param, &strip_nil_failure_messages/1)
-
-  defp strip_nil_failure_messages(value), do: value
-
-  defp adapt_v1(
+  defp adapt_v1_check_results(
          %{
            "agents_check_results" => agents_check_results,
            "expectation_results" => expectation_results
@@ -105,7 +50,7 @@ defmodule WandaWeb.V1.ExecutionView do
         &adapt_v1_agent_check_results(&1)
       )
 
-    adapted_expectation_results = adapt_v1_expect_type(expectation_results)
+    adapted_expectation_results = update_expect_enum(expectation_results)
 
     %{
       check_result
@@ -114,20 +59,18 @@ defmodule WandaWeb.V1.ExecutionView do
     }
   end
 
-  defp adapt_v1(check_result), do: check_result
-
   defp adapt_v1_agent_check_results(
          %{"expectation_evaluations" => expectation_evaluations} = agent_check_results
        ) do
     %{
       agent_check_results
-      | "expectation_evaluations" => adapt_v1_expect_type(expectation_evaluations)
+      | "expectation_evaluations" => update_expect_enum(expectation_evaluations)
     }
   end
 
   defp adapt_v1_agent_check_results(agent_check_results), do: agent_check_results
 
-  defp adapt_v1_expect_type(expectations) do
+  defp update_expect_enum(expectations) do
     Enum.map(expectations, fn
       %{"type" => "expect_enum"} = expectation -> Map.put(expectation, "type", "unknown")
       expectation -> expectation

--- a/lib/wanda_web/views/v2/execution_view.ex
+++ b/lib/wanda_web/views/v2/execution_view.ex
@@ -1,6 +1,48 @@
 defmodule WandaWeb.V2.ExecutionView do
   use WandaWeb, :view
 
+  alias WandaWeb.V2.ExecutionView
+
+  alias Wanda.Executions.Execution
+
+  def render("index.json", %{executions: executions, total_count: total_count}) do
+    %{
+      items: render_many(executions, ExecutionView, "execution.json"),
+      total_count: total_count
+    }
+  end
+
+  def render("show.json", %{execution: execution}) do
+    render_one(execution, ExecutionView, "execution.json")
+  end
+
+  def render("execution.json", %{
+        execution: %Execution{
+          execution_id: execution_id,
+          group_id: group_id,
+          status: status,
+          result: result,
+          targets: targets,
+          started_at: started_at,
+          completed_at: completed_at
+        }
+      }) do
+    %{
+      check_results: map_check_results(status, result),
+      status: status,
+      started_at: started_at,
+      completed_at: completed_at,
+      execution_id: execution_id,
+      group_id: group_id,
+      result: map_result(status, result),
+      targets: targets,
+      critical_count: count_results(status, result, "critical"),
+      warning_count: count_results(status, result, "warning"),
+      passing_count: count_results(status, result, "passing"),
+      timeout: map_timeout(status, result)
+    }
+  end
+
   def render("start.json", %{
         accepted_execution: %{
           execution_id: execution_id,
@@ -12,4 +54,39 @@ defmodule WandaWeb.V2.ExecutionView do
       group_id: group_id
     }
   end
+
+  defp map_result(:running, _), do: nil
+  defp map_result(:completed, %{"result" => result}), do: result
+
+  defp map_timeout(:running, _), do: nil
+  defp map_timeout(:completed, %{"timeout" => timeout}), do: timeout
+
+  defp map_check_results(:running, _), do: nil
+
+  defp map_check_results(:completed, %{"check_results" => check_results}),
+    do: Enum.map(check_results, &strip_nil_failure_messages/1)
+
+  defp count_results(:running, _, _), do: nil
+
+  defp count_results(:completed, %{"check_results" => check_results}, severity),
+    do: Enum.count(check_results, &(&1["result"] == severity))
+
+  defp strip_nil_failure_messages(param) when is_map(param),
+    do:
+      Enum.reduce(
+        param,
+        %{},
+        fn
+          {"failure_message", nil}, acc ->
+            acc
+
+          {key, value}, acc ->
+            Map.put(acc, key, strip_nil_failure_messages(value))
+        end
+      )
+
+  defp strip_nil_failure_messages(param) when is_list(param),
+    do: Enum.map(param, &strip_nil_failure_messages/1)
+
+  defp strip_nil_failure_messages(value), do: value
 end

--- a/test/wanda_web/controllers/v2/execution_controller_test.exs
+++ b/test/wanda_web/controllers/v2/execution_controller_test.exs
@@ -11,6 +11,173 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
   setup :verify_on_exit!
 
+  describe "list executions" do
+    test "should return a list of executions", %{conn: conn} do
+      insert_list(5, :execution)
+
+      json =
+        conn
+        |> get("/api/v1/checks/executions")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ListExecutionsResponse", api_spec)
+    end
+
+    test "should return a 422 status code if an invalid paramaters is passed", %{conn: conn} do
+      conn = get(conn, "/api/v1/checks/executions?limit=invalid")
+
+      assert 422 == conn.status
+    end
+  end
+
+  describe "get execution" do
+    test "should return a running execution", %{conn: conn} do
+      %{execution_id: execution_id} = insert(:execution)
+
+      json =
+        conn
+        |> get("/api/v1/checks/executions/#{execution_id}")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ExecutionResponse", api_spec)
+    end
+
+    test "should return a completed execution", %{conn: conn} do
+      targets = build_pair(:execution_target)
+      check_results = build(:check_results_from_targets, targets: targets)
+      result = build(:result, check_results: check_results, result: :passing)
+
+      %{execution_id: execution_id} =
+        insert(:execution, status: :completed, completed_at: DateTime.utc_now(), result: result)
+
+      json =
+        conn
+        |> get("/api/v1/checks/executions/#{execution_id}")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ExecutionResponse", api_spec)
+    end
+
+    test "should return a completed execution with errors", %{conn: conn} do
+      checks = ["check_id"]
+      [target_1, target_2, target_3] = targets = build_list(3, :execution_target, checks: checks)
+
+      expectation_name = "expectation_with_error"
+
+      expectation_evaluations =
+        build_list(1, :expectation_evaluation_error, name: expectation_name)
+
+      agent_check_results = [
+        build(:agent_check_result,
+          agent_id: target_1.agent_id,
+          expectation_evaluations: expectation_evaluations
+        ),
+        build(:agent_check_error,
+          agent_id: target_2.agent_id
+        ),
+        build(:agent_check_error,
+          agent_id: target_3.agent_id,
+          facts: nil,
+          message: "timeout",
+          type: :timeout
+        )
+      ]
+
+      expectation_results =
+        build_list(1, :expectation_result, name: expectation_name, result: false)
+
+      check_results =
+        build_list(1, :check_result,
+          expectation_results: expectation_results,
+          agents_check_results: agent_check_results
+        )
+
+      result =
+        build(:result,
+          check_results: check_results,
+          result: :critical,
+          timeout: [target_3.agent_id]
+        )
+
+      %{execution_id: execution_id} =
+        insert(:execution,
+          status: :completed,
+          completed_at: DateTime.utc_now(),
+          targets: targets,
+          result: result
+        )
+
+      json =
+        conn
+        |> get("/api/v1/checks/executions/#{execution_id}")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ExecutionResponse", api_spec)
+    end
+
+    test "should accept all different types of fact values", %{conn: conn} do
+      values = [
+        Faker.String.base64(),
+        Enum.random(-100..100),
+        Enum.random([false, true]),
+        %{Faker.String.base64() => Faker.String.base64()},
+        [
+          Faker.String.base64(),
+          Enum.random(-100..100),
+          %{Faker.String.base64() => Faker.String.base64()}
+        ]
+      ]
+
+      for value <- values do
+        facts = build_list(1, :fact, value: value)
+        agents_check_results = build_list(5, :agent_check_result, facts: facts)
+        check_results = build_list(1, :check_result, agents_check_results: agents_check_results)
+        result = build(:result, check_results: check_results, result: :passing)
+
+        %{execution_id: execution_id} =
+          insert(:execution, status: :completed, completed_at: DateTime.utc_now(), result: result)
+
+        json =
+          conn
+          |> get("/api/v1/checks/executions/#{execution_id}")
+          |> json_response(200)
+
+        api_spec = ApiSpec.spec()
+        assert_schema(json, "ExecutionResponse", api_spec)
+      end
+    end
+
+    test "should return a 404", %{conn: conn} do
+      assert_error_sent(404, fn ->
+        get(conn, "/api/v1/checks/executions/#{UUID.uuid4()}")
+      end)
+    end
+  end
+
+  describe "get last execution by group id" do
+    test "should return the last execution", %{conn: conn} do
+      %{group_id: group_id} = 10 |> insert_list(:execution) |> List.last()
+
+      json =
+        conn
+        |> get("/api/v1/checks/groups/#{group_id}/executions/last")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ExecutionResponse", api_spec)
+    end
+
+    test "should return a 404", %{conn: conn} do
+      assert_error_sent(404, fn ->
+        get(conn, "/api/v1/checks/groups/#{UUID.uuid4()}/executions/last")
+      end)
+    end
+  end
+
   describe "start execution" do
     test "should start an execution", %{conn: conn} do
       execution_id = UUID.uuid4()

--- a/test/wanda_web/views/v1/execution_view_test.exs
+++ b/test/wanda_web/views/v1/execution_view_test.exs
@@ -246,4 +246,45 @@ defmodule WandaWeb.V1.ExecutionViewTest do
              }
     end
   end
+
+  describe "adapt to V1 version" do
+    test "should set expect_enum expectations to unknown" do
+      agents_check_results =
+        build_list(
+          1,
+          :agent_check_result,
+          expectation_evaluations: build_list(1, :expectation_evaluation, type: :expect_enum)
+        )
+
+      expectation_results = build_list(1, :expectation_result, type: :expect_enum)
+
+      check_results =
+        build_list(1, :check_result,
+          agents_check_results: agents_check_results,
+          expectation_results: expectation_results
+        )
+
+      result = build(:result, check_results: check_results)
+
+      execution =
+        :execution
+        |> build(
+          result: result,
+          completed_at: DateTime.utc_now(),
+          status: :completed
+        )
+        |> insert(returning: true)
+
+      assert %{
+               check_results: [
+                 %{
+                   "agents_check_results" => [
+                     %{"expectation_evaluations" => [%{"type" => "unknown"}]}
+                   ],
+                   "expectation_results" => [%{"type" => "unknown"}]
+                 }
+               ]
+             } = render(WandaWeb.V1.ExecutionView, "show.json", execution: execution)
+    end
+  end
 end

--- a/test/wanda_web/views/v1/execution_view_test.exs
+++ b/test/wanda_web/views/v1/execution_view_test.exs
@@ -12,6 +12,8 @@ defmodule WandaWeb.V1.ExecutionViewTest do
     ExpectationResult
   }
 
+  alias WandaWeb.V1.ExecutionView
+
   describe "ExecutionView" do
     test "renders index.json" do
       started_at = DateTime.utc_now()
@@ -42,7 +44,7 @@ defmodule WandaWeb.V1.ExecutionViewTest do
                ],
                total_count: 10
              } =
-               render(WandaWeb.V1.ExecutionView, "index.json",
+               render(ExecutionView, "index.json",
                  executions: executions,
                  total_count: 10
                )
@@ -70,7 +72,7 @@ defmodule WandaWeb.V1.ExecutionViewTest do
                timeout: nil,
                targets: ^targets,
                check_results: nil
-             } = render(WandaWeb.V1.ExecutionView, "show.json", execution: execution)
+             } = render(ExecutionView, "show.json", execution: execution)
     end
 
     test "renders show.json for a completed execution" do
@@ -135,7 +137,7 @@ defmodule WandaWeb.V1.ExecutionViewTest do
                  %{"check_id" => "check_3"},
                  %{"check_id" => "check_4"}
                ]
-             } = render(WandaWeb.V1.ExecutionView, "show.json", execution: execution)
+             } = render(ExecutionView, "show.json", execution: execution)
     end
 
     test "renders show.json stripping nil failure_message keys" do
@@ -219,7 +221,7 @@ defmodule WandaWeb.V1.ExecutionViewTest do
             ]
           }
         ]
-      } = render(WandaWeb.V1.ExecutionView, "show.json", execution: execution)
+      } = render(ExecutionView, "show.json", execution: execution)
 
       Enum.each(critical_expectation_evaluations, fn
         %{
@@ -284,7 +286,7 @@ defmodule WandaWeb.V1.ExecutionViewTest do
                    "expectation_results" => [%{"type" => "unknown"}]
                  }
                ]
-             } = render(WandaWeb.V1.ExecutionView, "show.json", execution: execution)
+             } = render(ExecutionView, "show.json", execution: execution)
     end
   end
 end

--- a/test/wanda_web/views/v2/execution_view_test.exs
+++ b/test/wanda_web/views/v2/execution_view_test.exs
@@ -1,9 +1,253 @@
 defmodule WandaWeb.V2.ExecutionViewTest do
   use WandaWeb.ConnCase, async: true
 
+  import Phoenix.View
+  import Wanda.Factory
+
+  alias Wanda.Executions.{
+    AgentCheckResult,
+    CheckResult,
+    Execution,
+    ExpectationEvaluation,
+    ExpectationResult
+  }
+
   alias WandaWeb.V2.ExecutionView
 
   describe "ExecutionView" do
+    test "renders index.json" do
+      started_at = DateTime.utc_now()
+
+      [
+        %Execution{execution_id: execution_id_1, group_id: group_id_1},
+        %Execution{execution_id: execution_id_2, group_id: group_id_2}
+      ] =
+        executions =
+        Enum.map(1..2, fn _ ->
+          :execution
+          |> build(started_at: started_at)
+          |> insert(returning: true)
+        end)
+
+      assert %{
+               items: [
+                 %{
+                   execution_id: ^execution_id_1,
+                   group_id: ^group_id_1,
+                   started_at: ^started_at
+                 },
+                 %{
+                   execution_id: ^execution_id_2,
+                   group_id: ^group_id_2,
+                   started_at: ^started_at
+                 }
+               ],
+               total_count: 10
+             } =
+               render(ExecutionView, "index.json",
+                 executions: executions,
+                 total_count: 10
+               )
+    end
+
+    test "renders show.json for a running execution" do
+      started_at = DateTime.utc_now()
+
+      %Execution{execution_id: execution_id, group_id: group_id, targets: targets} =
+        execution =
+        :execution
+        |> build(started_at: started_at)
+        |> insert(returning: true)
+
+      assert %{
+               execution_id: ^execution_id,
+               group_id: ^group_id,
+               started_at: ^started_at,
+               completed_at: nil,
+               status: :running,
+               result: nil,
+               critical_count: nil,
+               warning_count: nil,
+               passing_count: nil,
+               timeout: nil,
+               targets: ^targets,
+               check_results: nil
+             } = render(ExecutionView, "show.json", execution: execution)
+    end
+
+    test "renders show.json for a completed execution" do
+      passing_checks = ["check_1", "check_2"]
+      warning_checks = ["check_3"]
+      critical_checks = ["check_4"]
+
+      passing_targets = build_pair(:execution_target, checks: passing_checks)
+      warning_targets = build_pair(:execution_target, checks: warning_checks)
+      critical_targets = build_pair(:execution_target, checks: critical_checks)
+      targets = passing_targets ++ warning_targets ++ critical_targets
+
+      passing_check_results = build(:check_results_from_targets, targets: passing_targets)
+
+      warning_check_results =
+        build(:check_results_from_targets, targets: warning_targets, result: :warning)
+
+      critical_check_results =
+        build(:check_results_from_targets, targets: critical_targets, result: :critical)
+
+      check_results = passing_check_results ++ warning_check_results ++ critical_check_results
+
+      result =
+        build(:result,
+          check_results: check_results,
+          result: :critical
+        )
+
+      %Execution{
+        execution_id: execution_id,
+        group_id: group_id,
+        started_at: started_at,
+        completed_at: completed_at,
+        result: %{
+          "timeout" => timeout
+        }
+      } =
+        execution =
+        :execution
+        |> build(
+          targets: targets,
+          result: result,
+          completed_at: DateTime.utc_now(),
+          status: :completed
+        )
+        |> insert(returning: true)
+
+      assert %{
+               execution_id: ^execution_id,
+               group_id: ^group_id,
+               started_at: ^started_at,
+               completed_at: ^completed_at,
+               status: :completed,
+               passing_count: 2,
+               warning_count: 1,
+               critical_count: 1,
+               result: "critical",
+               timeout: ^timeout,
+               check_results: [
+                 %{"check_id" => "check_1"},
+                 %{"check_id" => "check_2"},
+                 %{"check_id" => "check_3"},
+                 %{"check_id" => "check_4"}
+               ]
+             } = render(ExecutionView, "show.json", execution: execution)
+    end
+
+    test "renders show.json stripping nil failure_message keys" do
+      passing_checks = ["check_1", "check_2"]
+      critical_checks = ["check_3"]
+
+      passing_targets = build_pair(:execution_target, checks: passing_checks)
+      critical_targets = build_pair(:execution_target, checks: critical_checks)
+      targets = passing_targets ++ critical_targets
+
+      [
+        %CheckResult{
+          expectation_results: [
+            %ExpectationResult{
+              name: passing_expectation_result_name,
+              result: passing_expectation_result,
+              type: passing_expectation_result_type
+            }
+            | _
+          ],
+          agents_check_results: [
+            %AgentCheckResult{
+              expectation_evaluations: [
+                %ExpectationEvaluation{
+                  name: passing_check_result_name,
+                  return_value: passing_check_result_value,
+                  type: passing_check_result_type
+                }
+                | _
+              ]
+            }
+            | _
+          ]
+        }
+        | _
+      ] = passing_check_results = build(:check_results_from_targets, targets: passing_targets)
+
+      failure_message = Faker.StarWars.quote()
+
+      critical_check_results =
+        build(:check_results_from_targets,
+          targets: critical_targets,
+          result: :critical,
+          failure_message: failure_message
+        )
+
+      check_results = passing_check_results ++ critical_check_results
+
+      result =
+        build(:result,
+          check_results: check_results,
+          result: :critical
+        )
+
+      execution =
+        :execution
+        |> build(
+          targets: targets,
+          result: result,
+          completed_at: DateTime.utc_now(),
+          status: :completed
+        )
+        |> insert(returning: true)
+
+      %{
+        check_results: [
+          %{
+            "expectation_results" => [rendered_passing_expectation_result | _],
+            "agents_check_results" => [
+              %{
+                "expectation_evaluations" => [rendered_passing_expectation_evaluation | _]
+              }
+              | _
+            ]
+          },
+          _,
+          %{
+            "agents_check_results" => [
+              _,
+              %{"expectation_evaluations" => critical_expectation_evaluations}
+            ]
+          }
+        ]
+      } = render(ExecutionView, "show.json", execution: execution)
+
+      Enum.each(critical_expectation_evaluations, fn
+        %{
+          "type" => "expect",
+          "return_value" => false,
+          "failure_message" => expectation_failure_message
+        } ->
+          assert expectation_failure_message === failure_message
+
+        _ ->
+          :ok
+      end)
+
+      assert rendered_passing_expectation_evaluation == %{
+               "name" => passing_check_result_name,
+               "type" => to_string(passing_check_result_type),
+               "return_value" => passing_check_result_value
+             }
+
+      assert rendered_passing_expectation_result == %{
+               "name" => passing_expectation_result_name,
+               "type" => to_string(passing_expectation_result_type),
+               "result" => passing_expectation_result
+             }
+    end
+
     test "renders start.json with a payload" do
       execution_id = UUID.uuid4()
       group_id = UUID.uuid4()


### PR DESCRIPTION
More schema work...
Most of the new lines are copies from V1 to V2, but still, they need to be there...

- Move execution schemas to V1
- Create V2 schemas
- Update controllers