### PR TITLE
Adapted the existing checks to work with ascs_ers cluster

### DIFF
--- a/priv/catalog/6E9B82.yaml
+++ b/priv/catalog/6E9B82.yaml
@@ -48,18 +48,36 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: hana_scale_up
+  cluster_type: 
+    - hana_scale_up
+    - ascs_ers
 
 facts:
   - name: corosync_twonode
     gatherer: corosync.conf@v1
     argument: quorum.two_node
 
+  - name: corosync_num_nodes
+    gatherer: corosync.conf@v1
+    argument: nodelist.node
+
+  - name: cib_num_nodes
+    gatherer: cibadmin@v1
+    argument: cib.configuration.nodes.node
+
 values:
   - name: expected_twonode
     default: 1
 
+  - name: expected_threeormore
+    default: 0
+
 expectations:
+  - name: num_nodes_equal_in_corosync_and_cib
+    expect: facts.corosync_num_nodes.len == facts.cib_num_nodes.len
+    failure_message: Number of nodes mentioned in corosync.conf is not equal to number of nodes in cib.xml
+
   - name: twonode_parameter
-    expect: facts.corosync_twonode == values.expected_twonode
-    failure_message: Corosync 'two_node' value was expected to be '${values.expected_twonode}' but configured value is '${facts.corosync_twonode}'
+    expect: |
+     if facts.corosync_num_nodes.len == 2 { facts.corosync_twonode == values.expected_twonode } else if facts.corosync_num_nodes.len >= 3 { facts.corosync_twonode == values.expected_threeormore }
+    failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.corosync_twonode}' when there are '${facts.corosync_num_nodes.len}' number of nodes

--- a/priv/catalog/6E9B82.yaml
+++ b/priv/catalog/6E9B82.yaml
@@ -79,5 +79,11 @@ expectations:
 
   - name: twonode_parameter
     expect: |
-     if facts.corosync_num_nodes.len == 2 { facts.corosync_twonode == values.expected_twonode } else if facts.corosync_num_nodes.len >= 3 { facts.corosync_twonode == values.expected_threeormore }
+     if facts.corosync_num_nodes.len == 2 { 
+       facts.corosync_twonode == values.expected_twonode 
+     } else if facts.corosync_num_nodes.len >= 3 { 
+       facts.corosync_twonode == values.expected_threeormore 
+     } else {
+       false
+     }
     failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.corosync_twonode}' when there are '${facts.corosync_num_nodes.len}' number of nodes

--- a/priv/catalog/C620DC.yaml
+++ b/priv/catalog/C620DC.yaml
@@ -47,18 +47,28 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: hana_scale_up
+  cluster_type: 
+    - hana_scale_up
+    - ascs_ers
 
 facts:
   - name: corosync_expected_votes
     gatherer: corosync.conf@v1
     argument: quorum.expected_votes
 
-values:
-  - name: expected_expected_votes
-    default: 2
+  - name: corosync_num_nodes
+    gatherer: corosync.conf@v1
+    argument: nodelist.node
+
+  - name: cib_num_nodes
+    gatherer: cibadmin@v1
+    argument: cib.configuration.nodes.node    
 
 expectations:
+  - name: num_nodes_equal_in_corosync_and_cib
+    expect: facts.corosync_num_nodes.len == facts.cib_num_nodes.len
+    failure_message: Number of nodes mentioned in corosync.conf is not equal to number of nodes in cib.xml
+
   - name: expected_votes
-    expect: facts.corosync_expected_votes == values.expected_expected_votes
-    failure_message: Corosync 'expected_votes' value was expected to be '${values.expected_expected_votes}' but configured value is '${facts.corosync_expected_votes}'
+    expect: facts.corosync_expected_votes == facts.corosync_num_nodes.len
+    failure_message: Corosync 'expected_votes' value was expected to be number of nodes in the cluster but configured value is '${facts.corosync_expected_votes}'

--- a/priv/catalog/D78671.yaml
+++ b/priv/catalog/D78671.yaml
@@ -80,5 +80,11 @@ expectations:
   
   - name: expectations_two_node
     expect: |
-     if facts.corosync_num_nodes.len == 2 { facts.runtime_two_node == values.expected_runtime_two_node } else if facts.corosync_num_nodes.len >= 3 { facts.runtime_two_node == values.expected_runtime_threeormore }
+     if facts.corosync_num_nodes.len == 2 { 
+       facts.runtime_two_node == values.expected_runtime_two_node 
+     } else if facts.corosync_num_nodes.len >= 3 { 
+       facts.runtime_two_node == values.expected_runtime_threeormore 
+     } else {
+       false
+     }
     failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.runtime_two_node}' when there are '${facts.corosync_num_nodes.len}' number of nodes    

--- a/priv/catalog/D78671.yaml
+++ b/priv/catalog/D78671.yaml
@@ -49,18 +49,36 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: hana_scale_up
+  cluster_type: 
+    - hana_scale_up
+    - ascs_ers
 
 facts:
   - name: runtime_two_node
     gatherer: corosync-cmapctl@v1
     argument: runtime.votequorum.two_node
 
+  - name: corosync_num_nodes
+    gatherer: corosync.conf@v1
+    argument: nodelist.node
+
+  - name: cib_num_nodes
+    gatherer: cibadmin@v1
+    argument: cib.configuration.nodes.node      
+
 values:
   - name: expected_runtime_two_node
     default: 1
 
+  - name: expected_runtime_threeormore
+    default: 0
+
 expectations:
+  - name: num_nodes_equal_in_corosync_and_cib
+    expect: facts.corosync_num_nodes.len == facts.cib_num_nodes.len
+    failure_message: Number of nodes mentioned in corosync.conf and cib.xml are not equal
+  
   - name: expectations_two_node
-    expect: facts.runtime_two_node == values.expected_runtime_two_node
-    failure_message: Corosync 'two_node' value was expected to be '${values.expected_runtime_two_node}' but value of running config is '${facts.runtime_two_node}'
+    expect: |
+     if facts.corosync_num_nodes.len == 2 { facts.runtime_two_node == values.expected_runtime_two_node } else if facts.corosync_num_nodes.len >= 3 { facts.runtime_two_node == values.expected_runtime_threeormore }
+    failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.runtime_two_node}' when there are '${facts.corosync_num_nodes.len}' number of nodes    


### PR DESCRIPTION
Adapted 3 community checks "6E9B82", "C620DC" and "D78671" to work with ascs_ers cluster.  The existing checks had constant values for corosync configurations "two_node" and "expected_vote" which in this adaptation is changed to use conditional checks and depends upon how many nodes are configured in corosync and cib.