### PR TITLE
Fix API endpoint versioning in executions controller v2 tests

### DIFF
--- a/test/wanda_web/controllers/v2/execution_controller_test.exs
+++ b/test/wanda_web/controllers/v2/execution_controller_test.exs
@@ -17,7 +17,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
       json =
         conn
-        |> get("/api/v1/checks/executions")
+        |> get("/api/v2/checks/executions")
         |> json_response(200)
 
       api_spec = ApiSpec.spec()
@@ -25,7 +25,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
     end
 
     test "should return a 422 status code if an invalid paramaters is passed", %{conn: conn} do
-      conn = get(conn, "/api/v1/checks/executions?limit=invalid")
+      conn = get(conn, "/api/v2/checks/executions?limit=invalid")
 
       assert 422 == conn.status
     end
@@ -37,7 +37,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
       json =
         conn
-        |> get("/api/v1/checks/executions/#{execution_id}")
+        |> get("/api/v2/checks/executions/#{execution_id}")
         |> json_response(200)
 
       api_spec = ApiSpec.spec()
@@ -112,7 +112,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
       json =
         conn
-        |> get("/api/v1/checks/executions/#{execution_id}")
+        |> get("/api/v2/checks/executions/#{execution_id}")
         |> json_response(200)
 
       api_spec = ApiSpec.spec()
@@ -143,7 +143,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
         json =
           conn
-          |> get("/api/v1/checks/executions/#{execution_id}")
+          |> get("/api/v2/checks/executions/#{execution_id}")
           |> json_response(200)
 
         api_spec = ApiSpec.spec()
@@ -153,7 +153,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
     test "should return a 404", %{conn: conn} do
       assert_error_sent(404, fn ->
-        get(conn, "/api/v1/checks/executions/#{UUID.uuid4()}")
+        get(conn, "/api/v2/checks/executions/#{UUID.uuid4()}")
       end)
     end
   end
@@ -164,7 +164,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
       json =
         conn
-        |> get("/api/v1/checks/groups/#{group_id}/executions/last")
+        |> get("/api/v2/checks/groups/#{group_id}/executions/last")
         |> json_response(200)
 
       api_spec = ApiSpec.spec()
@@ -173,7 +173,7 @@ defmodule WandaWeb.V2.ExecutionControllerTest do
 
     test "should return a 404", %{conn: conn} do
       assert_error_sent(404, fn ->
-        get(conn, "/api/v1/checks/groups/#{UUID.uuid4()}/executions/last")
+        get(conn, "/api/v2/checks/groups/#{UUID.uuid4()}/executions/last")
       end)
     end
   end


### PR DESCRIPTION
Fixed the version invoked by the tests for `execution_controller` version 2. Basically we copypasted the old tests and we sticked with `v1` leaving a fair half of the controller untested for quite some time.