### PR TITLE
Add premium deprecation warning

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "title": "Trento Check Definition Schema",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
This commit partly reverts 51765fb, but adds a deprecation annotation. This enables check authors to spot the deprecation using other tooling than tlint.  Furthermore, it allows us to add and remove deprecations without having to touch tlint every time.  Yes, this is part of the specification :D

Also https://github.com/trento-project/tlint/pull/24 needs it :P