### PR TITLE
Fix deps in trento-wanda.spec

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -25,7 +25,11 @@ Source:         %{name}-%{version}.tar.gz
 Source1:        deps.tar.gz
 Source2:        premium-checks.tar.gz
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15, elixir-hex, erlang-rebar3, git-core, cargo-packaging, rust >= 1.66
+BuildRequires:  elixir >= 1.15
+BuildRequires:  elixir-hex
+BuildRequires:  erlang-rebar3
+BuildRequires:  git-core
+BuildRequires:  rust+cargo >= 1.66
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
- use `rust+cargo` as a package name to work around some dependency resolution issues
- use one line per requirement as is common convention in RPM packaging