### PR TITLE
Openapi no additional properties

### DIFF
--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -3,7 +3,7 @@ defmodule Wanda.Catalog.Check do
   Represents a check.
   """
 
-  alias Wanda.Catalog.{Expectation, Fact, Value}
+  alias Wanda.Catalog.{Expectation, Fact, Value, Metadata}
 
   @derive Jason.Encoder
   defstruct [
@@ -27,7 +27,7 @@ defmodule Wanda.Catalog.Check do
           group: String.t(),
           description: String.t(),
           remediation: String.t(),
-          metadata: map(),
+          metadata: Metadata.t(),
           severity: :warning | :critical,
           facts: [Fact.t()],
           values: [Value.t()],

--- a/lib/wanda/catalog/metadata.ex
+++ b/lib/wanda/catalog/metadata.ex
@@ -1,15 +1,14 @@
 defmodule Wanda.Catalog.Metadata do
-    @moduledoc """
-    Represents Check Metadata.
-    """
-  
-    @derive Jason.Encoder
-    defstruct [:target_type, :cluster_type, :provider]
-  
-    @type t :: %__MODULE__{
-        target_type: String.t(),
-        cluster_type: String.t(),
-        provider: [String.t()]
-          }
-  end
-  
+  @moduledoc """
+  Represents Check Metadata.
+  """
+
+  @derive Jason.Encoder
+  defstruct [:target_type, :cluster_type, :provider]
+
+  @type t :: %__MODULE__{
+          target_type: String.t(),
+          cluster_type: String.t(),
+          provider: [String.t()]
+        }
+end

--- a/lib/wanda/catalog/metadata.ex
+++ b/lib/wanda/catalog/metadata.ex
@@ -1,0 +1,15 @@
+defmodule Wanda.Catalog.Metadata do
+    @moduledoc """
+    Represents Check Metadata.
+    """
+  
+    @derive Jason.Encoder
+    defstruct [:target_type, :cluster_type, :provider]
+  
+    @type t :: %__MODULE__{
+        target_type: String.t(),
+        cluster_type: String.t(),
+        provider: [String.t()]
+          }
+  end
+  

--- a/lib/wanda_web/schemas/accepted_execution_response.ex
+++ b/lib/wanda_web/schemas/accepted_execution_response.ex
@@ -14,6 +14,7 @@ defmodule WandaWeb.Schemas.AcceptedExecutionResponse do
     title: "AcceptedExecutionResponse",
     description: "Identifiers of the recently accepted execution",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid},
       group_id: %Schema{type: :string, format: :uuid}

--- a/lib/wanda_web/schemas/bad_request.ex
+++ b/lib/wanda_web/schemas/bad_request.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.BadRequest do
   OpenApiSpex.schema(%{
     title: "BadRequest",
     type: :object,
+    additionalProperties: false,
     properties: %{
       errors: %Schema{
         type: :array,

--- a/lib/wanda_web/schemas/health.ex
+++ b/lib/wanda_web/schemas/health.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.Health do
   OpenApiSpex.schema(%Schema{
     title: "Health",
     type: :object,
+    additionalProperties: false,
     example: %{
       database: "pass"
     },

--- a/lib/wanda_web/schemas/not_found.ex
+++ b/lib/wanda_web/schemas/not_found.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.NotFound do
   OpenApiSpex.schema(%{
     title: "NotFound",
     type: :object,
+    additionalProperties: false,
     properties: %{
       errors: %Schema{
         type: :array,

--- a/lib/wanda_web/schemas/ready.ex
+++ b/lib/wanda_web/schemas/ready.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.Ready do
   OpenApiSpex.schema(%Schema{
     title: "Ready",
     type: :object,
+    additionalProperties: false,
     example: %{
       ready: true
     },

--- a/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.CatalogResponse do
     title: "CatalogResponse",
     description: "Checks catalog listing response",
     type: :object,
+    additionalProperties: false,
     properties: %{
       items: %Schema{type: :array, description: "List of catalog checks", items: Check}
     }

--- a/lib/wanda_web/schemas/v1/catalog/check.ex
+++ b/lib/wanda_web/schemas/v1/catalog/check.ex
@@ -26,7 +26,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
           target_type: %Schema{type: :string, description: "Target type"},
           cluster_type: %Schema{type: :string, description: "Cluster type"},
           provider: %Schema{type: :string, description: "Supported provider"}
-        },
+        }
       },
       when: %Schema{
         type: :string,
@@ -114,6 +114,16 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
         }
       }
     },
-    required: [:id, :name, :group,:description,:remediation, :severity, :facts, :values, :expectations]
+    required: [
+      :id,
+      :name,
+      :group,
+      :description,
+      :remediation,
+      :severity,
+      :facts,
+      :values,
+      :expectations
+    ]
   })
 end

--- a/lib/wanda_web/schemas/v1/catalog/check.ex
+++ b/lib/wanda_web/schemas/v1/catalog/check.ex
@@ -21,9 +21,13 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
       metadata: %Schema{
         type: :object,
         nullable: true,
-        description: "Optional metadata for the check"
+        description: "Optional metadata for a check",
+        properties: %{
+          target_type: %Schema{type: :string, description: "Target type"},
+          cluster_type: %Schema{type: :string, description: "Cluster type"},
+          provider: %Schema{type: :string, description: "Supported provider"}
+        },
       },
-
       when: %Schema{
         type: :string,
         description: "Expression to determine whether a check should run",
@@ -110,6 +114,6 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
         }
       }
     },
-    required: [:id, :name, :severity, :facts, :values, :expectations]
+    required: [:id, :name, :group,:description,:remediation, :severity, :facts, :values, :expectations]
   })
 end

--- a/lib/wanda_web/schemas/v1/catalog/check.ex
+++ b/lib/wanda_web/schemas/v1/catalog/check.ex
@@ -11,9 +11,19 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
     title: "Check",
     description: "A single check from the catalog",
     type: :object,
+    additionalProperties: false,
     properties: %{
       id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Check name"},
+      group: %Schema{type: :string, description: "Check group"},
+      description: %Schema{type: :string, description: "Check description"},
+      remediation: %Schema{type: :string, description: "Check remediation"},
+      metadata: %Schema{
+        type: :object,
+        nullable: true,
+        description: "Optional metadata for the check"
+      },
+
       when: %Schema{
         type: :string,
         description: "Expression to determine whether a check should run",

--- a/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckError do
     description:
       "An error describing that some of the facts could not be gathered on a specific agent eg. gathering failure or timeout",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -14,9 +14,11 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
   OpenApiSpex.schema(%{
     title: "AgentCheckResult",
     description: "The result of check on a specific agent",
+    additionalProperties: false,
     type: :object,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+      values: %Schema{type: :array, description: "Evaluated values"},
       facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
       expectation_evaluations: %Schema{
         type: :array,
@@ -29,6 +31,7 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
         description: "Result of the single expectation evaluation"
       }
     },
-    required: [:agent_id, :facts, :expectation_evaluations]
+   
+    required: [:agent_id, :facts, :expectation_evaluations, :values]
   })
 end

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -31,7 +31,6 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
         description: "Result of the single expectation evaluation"
       }
     },
-   
     required: [:agent_id, :facts, :expectation_evaluations, :values]
   })
 end

--- a/lib/wanda_web/schemas/v1/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/check_result.ex
@@ -14,6 +14,7 @@ defmodule WandaWeb.Schemas.V1.Execution.CheckResult do
   OpenApiSpex.schema(%{
     title: "CheckResult",
     description: "The result of a check",
+    additionalProperties: false,
     type: :object,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},

--- a/lib/wanda_web/schemas/v1/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/execution_response.ex
@@ -16,6 +16,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExecutionResponse do
     title: "ExecutionResponse",
     description: "The representation of an execution, it may be a running or completed one",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluation do
     title: "ExpectationEvaluation",
     description: "Evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       return_value: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluationError do
     title: "ExpectationEvaluationError",
     description: "An error occurred during the evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       message: %Schema{type: :string, description: "Error message"},

--- a/lib/wanda_web/schemas/v1/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_result.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationResult do
     title: "ExpectationResult",
     description: "The result of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       result: %Schema{type: :boolean, description: "Result of the expectation condition"},

--- a/lib/wanda_web/schemas/v1/execution/fact.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Fact do
     title: "Fact",
     description: "The result of a check",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Name"},

--- a/lib/wanda_web/schemas/v1/execution/fact_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact_error.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.FactError do
     title: "FactError",
     description: "An error describing that a fact could not be gathered",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Fact name"},

--- a/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
@@ -11,7 +11,8 @@ defmodule WandaWeb.Schemas.V1.Execution.ListExecutionsResponse do
 
   OpenApiSpex.schema(%{
     title: "ListExecutionsResponse",
-    description: "The paginated list of executions",
+    description: "The paginated list of executions",     
+    additionalProperties: false,
     type: :object,
     properties: %{
       items: %Schema{type: :array, items: ExecutionResponse},

--- a/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
@@ -11,7 +11,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ListExecutionsResponse do
 
   OpenApiSpex.schema(%{
     title: "ListExecutionsResponse",
-    description: "The paginated list of executions",     
+    description: "The paginated list of executions",
     additionalProperties: false,
     type: :object,
     properties: %{

--- a/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V1.Execution.StartExecutionRequest do
       title: "Target",
       description: "Target Agent on which facts gathering should happen",
       type: :object,
+      additionalProperties: false,
       properties: %{
         agent_id: %Schema{
           type: :string,

--- a/lib/wanda_web/schemas/v1/execution/target.ex
+++ b/lib/wanda_web/schemas/v1/execution/target.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Target do
     title: "Target",
     description: "Target where execution facts are gathered",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       checks: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/value.ex
+++ b/lib/wanda_web/schemas/v1/execution/value.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Value do
     title: "Value",
     description: "A Value used in the expectations evaluation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       value: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -16,6 +16,7 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
     title: "AgentCheckResult",
     description: "The result of check on a specific agent",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},

--- a/lib/wanda_web/schemas/v2/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/check_result.ex
@@ -13,6 +13,7 @@ defmodule WandaWeb.Schemas.V2.Execution.CheckResult do
     title: "CheckResult",
     description: "The result of a check",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       expectation_results: %Schema{type: :array, items: ExpectationResult},

--- a/lib/wanda_web/schemas/v2/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/execution_response.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExecutionResponse do
     title: "ExecutionResponse",
     description: "The representation of an execution, it may be a running or completed one",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},

--- a/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExpectationEvaluation do
     title: "ExpectationEvaluation",
     description: "Evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       return_value: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_result.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExpectationResult do
     title: "ExpectationResult",
     description: "The result of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       result: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ListExecutionsResponse do
   OpenApiSpex.schema(%{
     title: "ListExecutionsResponse",
     description: "The paginated list of executions",
+    additionalProperties: false,
     type: :object,
     properties: %{
       items: %Schema{type: :array, items: ExecutionResponse},

--- a/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V2.Execution.StartExecutionRequest do
       title: "Target",
       description: "Target Agent on which facts gathering should happen",
       type: :object,
+      additionalProperties: false,
       properties: %{
         agent_id: %Schema{
           type: :string,

--- a/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
@@ -11,7 +11,10 @@ defmodule WandaWeb.Schemas.V3.Catalog.CatalogResponse do
   OpenApiSpex.schema(%{
     title: "CatalogResponse",
     description: "Checks catalog listing response",
+    additionalProperties: false,
     type: :object,
+
+
     properties: %{
       items: %Schema{type: :array, description: "List of catalog checks", items: Check}
     }

--- a/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
@@ -13,8 +13,6 @@ defmodule WandaWeb.Schemas.V3.Catalog.CatalogResponse do
     description: "Checks catalog listing response",
     additionalProperties: false,
     type: :object,
-
-
     properties: %{
       items: %Schema{type: :array, description: "List of catalog checks", items: Check}
     }

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -26,7 +26,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
           target_type: %Schema{type: :string, description: "Target type"},
           cluster_type: %Schema{type: :string, description: "Cluster type"},
           provider: %Schema{type: :string, description: "Supported provider"}
-        },
+        }
       },
       when: %Schema{
         type: :string,
@@ -120,6 +120,18 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         }
       }
     },
-    required: [:id, :name, :group, :description, :remediation, :metadata, :severity, :facts, :values, :expectations, :premium]
+    required: [
+      :id,
+      :name,
+      :group,
+      :description,
+      :remediation,
+      :metadata,
+      :severity,
+      :facts,
+      :values,
+      :expectations,
+      :premium
+    ]
   })
 end

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -21,7 +21,12 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
       metadata: %Schema{
         type: :object,
         nullable: true,
-        description: "Optional metadata for the check"
+        description: "Optional metadata for the check",
+        properties: %{
+          target_type: %Schema{type: :string, description: "Target type"},
+          cluster_type: %Schema{type: :string, description: "Cluster type"},
+          provider: %Schema{type: :string, description: "Supported provider"}
+        },
       },
       when: %Schema{
         type: :string,
@@ -115,6 +120,6 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         }
       }
     },
-    required: [:id, :name, :severity, :facts, :values, :expectations]
+    required: [:id, :name, :group, :description, :remediation, :metadata, :severity, :facts, :values, :expectations, :premium]
   })
 end

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -11,9 +11,18 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
     title: "Check",
     description: "A single check from the catalog",
     type: :object,
+    additionalProperties: false,
     properties: %{
       id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Check name"},
+      group: %Schema{type: :string, description: "Check group"},
+      description: %Schema{type: :string, description: "Check description"},
+      remediation: %Schema{type: :string, description: "Check remediation"},
+      metadata: %Schema{
+        type: :object,
+        nullable: true,
+        description: "Optional metadata for the check"
+      },
       when: %Schema{
         type: :string,
         description: "Expression to determine whether a check should run",

--- a/lib/wanda_web/views/v1/catalog_view.ex
+++ b/lib/wanda_web/views/v1/catalog_view.ex
@@ -6,6 +6,7 @@ defmodule WandaWeb.V1.CatalogView do
   alias Wanda.Catalog.Check
 
   def render("catalog.json", %{catalog: catalog}) do
+    IO.inspect(catalog, label: " view render catalog")
     %{items: render_many(catalog, CatalogView, "check.json", as: :check)}
   end
 

--- a/lib/wanda_web/views/v1/catalog_view.ex
+++ b/lib/wanda_web/views/v1/catalog_view.ex
@@ -6,7 +6,6 @@ defmodule WandaWeb.V1.CatalogView do
   alias Wanda.Catalog.Check
 
   def render("catalog.json", %{catalog: catalog}) do
-    IO.inspect(catalog, label: " view render catalog")
     %{items: render_many(catalog, CatalogView, "check.json", as: :check)}
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -23,8 +23,8 @@ defmodule Wanda.Factory do
     %Catalog.Check{
       id: UUID.uuid4(),
       name: Faker.StarWars.character(),
-      group: Faker.Company.name() ,
-      description:  Faker.Lorem.sentence(),
+      group: Faker.Company.name(),
+      description: Faker.Lorem.sentence(),
       remediation: Faker.Lorem.sentence(),
       metadata: build(:catalog_metadata),
       severity: Enum.random([:critical, :warning, :passing]),
@@ -33,15 +33,15 @@ defmodule Wanda.Factory do
       expectations: build_list(10, :catalog_expectation),
       when: nil,
       premium: Enum.random([false, true]),
-    
     }
   end
 
   def catalog_metadata_factory do
-    %{
+    %Catalog.Metadata{
       target_type: Faker.StarWars.character(),
       cluster_type: Faker.StarWars.character(),
-      provider: Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(1..6))
+      provider:
+        Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(0..6))
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -32,7 +32,7 @@ defmodule Wanda.Factory do
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
       when: nil,
-      premium: Enum.random([false, true]),
+      premium: Enum.random([false, true])
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -23,11 +23,25 @@ defmodule Wanda.Factory do
     %Catalog.Check{
       id: UUID.uuid4(),
       name: Faker.StarWars.character(),
+      group: Faker.Company.name() ,
+      description:  Faker.Lorem.sentence(),
+      remediation: Faker.Lorem.sentence(),
+      metadata: build(:catalog_metadata),
       severity: Enum.random([:critical, :warning, :passing]),
       facts: build_list(10, :catalog_fact),
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
-      premium: Enum.random([false, true])
+      when: nil,
+      premium: Enum.random([false, true]),
+    
+    }
+  end
+
+  def catalog_metadata_factory do
+    %{
+      target_type: Faker.StarWars.character(),
+      cluster_type: Faker.StarWars.character(),
+      provider: Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(1..6))
     }
   end
 


### PR DESCRIPTION
# Description
This PR aims to fix the properties of OpenApi Schemas for wanda. 
This change involves mostly changes in the schemas.

Adding `additionalProperties: false`  to schemas to ensure which properties are expected in request and response payloads and to enforce stricter validation of input data.




