### PR TITLE
Decouple checks from being contained in the project

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,7 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   ],
   processor: Wanda.Messaging.Adapters.AMQP.Processor
 
-config :wanda, Wanda.Catalog, catalog_path: "priv/catalog"
+config :wanda, Wanda.Catalog, catalog_paths: ["priv/catalog"]
 
 config :wanda, Wanda.Policy, execution_server_impl: Wanda.Executions.Server
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -97,6 +97,7 @@ if config_env() in [:prod, :demo] do
   # Update catalog path to the current application dir during runtime
   config :wanda, Wanda.Catalog,
     catalog_paths: [
+      "/usr/share/trento/checks",
       System.get_env(
         "CATALOG_PATH",
         Application.app_dir(

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,7 +96,7 @@ if config_env() in [:prod, :demo] do
 
   # Update catalog path to the current application dir during runtime
   config :wanda, Wanda.Catalog,
-    catalog_path:
+    catalog_paths: [
       System.get_env(
         "CATALOG_PATH",
         Application.app_dir(
@@ -104,6 +104,7 @@ if config_env() in [:prod, :demo] do
           "priv/catalog"
         )
       )
+    ]
 end
 
 if config_env() === :demo do

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,7 +27,7 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :wanda, Wanda.Catalog, catalog_paths: ["/opt/trento-checks", "test/fixtures/catalog"]
+config :wanda, Wanda.Catalog, catalog_paths: ["/usr/share/trento/checks", "test/fixtures/catalog"]
 
 config :wanda, :messaging, adapter: Wanda.Messaging.Adapters.AMQP
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,7 +27,7 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :wanda, Wanda.Catalog, catalog_path: "test/fixtures/catalog"
+config :wanda, Wanda.Catalog, catalog_paths: ["/opt/trento-checks", "test/fixtures/catalog"]
 
 config :wanda, :messaging, adapter: Wanda.Messaging.Adapters.AMQP
 

--- a/test/fixtures/catalog/malformed_file.yaml
+++ b/test/fixtures/catalog/malformed_file.yaml
@@ -1,0 +1,1 @@
+some random string: kekw: aa

--- a/test/fixtures/catalog/with_metadata.yaml
+++ b/test/fixtures/catalog/with_metadata.yaml
@@ -10,6 +10,7 @@ metadata:
     - that
 description: |
   Just a check
+severity: critical
 remediation: |
   ## Remediation
   Remediation text

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -22,7 +22,9 @@ defmodule Wanda.CatalogTest do
         catalog_path()
         |> File.ls!()
         |> Enum.sort()
-        |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
+        |> Enum.filter(fn file ->
+          file != "malformed_check.yaml" and file != "malformed_file.yaml"
+        end)
 
       catalog = Catalog.get_catalog()
       assert length(valid_files) == length(catalog)
@@ -35,6 +37,17 @@ defmodule Wanda.CatalogTest do
 
         assert %Check{id: ^file_name} = check
       end)
+    end
+
+    test "should read the whole catalog and throw no errors with malformed files" do
+      files =
+        catalog_path()
+        |> File.ls!()
+        |> Enum.sort()
+
+      catalog = Catalog.get_catalog()
+
+      assert length(files) == length(catalog) + 2
     end
 
     test "should filter out checks if the when clause doesn't match" do

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -11,12 +11,15 @@ defmodule Wanda.CatalogTest do
     Value
   }
 
+  def catalog_path do
+    catalog_paths = Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_paths]
+    Enum.at(catalog_paths, 1)
+  end
+
   describe "checks catalog" do
     test "should return the whole catalog" do
-      catalog_path = Application.fetch_env!(:wanda, Wanda.Catalog)[:catalog_path]
-
       valid_files =
-        catalog_path
+        catalog_path()
         |> File.ls!()
         |> Enum.sort()
         |> Enum.filter(fn file -> file != "malformed_check.yaml" end)
@@ -123,7 +126,7 @@ defmodule Wanda.CatalogTest do
                     failure_message: nil
                   }
                 ]
-              }} = Catalog.get_check("expect_check")
+              }} = Catalog.get_check(catalog_path(), "expect_check")
     end
 
     test "should load a expect_same expectation type" do
@@ -137,7 +140,7 @@ defmodule Wanda.CatalogTest do
                     expression: "facts.jedi"
                   }
                 ]
-              }} = Catalog.get_check("expect_same_check")
+              }} = Catalog.get_check(catalog_path(), "expect_same_check")
     end
 
     test "should load a expect_enum expectation type" do
@@ -170,23 +173,25 @@ defmodule Wanda.CatalogTest do
                     warning_message: "some warning message ${facts.jedi}"
                   }
                 ]
-              }} = Catalog.get_check("expect_enum_check")
+              }} = Catalog.get_check(catalog_path(), "expect_enum_check")
     end
 
     test "should load a warning severity" do
-      assert {:ok, %Check{severity: :warning}} = Catalog.get_check("warning_severity_check")
+      assert {:ok, %Check{severity: :warning}} =
+               Catalog.get_check(catalog_path(), "warning_severity_check")
     end
 
     test "should load premium as false by default" do
-      assert {:ok, %Check{premium: false}} = Catalog.get_check("warning_severity_check")
+      assert {:ok, %Check{premium: false}} =
+               Catalog.get_check(catalog_path(), "warning_severity_check")
     end
 
     test "should return an error for non-existent check" do
-      assert {:error, _} = Catalog.get_check("non_existent_check")
+      assert {:error, _} = Catalog.get_check(catalog_path(), "non_existent_check")
     end
 
     test "should return an error for malformed check" do
-      assert {:error, :malformed_check} = Catalog.get_check("malformed_check")
+      assert {:error, :malformed_check} = Catalog.get_check(catalog_path(), "malformed_check")
     end
 
     test "should load multiple checks" do


### PR DESCRIPTION
With this PR Wanda becomes able to read whatever path on the filesystem as a source directory for checks.

In tests I specified `/opt/trento-checks` but we can specify whatever path we see fit for in the config.