### PR TITLE
Add V3 backward compatibility check in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,6 +222,7 @@ jobs:
         include:
           - version: V1
           - version: V2
+          - version: V3
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
Add V3 backward compatibility check in CI.
Depends on: https://github.com/trento-project/wanda/pull/371