### PR TITLE
Add VOLUME mount to both dockerfile and sles dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 WORKDIR /app
 COPY --from=release /build/_build/$MIX_ENV/rel/wanda .
+VOLUME /usr/share/trento/checks
 EXPOSE 4000/tcp
 ENTRYPOINT ["/app/bin/wanda"]

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -32,5 +32,6 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 WORKDIR /app
 COPY --from=release /build/wanda/_build/prod/rel/wanda .
+VOLUME /usr/share/trento/checks
 EXPOSE 4000/tcp
 ENTRYPOINT ["/app/bin/wanda"]


### PR DESCRIPTION
Just adding the VOLUME mount for checks otherwise mounting `/usr/share/trento/checks` won't work
