### PR TITLE
Check 816815 - enhance check to use systemd gatherer v2

### DIFF
--- a/priv/catalog/816815.yaml
+++ b/priv/catalog/816815.yaml
@@ -40,14 +40,21 @@ metadata:
 
 facts:
   - name: sbd_service_state
-    gatherer: systemd@v1
-    argument: sbd
+    gatherer: systemd@v2
+    argument: sbd.service
 
 values:
-  - name: expected_sbd_service_state
+  - name: expected_sbd_state_active
     default: active
 
+  - name: expected_sbd_state_enabled
+    default: enabled
+
 expectations:
-  - name: expectations_sbd_service_state
-    expect: facts.sbd_service_state == values.expected_sbd_service_state
-    failure_message: SBD service was expected to be active (enabled and running) but returned value is '${facts.sbd_service_state}'
+  - name: expectations_sbd_state_active
+    expect: facts.sbd_service_state.active_state == values.expected_sbd_state_active
+    failure_message: SBD service was expected to be '${values.expected_sbd_state_active}' (running) but is '${facts.sbd_service_state.active_state}'
+
+  - name: expectations_sbd_state_enabled
+    expect: facts.sbd_service_state.unit_file_state == values.expected_sbd_state_enabled
+    failure_message: SBD service was expected to be '${values.expected_sbd_state_enabled}' but is '${facts.sbd_service_state.unit_file_state}'


### PR DESCRIPTION
Check 816815 - enhance check to use systemd gatherer v2, so checking for 'service enabled' is now possible (jsc#TRNT-1098)
The changes were successfully tested by @scmschmidt
