### PR TITLE
Add architecture type docs

### DIFF
--- a/guides/specification.md
+++ b/guides/specification.md
@@ -741,9 +741,10 @@ Examples of entries in the scope. What is actually available during the executio
 
 | name | Type | Reference
 | ---- | -----| ----------
-| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/domain/enums/provider.ex)
-| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/domain/enums/cluster_type.ex)
+| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/enums/provider.ex)
+| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_type.ex)
 | `env.target_type` | one of `cluster`, `host` | No enum available
+| `env.architecture_type` | one of `classic`, `angi` | [Architecture types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_architecture_type.ex)
 
 #### **facts**
 

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -739,12 +739,12 @@ Scopes are namespaced and access to items in the scope is name based.
 
 Examples of entries in the scope. What is actually available during the execution depends on the scenario. Find the updated values in the reference column link.
 
-| name | Type | Reference
-| ---- | -----| ----------
-| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/enums/provider.ex)
-| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_type.ex)
-| `env.target_type` | one of `cluster`, `host` | No enum available
-| `env.architecture_type` | one of `classic`, `angi` | [Architecture types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_architecture_type.ex)
+| name | Type | Reference | Applicable
+| ---- | -----| --------- | -----------
+| `env.target_type` | one of `cluster`, `host` | No enum available | All
+| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/enums/provider.ex) | All
+| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_type.ex) | `target_type` is `cluster`
+| `env.architecture_type` | one of `classic`, `angi` | [Architecture types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_architecture_type.ex) | `cluster_type` is one of `hana_scale_up`, `hana_scale_out`
 
 #### **facts**
 


### PR DESCRIPTION
# Description
Add new `architecture_type` documentation. 
Based on: https://github.com/trento-project/web/pull/2768

Have a look in: https://github.com/trento-project/wanda/blob/document-architecture-type/guides/specification.md#evaluation-scope

I have added a new `Applicable` column. I think it is interesting to know that some env values are only applicable/usable in certain conditions. The table gets uglier, but well, information is more important.

