### PR TITLE
Update Checks schema

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -96,7 +96,17 @@
               "type": "string"
             },
             {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -126,7 +136,17 @@
               "type": "string"
             },
             {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
             }
           ]
         },


### PR DESCRIPTION
Updates the Checks schema. The following fields can now take an array as a value:
- `values[n].default`
- `values[n].conditions[n].value`

The arrays can take types `integer` or `string`.

Testing for this will reside in https://github.com/trento-project/tlint/pull/21.