### PR TITLE
Add checks catalogue to Docker compose file

### DIFF
--- a/docker-compose.checks.yaml
+++ b/docker-compose.checks.yaml
@@ -14,12 +14,18 @@ services:
     depends_on:
       - postgres
       - rabbitmq
+      - checks
     ports:
       - 4000:4000
     entrypoint: /bin/sh -c "/app/bin/wanda eval \"Wanda.Release.init()\" && /app/bin/wanda start"
     volumes:
       - ./priv/catalog/:/app/catalog:rw
-      - checks_catalog:/usr/share/trento/checks
+      - checks_catalog:/usr/share/trento/checks:ro
+
+  checks:
+    image: registry.opensuse.org/devel/sap/trento/factory/containers/trento/trento-checks:latest
+    volumes:
+      - checks_catalog:/usr/share/trento/checks:rw
 
   rabbitmq:
     image: rabbitmq:3.10.5-management-alpine


### PR DESCRIPTION
This commit adds Wanda's newly gained feature reading checks from disk to the Docker compose based setup

## How was this tested?

Not yet

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Wanda guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.

- [x] **DONE**
