### PR TITLE
Add rust to asdf tooling

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.15.7-otp-26
 erlang 26.2.1
+rust 1.66.1


### PR DESCRIPTION
Added rust to the `.tool-versions` file so we ensure to stick with a supported rust version.
