### PR TITLE
Openapi no additional properties take two

### DIFF
--- a/lib/wanda_web/schemas/accepted_execution_response.ex
+++ b/lib/wanda_web/schemas/accepted_execution_response.ex
@@ -14,6 +14,7 @@ defmodule WandaWeb.Schemas.AcceptedExecutionResponse do
     title: "AcceptedExecutionResponse",
     description: "Identifiers of the recently accepted execution",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid},
       group_id: %Schema{type: :string, format: :uuid}

--- a/lib/wanda_web/schemas/bad_request.ex
+++ b/lib/wanda_web/schemas/bad_request.ex
@@ -10,11 +10,13 @@ defmodule WandaWeb.Schemas.BadRequest do
   OpenApiSpex.schema(%{
     title: "BadRequest",
     type: :object,
+    additionalProperties: false,
     properties: %{
       errors: %Schema{
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             detail: %Schema{
               type: :string,

--- a/lib/wanda_web/schemas/health.ex
+++ b/lib/wanda_web/schemas/health.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.Health do
   OpenApiSpex.schema(%Schema{
     title: "Health",
     type: :object,
+    additionalProperties: false,
     example: %{
       database: "pass"
     },

--- a/lib/wanda_web/schemas/not_found.ex
+++ b/lib/wanda_web/schemas/not_found.ex
@@ -10,11 +10,13 @@ defmodule WandaWeb.Schemas.NotFound do
   OpenApiSpex.schema(%{
     title: "NotFound",
     type: :object,
+    additionalProperties: false,
     properties: %{
       errors: %Schema{
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             detail: %Schema{type: :string, example: "The requested resource cannot be found."},
             title: %Schema{type: :string, example: "Not Found"}

--- a/lib/wanda_web/schemas/ready.ex
+++ b/lib/wanda_web/schemas/ready.ex
@@ -10,6 +10,7 @@ defmodule WandaWeb.Schemas.Ready do
   OpenApiSpex.schema(%Schema{
     title: "Ready",
     type: :object,
+    additionalProperties: false,
     example: %{
       ready: true
     },

--- a/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.CatalogResponse do
     title: "CatalogResponse",
     description: "Checks catalog listing response",
     type: :object,
+    additionalProperties: false,
     properties: %{
       items: %Schema{type: :array, description: "List of catalog checks", items: Check}
     }

--- a/lib/wanda_web/schemas/v1/catalog/check.ex
+++ b/lib/wanda_web/schemas/v1/catalog/check.ex
@@ -11,12 +11,16 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
     title: "Check",
     description: "A single check from the catalog",
     type: :object,
+    additionalProperties: false,
     properties: %{
       id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Check name"},
-      when: %Schema{
-        type: :string,
-        description: "Expression to determine whether a check should run",
+      group: %Schema{type: :string, description: "Check group"},
+      description: %Schema{type: :string, description: "Check description"},
+      remediation: %Schema{type: :string, description: "Check remediation"},
+      metadata: %Schema{
+        type: :object,
+        description: "Check metadata",
         nullable: true
       },
       severity: %Schema{
@@ -24,14 +28,11 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
         description: "Check severity: critical|warning",
         enum: [:critical, :warning]
       },
-      premium: %Schema{
-        type: :boolean,
-        description: "Check is Premium or not"
-      },
       facts: %Schema{
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Fact name"},
             gatherer: %Schema{type: :string, description: "Used gatherer"},
@@ -44,6 +45,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Value name"},
             default: %Schema{
@@ -54,6 +56,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
               type: :array,
               items: %Schema{
                 type: :object,
+                additionalProperties: false,
                 properties: %{
                   value: %Schema{
                     oneOf: [
@@ -79,6 +82,7 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Expectation name"},
             type: %Schema{
@@ -96,10 +100,32 @@ defmodule WandaWeb.Schemas.V1.Catalog.Check do
               description: "Message returned when the check fails"
             }
           },
-          required: [:name, :type, :expression]
+          required: [:name, :type, :expression, :failure_message]
         }
+      },
+      when: %Schema{
+        type: :string,
+        description: "Expression to determine whether a check should run",
+        nullable: true
+      },
+      premium: %Schema{
+        type: :boolean,
+        description: "Check is Premium or not"
       }
     },
-    required: [:id, :name, :severity, :facts, :values, :expectations]
+    required: [
+      :id,
+      :name,
+      :group,
+      :description,
+      :remediation,
+      :metadata,
+      :severity,
+      :facts,
+      :values,
+      :expectations,
+      :when,
+      :premium
+    ]
   })
 end

--- a/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckError do
     description:
       "An error describing that some of the facts could not be gathered on a specific agent eg. gathering failure or timeout",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/check_result.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V1.Execution.CheckResult do
     title: "CheckResult",
     description: "The result of a check",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       expectation_results: %Schema{type: :array, items: ExpectationResult},

--- a/lib/wanda_web/schemas/v1/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/execution_response.ex
@@ -16,6 +16,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExecutionResponse do
     title: "ExecutionResponse",
     description: "The representation of an execution, it may be a running or completed one",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluation do
     title: "ExpectationEvaluation",
     description: "Evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       return_value: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluationError do
     title: "ExpectationEvaluationError",
     description: "An error occurred during the evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       message: %Schema{type: :string, description: "Error message"},

--- a/lib/wanda_web/schemas/v1/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_result.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ExpectationResult do
     title: "ExpectationResult",
     description: "The result of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       result: %Schema{type: :boolean, description: "Result of the expectation condition"},

--- a/lib/wanda_web/schemas/v1/execution/fact.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Fact do
     title: "Fact",
     description: "The result of a check",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Name"},

--- a/lib/wanda_web/schemas/v1/execution/fact_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact_error.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.FactError do
     title: "FactError",
     description: "An error describing that a fact could not be gathered",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Fact name"},

--- a/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
@@ -13,6 +13,7 @@ defmodule WandaWeb.Schemas.V1.Execution.ListExecutionsResponse do
     title: "ListExecutionsResponse",
     description: "The paginated list of executions",
     type: :object,
+    additionalProperties: false,
     properties: %{
       items: %Schema{type: :array, items: ExecutionResponse},
       total_count: %Schema{type: :integer, description: "Total count of executions"}

--- a/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V1.Execution.StartExecutionRequest do
       title: "Target",
       description: "Target Agent on which facts gathering should happen",
       type: :object,
+      additionalProperties: false,
       properties: %{
         agent_id: %Schema{
           type: :string,
@@ -37,6 +38,7 @@ defmodule WandaWeb.Schemas.V1.Execution.StartExecutionRequest do
     title: "StartExecutionRequest",
     description: "Context to run a Check Execution",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution identifier"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group Execution identifier"},

--- a/lib/wanda_web/schemas/v1/execution/target.ex
+++ b/lib/wanda_web/schemas/v1/execution/target.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Target do
     title: "Target",
     description: "Target where execution facts are gathered",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       checks: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/value.ex
+++ b/lib/wanda_web/schemas/v1/execution/value.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V1.Execution.Value do
     title: "Value",
     description: "A Value used in the expectations evaluation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       value: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -16,6 +16,7 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
     title: "AgentCheckResult",
     description: "The result of check on a specific agent",
     type: :object,
+    additionalProperties: false,
     properties: %{
       agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
       facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},

--- a/lib/wanda_web/schemas/v2/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/check_result.ex
@@ -13,6 +13,7 @@ defmodule WandaWeb.Schemas.V2.Execution.CheckResult do
     title: "CheckResult",
     description: "The result of a check",
     type: :object,
+    additionalProperties: false,
     properties: %{
       check_id: %Schema{type: :string, description: "Check ID"},
       expectation_results: %Schema{type: :array, items: ExpectationResult},

--- a/lib/wanda_web/schemas/v2/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/execution_response.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExecutionResponse do
     title: "ExecutionResponse",
     description: "The representation of an execution, it may be a running or completed one",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution ID"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},

--- a/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExpectationEvaluation do
     title: "ExpectationEvaluation",
     description: "Evaluation of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Name"},
       return_value: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_result.ex
@@ -9,6 +9,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ExpectationResult do
     title: "ExpectationResult",
     description: "The result of an expectation",
     type: :object,
+    additionalProperties: false,
     properties: %{
       name: %Schema{type: :string, description: "Expectation name"},
       result: %Schema{

--- a/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
@@ -13,6 +13,7 @@ defmodule WandaWeb.Schemas.V2.Execution.ListExecutionsResponse do
     title: "ListExecutionsResponse",
     description: "The paginated list of executions",
     type: :object,
+    additionalProperties: false,
     properties: %{
       items: %Schema{type: :array, items: ExecutionResponse},
       total_count: %Schema{type: :integer, description: "Total count of executions"}

--- a/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
@@ -15,6 +15,7 @@ defmodule WandaWeb.Schemas.V2.Execution.StartExecutionRequest do
       title: "Target",
       description: "Target Agent on which facts gathering should happen",
       type: :object,
+      additionalProperties: false,
       properties: %{
         agent_id: %Schema{
           type: :string,
@@ -37,6 +38,7 @@ defmodule WandaWeb.Schemas.V2.Execution.StartExecutionRequest do
     title: "StartExecutionRequest",
     description: "Context to run a Check Execution",
     type: :object,
+    additionalProperties: false,
     properties: %{
       execution_id: %Schema{type: :string, format: :uuid, description: "Execution identifier"},
       group_id: %Schema{type: :string, format: :uuid, description: "Group Execution identifier"},

--- a/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
@@ -12,6 +12,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.CatalogResponse do
     title: "CatalogResponse",
     description: "Checks catalog listing response",
     type: :object,
+    additionalProperties: false,
     properties: %{
       items: %Schema{type: :array, description: "List of catalog checks", items: Check}
     }

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -11,12 +11,16 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
     title: "Check",
     description: "A single check from the catalog",
     type: :object,
+    additionalProperties: false,
     properties: %{
       id: %Schema{type: :string, description: "Check ID"},
       name: %Schema{type: :string, description: "Check name"},
-      when: %Schema{
-        type: :string,
-        description: "Expression to determine whether a check should run",
+      group: %Schema{type: :string, description: "Check group"},
+      description: %Schema{type: :string, description: "Check description"},
+      remediation: %Schema{type: :string, description: "Check remediation"},
+      metadata: %Schema{
+        type: :object,
+        description: "Check metadata",
         nullable: true
       },
       severity: %Schema{
@@ -24,14 +28,11 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         description: "Check severity: critical|warning",
         enum: [:critical, :warning]
       },
-      premium: %Schema{
-        type: :boolean,
-        description: "Check is Premium or not"
-      },
       facts: %Schema{
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Fact name"},
             gatherer: %Schema{type: :string, description: "Used gatherer"},
@@ -44,6 +45,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Value name"},
             default: %Schema{
@@ -54,6 +56,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
               type: :array,
               items: %Schema{
                 type: :object,
+                additionalProperties: false,
                 properties: %{
                   value: %Schema{
                     oneOf: [
@@ -79,6 +82,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         type: :array,
         items: %Schema{
           type: :object,
+          additionalProperties: false,
           properties: %{
             name: %Schema{type: :string, description: "Expectation name"},
             type: %Schema{
@@ -102,10 +106,32 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
                 "Message returned when the check return value is warning. Only available for `expect_enum` expectations"
             }
           },
-          required: [:name, :type, :expression]
+          required: [:name, :type, :expression, :failure_message, :warning_message]
         }
+      },
+      when: %Schema{
+        type: :string,
+        description: "Expression to determine whether a check should run",
+        nullable: true
+      },
+      premium: %Schema{
+        type: :boolean,
+        description: "Check is Premium or not"
       }
     },
-    required: [:id, :name, :severity, :facts, :values, :expectations]
+    required: [
+      :id,
+      :name,
+      :group,
+      :description,
+      :remediation,
+      :metadata,
+      :severity,
+      :facts,
+      :values,
+      :expectations,
+      :when,
+      :premium
+    ]
   })
 end

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -106,7 +106,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
                 "Message returned when the check return value is warning. Only available for `expect_enum` expectations"
             }
           },
-          required: [:name, :type, :expression, :failure_message, :warning_message]
+          required: [:name, :type, :expression, :failure_message]
         }
       },
       when: %Schema{

--- a/lib/wanda_web/views/v1/catalog_view.ex
+++ b/lib/wanda_web/views/v1/catalog_view.ex
@@ -13,9 +13,18 @@ defmodule WandaWeb.V1.CatalogView do
 
   def adapt_v1(%{expectations: expectations} = check) do
     adapted_expectations =
-      Enum.map(expectations, fn
+      expectations
+      |> Enum.map(fn
         %{type: :expect_enum} = expectation -> Map.put(expectation, :type, :unknown)
         expectation -> expectation
+      end)
+      |> Enum.map(fn %{
+                       name: name,
+                       type: type,
+                       expression: expression,
+                       failure_message: failure_message
+                     } ->
+        %{name: name, type: type, expression: expression, failure_message: failure_message}
       end)
 
     %{check | expectations: adapted_expectations}

--- a/lib/wanda_web/views/v1/catalog_view.ex
+++ b/lib/wanda_web/views/v1/catalog_view.ex
@@ -18,14 +18,7 @@ defmodule WandaWeb.V1.CatalogView do
         %{type: :expect_enum} = expectation -> Map.put(expectation, :type, :unknown)
         expectation -> expectation
       end)
-      |> Enum.map(fn %{
-                       name: name,
-                       type: type,
-                       expression: expression,
-                       failure_message: failure_message
-                     } ->
-        %{name: name, type: type, expression: expression, failure_message: failure_message}
-      end)
+      |> Enum.map(&Map.drop(Map.from_struct(&1), [:warning_message]))
 
     %{check | expectations: adapted_expectations}
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -23,10 +23,20 @@ defmodule Wanda.Factory do
     %Catalog.Check{
       id: UUID.uuid4(),
       name: Faker.StarWars.character(),
+      group: Faker.Company.name(),
+      description: Faker.Lorem.sentence(),
+      remediation: Faker.Lorem.sentence(),
+      metadata: %{
+        target_type: Faker.StarWars.character(),
+        cluster_type: Faker.Lorem.sentence(),
+        provider:
+          Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(0..6))
+      },
       severity: Enum.random([:critical, :warning, :passing]),
       facts: build_list(10, :catalog_fact),
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
+      when: Faker.Lorem.sentence(),
       premium: Enum.random([false, true])
     }
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -27,10 +27,10 @@ defmodule Wanda.Factory do
       description: Faker.Lorem.sentence(),
       remediation: Faker.Lorem.sentence(),
       metadata: %{
-        target_type: Faker.StarWars.character(),
-        cluster_type: Faker.Lorem.sentence(),
+        target_type: Enum.random(["cluster", "host"]),
+        cluster_type: Enum.random(["ASCS_ERS", "HANA_SCALE_UP"]),
         provider:
-          Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(0..6))
+          Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(1..6))
       },
       severity: Enum.random([:critical, :warning, :passing]),
       facts: build_list(10, :catalog_fact),
@@ -68,7 +68,9 @@ defmodule Wanda.Factory do
     %Catalog.Expectation{
       name: Faker.StarWars.character(),
       type: Enum.random([:expect, :expect_same, :expect_enum]),
-      expression: Faker.StarWars.quote()
+      expression: Faker.StarWars.quote(),
+      failure_message: Faker.Lorem.sentence(),
+      warning_message: Faker.Lorem.sentence()
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -28,7 +28,7 @@ defmodule Wanda.Factory do
       remediation: Faker.Lorem.sentence(),
       metadata: %{
         target_type: Enum.random(["cluster", "host"]),
-        cluster_type: Enum.random(["ASCS_ERS", "HANA_SCALE_UP"]),
+        cluster_type: Enum.random(["ascs_ers", "hana_scale_up"]),
         provider:
           Enum.take_random(["azure", "nutanix", "kvm", "vmware, gcp, aws"], Enum.random(1..6))
       },

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -839,7 +839,8 @@ defmodule Wanda.Executions.EvaluationTest do
           if facts.#{fact_name} == "unknown" {
             "unknown"
           }
-          """
+          """,
+          failure_message: nil
         )
 
       [%Catalog.Check{id: check_id}] =
@@ -1761,12 +1762,14 @@ defmodule Wanda.Executions.EvaluationTest do
             build(:catalog_expectation,
               name: expectation_name,
               type: :expect_same,
-              expression: "facts.#{fact_name}"
+              expression: "facts.#{fact_name}",
+              failure_message: nil
             ),
             build(:catalog_expectation,
               name: another_expectation_name,
               type: :expect_same,
-              expression: "facts.#{another_fact_name} == \"#{another_fact_value}\""
+              expression: "facts.#{another_fact_name} == \"#{another_fact_value}\"",
+              failure_message: nil
             )
           ]
         )

--- a/test/wanda_web/views/v1/catalog_view_test.exs
+++ b/test/wanda_web/views/v1/catalog_view_test.exs
@@ -9,14 +9,41 @@ defmodule WandaWeb.V1.CatalogViewTest do
   describe "CatalogView" do
     test "renders catalog.json" do
       checks = [
-        build(:check, expectations: build_list(3, :catalog_expectation, type: :expect)),
-        build(:check, expectations: build_list(3, :catalog_expectation, type: :expect_same))
+        build(:check, expectations: build_list(2, :catalog_expectation, type: :expect)),
+        build(:check, expectations: build_list(2, :catalog_expectation, type: :expect_same))
       ]
 
+      updated_checks =
+        Enum.map(checks, fn check ->
+          updated_expectations =
+            Enum.map(check.expectations, fn %{
+                                              name: name,
+                                              type: type,
+                                              expression: expression,
+                                              failure_message: failure_message
+                                            } ->
+              %{name: name, type: type, expression: expression, failure_message: failure_message}
+            end)
+
+          %{check | expectations: updated_expectations}
+        end)
+
+      rendered_catalog = render(CatalogView, "catalog.json", catalog: checks)
+
       assert %{
-               items: ^checks
-             } = render(CatalogView, "catalog.json", catalog: checks)
+               items: ^updated_checks
+             } = rendered_catalog
     end
+  end
+
+  test "renders catalog.json v1 without additional properties " do
+    checks = [
+      build(:check, expectations: build_list(2, :catalog_expectation, type: :expect)),
+      build(:check, expectations: build_list(2, :catalog_expectation, type: :expect_same))
+    ]
+
+    rendered_catalog = render(CatalogView, "catalog.json", catalog: checks)
+    refute Access.get(rendered_catalog, :warning_message)
   end
 
   describe "adapt to V1 version" do

--- a/test/wanda_web/views/v1/catalog_view_test.exs
+++ b/test/wanda_web/views/v1/catalog_view_test.exs
@@ -36,7 +36,7 @@ defmodule WandaWeb.V1.CatalogViewTest do
     end
   end
 
-  test "renders catalog.json v1 without additional properties " do
+  test "renders catalog.json like expected in the v1 schema" do
     checks = [
       build(:check, expectations: build_list(2, :catalog_expectation, type: :expect)),
       build(:check, expectations: build_list(2, :catalog_expectation, type: :expect_same))

--- a/test/wanda_web/views/v2/catalog_view_test.exs
+++ b/test/wanda_web/views/v2/catalog_view_test.exs
@@ -13,8 +13,23 @@ defmodule WandaWeb.V2.CatalogViewTest do
         build(:check, expectations: build_list(3, :catalog_expectation, type: :expect_same))
       ]
 
+      updated_checks =
+        Enum.map(checks, fn check ->
+          updated_expectations =
+            Enum.map(check.expectations, fn %{
+                                              name: name,
+                                              type: type,
+                                              expression: expression,
+                                              failure_message: failure_message
+                                            } ->
+              %{name: name, type: type, expression: expression, failure_message: failure_message}
+            end)
+
+          %{check | expectations: updated_expectations}
+        end)
+
       assert %{
-               items: ^checks
+               items: ^updated_checks
              } = render(CatalogView, "catalog.json", catalog: checks)
     end
   end

--- a/test/wanda_web/views/v2/catalog_view_test.exs
+++ b/test/wanda_web/views/v2/catalog_view_test.exs
@@ -4,33 +4,34 @@ defmodule WandaWeb.V2.CatalogViewTest do
   import Phoenix.View
   import Wanda.Factory
 
+  alias Wanda.Catalog.Check
   alias WandaWeb.V2.CatalogView
 
   describe "CatalogView" do
     test "renders catalog.json" do
       checks = [
-        build(:check, expectations: build_list(3, :catalog_expectation, type: :expect)),
-        build(:check, expectations: build_list(3, :catalog_expectation, type: :expect_same))
+        build(:check, expectations: build_list(2, :catalog_expectation, type: :expect)),
+        build(:check, expectations: build_list(2, :catalog_expectation, type: :expect_same))
       ]
 
-      updated_checks =
-        Enum.map(checks, fn check ->
-          updated_expectations =
-            Enum.map(check.expectations, fn %{
-                                              name: name,
-                                              type: type,
-                                              expression: expression,
-                                              failure_message: failure_message
-                                            } ->
-              %{name: name, type: type, expression: expression, failure_message: failure_message}
-            end)
-
-          %{check | expectations: updated_expectations}
+      adapted_checks =
+        Enum.map(checks, fn %Check{expectations: expectations} = check ->
+          %{
+            check
+            | expectations:
+                Enum.map(expectations, fn expectation ->
+                  expectation
+                  |> Map.from_struct()
+                  |> Map.drop([:warning_message])
+                end)
+          }
         end)
 
+      rendered_catalog = render(CatalogView, "catalog.json", catalog: checks)
+
       assert %{
-               items: ^updated_checks
-             } = render(CatalogView, "catalog.json", catalog: checks)
+               items: ^adapted_checks
+             } = rendered_catalog
     end
   end
 


### PR DESCRIPTION
# Description

This PR aims to fix the properties of OpenApi Schemas for wanda.
This change involves mostly changes in the schemas.

Adding additionalProperties: false to schemas to ensure which properties are expected in request and response payloads to enforce stricter validation of input data.

Additionally, the view had to be adjusted to filter out the warning message from v1. 
Updated catalog factory and fixed existing tests
