### PR TITLE
Require trento-checks and remove premium source

### DIFF
--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -6,8 +6,7 @@
 #!ExclusiveArch: x86_64
 
 FROM bci/rust:1.66 AS release
-ADD wanda.tar.gz premium-checks.tar.gz* /build/
-RUN mv /build/priv/catalog/* /build/wanda/priv/catalog || true && rm -fr /build/priv/
+ADD wanda.tar.gz /build/
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
 RUN zypper -n in git-core elixir>=1.15 elixir-hex erlang-rebar3

--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -23,13 +23,13 @@ License:        Apache-2.0
 URL:            https://github.com/trento-project/wanda
 Source:         %{name}-%{version}.tar.gz
 Source1:        deps.tar.gz
-Source2:        premium-checks.tar.gz
 Group:          System/Monitoring
 BuildRequires:  elixir >= 1.15
 BuildRequires:  elixir-hex
 BuildRequires:  erlang-rebar3
 BuildRequires:  git-core
 BuildRequires:  rust+cargo >= 1.66
+Requires:       trento-checks
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.
@@ -38,14 +38,6 @@ Within Trento, Wanda is the service responsible to orchestrate Checks executions
 
 %prep
 %autosetup -a1
-
-# Check if premium-checks are present
-if [ -f %{SOURCE2} ]; then
-    tar -xzf %{SOURCE2}
-else
-    echo "Optional premium checks are not available."
-    tar -cf %{SOURCE2} -T /dev/null
-fi
 
 %build
 export LANG=en_US.UTF-8


### PR DESCRIPTION
# Description

Require `trento-checks` during wanda rpm installation and remove premium source usage.
Otherwise, the user must do `zypper in trento-checks` manually

## How was this tested?

Just watching how OBS package is built
