### PR TITLE
Updated metadata of cluster_type with hana_scale_out for existing checks

### DIFF
--- a/priv/catalog/00081D.yaml
+++ b/priv/catalog/00081D.yaml
@@ -50,6 +50,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/0B6DB2.yaml
+++ b/priv/catalog/0B6DB2.yaml
@@ -54,6 +54,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/156F64.yaml
+++ b/priv/catalog/156F64.yaml
@@ -51,6 +51,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/15F7A8.yaml
+++ b/priv/catalog/15F7A8.yaml
@@ -50,6 +50,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/205AF7.yaml
+++ b/priv/catalog/205AF7.yaml
@@ -46,6 +46,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/21FCA6.yaml
+++ b/priv/catalog/21FCA6.yaml
@@ -51,6 +51,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/222A57.yaml
+++ b/priv/catalog/222A57.yaml
@@ -18,6 +18,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/24ABCB.yaml
+++ b/priv/catalog/24ABCB.yaml
@@ -46,6 +46,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/32CFC6.yaml
+++ b/priv/catalog/32CFC6.yaml
@@ -41,6 +41,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/33403D.yaml
+++ b/priv/catalog/33403D.yaml
@@ -69,6 +69,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/49591F.yaml
+++ b/priv/catalog/49591F.yaml
@@ -51,6 +51,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/53D035.yaml
+++ b/priv/catalog/53D035.yaml
@@ -52,6 +52,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/61451E.yaml
+++ b/priv/catalog/61451E.yaml
@@ -34,6 +34,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/68626E.yaml
+++ b/priv/catalog/68626E.yaml
@@ -29,6 +29,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/790926.yaml
+++ b/priv/catalog/790926.yaml
@@ -41,6 +41,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/7E0221.yaml
+++ b/priv/catalog/7E0221.yaml
@@ -71,6 +71,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/816815.yaml
+++ b/priv/catalog/816815.yaml
@@ -35,6 +35,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/822E47.yaml
+++ b/priv/catalog/822E47.yaml
@@ -50,6 +50,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/845CC9.yaml
+++ b/priv/catalog/845CC9.yaml
@@ -51,6 +51,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/9FAAD0.yaml
+++ b/priv/catalog/9FAAD0.yaml
@@ -15,6 +15,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/9FEFB0.yaml
+++ b/priv/catalog/9FEFB0.yaml
@@ -17,6 +17,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/A1244C.yaml
+++ b/priv/catalog/A1244C.yaml
@@ -51,6 +51,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/B089BE.yaml
+++ b/priv/catalog/B089BE.yaml
@@ -30,6 +30,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/C3166E.yaml
+++ b/priv/catalog/C3166E.yaml
@@ -14,6 +14,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
 

--- a/priv/catalog/CAEFF1.yaml
+++ b/priv/catalog/CAEFF1.yaml
@@ -40,6 +40,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/D028B9.yaml
+++ b/priv/catalog/D028B9.yaml
@@ -17,6 +17,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/DA114A.yaml
+++ b/priv/catalog/DA114A.yaml
@@ -36,6 +36,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/DC5429.yaml
+++ b/priv/catalog/DC5429.yaml
@@ -20,6 +20,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/F50AF5.yaml
+++ b/priv/catalog/F50AF5.yaml
@@ -17,6 +17,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:

--- a/priv/catalog/FB0E0D.yaml
+++ b/priv/catalog/FB0E0D.yaml
@@ -50,6 +50,7 @@ metadata:
   target_type: cluster
   cluster_type: 
     - hana_scale_up
+    - hana_scale_out
     - ascs_ers
 
 facts:


### PR DESCRIPTION
This pull request will update the metadata for cluster_type of existing checks with value for hana_scale_out