### PR TITLE
Operations orchestration skeleton

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -60,7 +60,9 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
 # different ports.
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+config :logger, :console,
+  format: "[$level] $message\n",
+  metadata: [:request_id, :state]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/wanda/application.ex
+++ b/lib/wanda/application.ex
@@ -17,7 +17,8 @@ defmodule Wanda.Application do
         WandaWeb.Endpoint,
         # Start a worker by calling: Wanda.Worker.start_link(arg)
         # {Wanda.Worker, arg}
-        {DynamicSupervisor, strategy: :one_for_one, name: Wanda.Executions.Supervisor}
+        {DynamicSupervisor, strategy: :one_for_one, name: Wanda.Executions.Supervisor},
+        {DynamicSupervisor, strategy: :one_for_one, name: Wanda.Operations.Supervisor}
       ] ++ Application.get_env(:wanda, :children, [])
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -1,0 +1,6 @@
+defmodule Wanda.Operations do
+  @moduledoc """
+  Operations are combined actions dispatched to different agents in order to apply
+  persistent changes on them.
+  """
+end

--- a/lib/wanda/operations/agent_report.ex
+++ b/lib/wanda/operations/agent_report.ex
@@ -1,0 +1,15 @@
+defmodule Wanda.Operations.AgentReport do
+  @moduledoc """
+  Report of an executed operation from an individual agent
+  """
+
+  defstruct [
+    :agent_id,
+    :result
+  ]
+
+  @type t :: %__MODULE__{
+          agent_id: String.t(),
+          result: :updated | :not_updated | :failed | :rolled_back | :skipped | :not_executed
+        }
+end

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -1,0 +1,22 @@
+defmodule Wanda.Operations.Catalog.Operation do
+  @moduledoc """
+  An operation is a set of actions executed step by step in agents to apply
+  permanent changes in them.
+  """
+
+  alias Wanda.Operations.Catalog.Step
+
+  defstruct [
+    :id,
+    :name,
+    :steps,
+    required_args: []
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          steps: [Step.t()],
+          required_args: [String.t()]
+        }
+end

--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -1,0 +1,17 @@
+defmodule Wanda.Operations.Catalog.Step do
+  @moduledoc """
+  A individual operation step running a single operator.
+  The predicate is a rhai execution that returns true/false
+  defining if the step needs to be executed in a certain agent.
+  """
+
+  defstruct [
+    :operator,
+    :predicate
+  ]
+
+  @type t :: %__MODULE__{
+          operator: String.t(),
+          predicate: String.t()
+        }
+end

--- a/lib/wanda/operations/operation_target.ex
+++ b/lib/wanda/operations/operation_target.ex
@@ -1,0 +1,17 @@
+defmodule Wanda.Operations.OperationTarget do
+  @moduledoc """
+  An operation target defines an agent where the operation is executed
+  with arguments attached to this target, usually used to run the
+  operation step predicate
+  """
+
+  defstruct [
+    :agent_id,
+    arguments: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          agent_id: String.t(),
+          arguments: %{String.t() => boolean() | number() | String.t()}
+        }
+end

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -76,9 +76,9 @@ defmodule Wanda.Operations.Server do
         %State{} = state
       ) do
     engine = EvaluationEngine.new()
-    state = initialize_report_results(state)
+    new_state = initialize_report_results(state)
 
-    {:noreply, %State{state | engine: engine}, {:continue, :execute_step}}
+    {:noreply, %State{new_state | engine: engine}, {:continue, :execute_step}}
   end
 
   @impl true
@@ -113,7 +113,7 @@ defmodule Wanda.Operations.Server do
 
     %Step{predicate: predicate, operator: operator} = Enum.at(steps, current_step_index)
 
-    state =
+    new_state =
       %State{pending_targets_on_step: pending_targets} =
       state
       |> predicate_targets_execution(predicate)
@@ -122,9 +122,9 @@ defmodule Wanda.Operations.Server do
       |> maybe_increase_current_step()
 
     if pending_targets == [] do
-      {:noreply, state, {:continue, :execute_step}}
+      {:noreply, new_state, {:continue, :execute_step}}
     else
-      {:noreply, state}
+      {:noreply, new_state}
     end
   end
 
@@ -159,16 +159,16 @@ defmodule Wanda.Operations.Server do
 
     pending_targets = List.delete(targets, agent_id)
 
-    state =
+    new_state =
       %State{state | pending_targets_on_step: pending_targets}
       |> update_report_results(step_number, agent_id, operation_result)
       |> maybe_set_step_failed(operation_result)
       |> maybe_increase_current_step()
 
     if pending_targets == [] do
-      {:noreply, state, {:continue, :execute_step}}
+      {:noreply, new_state, {:continue, :execute_step}}
     else
-      {:noreply, state}
+      {:noreply, new_state}
     end
   end
 

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -1,5 +1,7 @@
 defmodule Wanda.Operations.Server do
   @moduledoc """
+  Represents the execution of operations in target agents
+  Orchestrates operation executions - issuing operations and receiving back the reports.
   """
 
   @behaviour Wanda.Operations.ServerBehaviour

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -1,0 +1,345 @@
+defmodule Wanda.Operations.Server do
+  @moduledoc """
+  """
+
+  @behaviour Wanda.Operations.ServerBehaviour
+
+  use GenServer, restart: :transient
+
+  alias Wanda.Operations.{AgentReport, OperationTarget, State, StepReport, Supervisor}
+  alias Wanda.Operations.Catalog.{Operation, Step}
+
+  alias Wanda.EvaluationEngine
+
+  require Logger
+
+  @default_timeout 5 * 60 * 1_000
+
+  @impl true
+  def start_operation(operation_id, group_id, operation, targets, config \\ []) do
+    %Operation{required_args: required_args} = operation
+
+    # Check if all targets have the required arguments
+    all_arguments_present =
+      Enum.all?(targets, fn %OperationTarget{arguments: arguments} ->
+        required_args -- Map.keys(arguments) == []
+      end)
+
+    maybe_start_operation(
+      all_arguments_present,
+      operation_id,
+      group_id,
+      operation,
+      targets,
+      config
+    )
+  end
+
+  @impl true
+  def receive_operation_reports(operation_id, group_id, step_number, agent_id, operation_result),
+    do:
+      group_id
+      |> via_tuple()
+      |> GenServer.cast({:receive_reports, operation_id, agent_id, step_number, operation_result})
+
+  def start_link(opts) do
+    group_id = Keyword.fetch!(opts, :group_id)
+    config = Keyword.get(opts, :config, [])
+
+    GenServer.start_link(
+      __MODULE__,
+      %State{
+        operation_id: Keyword.fetch!(opts, :operation_id),
+        group_id: group_id,
+        operation: Keyword.fetch!(opts, :operation),
+        targets: Keyword.fetch!(opts, :targets),
+        timeout: Keyword.get(config, :timeout, @default_timeout),
+        current_step_index: 0,
+        step_failed: false
+      },
+      name: via_tuple(group_id)
+    )
+  end
+
+  @impl true
+  def init(%State{operation_id: operation_id} = state) do
+    Logger.debug("Starting operation: #{operation_id}", state: inspect(state))
+
+    {:ok, state, {:continue, :start_operation}}
+  end
+
+  @impl true
+  def handle_continue(
+        :start_operation,
+        %State{} = state
+      ) do
+    engine = EvaluationEngine.new()
+    state = initialize_report_results(state)
+
+    {:noreply, %State{state | engine: engine}, {:continue, :execute_step}}
+  end
+
+  @impl true
+  def handle_continue(
+        :execute_step,
+        %State{
+          step_failed: true,
+          agent_reports: _agent_reports
+        } = state
+      ) do
+    Logger.debug("Last step failed in some agent. Stopping operation", state: inspect(state))
+
+    # Evaluate results using agent_reports
+    # Start rollback?
+    # Publish and store results
+
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_continue(
+        :execute_step,
+        %State{
+          operation: %Operation{
+            steps: steps
+          },
+          current_step_index: current_step_index
+        } = state
+      )
+      when current_step_index < length(steps) do
+    Logger.debug("Starting operation step: #{current_step_index}", state: inspect(state))
+
+    %Step{predicate: predicate, operator: operator} = Enum.at(steps, current_step_index)
+
+    state =
+      %State{pending_targets_on_step: pending_targets} =
+      state
+      |> predicate_targets_execution(predicate)
+      |> maybe_save_skipped_operation_state()
+      |> maybe_request_operation_execution(operator)
+      |> maybe_increase_current_step()
+
+    if pending_targets == [] do
+      {:noreply, state, {:continue, :execute_step}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_continue(
+        :execute_step,
+        %State{
+          agent_reports: _agent_reports
+        } = state
+      ) do
+    Logger.debug("All operation steps completed.", state: inspect(state))
+
+    # Evaluate results using agent_reports
+    # Publish and store results
+
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_cast(
+        {:receive_reports, operation_id, agent_id, step_number, operation_result},
+        %State{
+          operation_id: operation_id,
+          current_step_index: step_number,
+          pending_targets_on_step: targets
+        } = state
+      ) do
+    Logger.debug(
+      "Operation report received: #{operation_id}, #{agent_id}, #{step_number}, #{operation_result}",
+      state: inspect(state)
+    )
+
+    pending_targets = List.delete(targets, agent_id)
+
+    state =
+      %State{state | pending_targets_on_step: pending_targets}
+      |> update_report_results(step_number, agent_id, operation_result)
+      |> maybe_set_step_failed(operation_result)
+      |> maybe_increase_current_step()
+
+    if pending_targets == [] do
+      {:noreply, state, {:continue, :execute_step}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_cast(
+        {:receive_reports, operation_id, _, step_number, _},
+        %State{
+          operation_id: operation_id
+        } = state
+      ) do
+    Logger.error("Unexpected step number #{step_number} report received")
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(
+        {:receive_reports, operation_id, _, _, _},
+        %State{group_id: group_id} = state
+      ) do
+    Logger.error("Operation #{operation_id} does not match for group #{group_id}")
+
+    {:noreply, state}
+  end
+
+  defp maybe_start_operation(false, _, _, _, _, _), do: {:error, :arguments_missing}
+
+  defp maybe_start_operation(true, operation_id, group_id, operation, targets, config) do
+    case DynamicSupervisor.start_child(
+           Supervisor,
+           {__MODULE__,
+            operation_id: operation_id,
+            group_id: group_id,
+            operation: operation,
+            targets: targets,
+            config: config}
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, {:already_started, _}} ->
+        {:error, :already_running}
+
+      error ->
+        error
+    end
+  end
+
+  # Initialize operation results as not executed for all steps and agents
+  defp initialize_report_results(
+         %State{
+           targets: targets,
+           operation: %Operation{
+             steps: steps
+           }
+         } = state
+       ) do
+    not_executed_agent_reports =
+      Enum.map(targets, fn %OperationTarget{agent_id: agent_id} ->
+        %AgentReport{agent_id: agent_id, result: :not_executed}
+      end)
+
+    agent_reports =
+      steps
+      |> Enum.with_index()
+      |> Enum.map(fn {_, index} ->
+        %StepReport{step_number: index, agents: not_executed_agent_reports}
+      end)
+
+    %State{state | agent_reports: agent_reports}
+  end
+
+  defp predicate_targets_execution(
+         %State{
+           engine: engine,
+           targets: targets
+         } = state,
+         predicate
+       ) do
+    pending_targets =
+      Enum.reduce(targets, [], fn %OperationTarget{agent_id: agent_id, arguments: arguments},
+                                  acc ->
+        if predicate_is_met(engine, predicate, arguments) do
+          [agent_id | acc]
+        else
+          acc
+        end
+      end)
+
+    %State{state | pending_targets_on_step: pending_targets}
+  end
+
+  defp predicate_is_met(_, "*", _), do: true
+  defp predicate_is_met(_, "", _), do: true
+
+  defp predicate_is_met(engine, predicate, arguments) do
+    case EvaluationEngine.eval(engine, predicate, arguments) do
+      {:ok, true} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp maybe_save_skipped_operation_state(
+         %State{
+           targets: targets,
+           pending_targets_on_step: pending_targets,
+           current_step_index: step_number
+         } = state
+       ) do
+    targets
+    |> Enum.filter(fn %OperationTarget{agent_id: agent_id} -> agent_id not in pending_targets end)
+    |> Enum.reduce(state, fn %OperationTarget{agent_id: agent_id}, acc ->
+      update_report_results(acc, step_number, agent_id, :skipped)
+    end)
+  end
+
+  defp maybe_request_operation_execution(%State{pending_targets_on_step: []} = state, _) do
+    state
+  end
+
+  defp maybe_request_operation_execution(
+         %State{} = state,
+         _operator
+       ) do
+    # publish operation execution to agents
+
+    state
+  end
+
+  defp maybe_increase_current_step(
+         %State{pending_targets_on_step: [], current_step_index: index} = state
+       ),
+       do: %State{state | current_step_index: index + 1}
+
+  defp maybe_increase_current_step(state), do: state
+
+  # update_report_results updates the agent report status for the given
+  # agent, step_number and result
+  defp update_report_results(
+         %State{agent_reports: current_agent_reports} = state,
+         step_number,
+         agent_id,
+         result
+       ) do
+    %StepReport{agents: current_agents} =
+      step_to_update = Enum.at(current_agent_reports, step_number)
+
+    updated_agents =
+      Enum.map(current_agents, fn
+        %AgentReport{agent_id: ^agent_id} = agent_report ->
+          %AgentReport{agent_report | result: result}
+
+        agent_report ->
+          agent_report
+      end)
+
+    updated_agent_reports =
+      List.replace_at(current_agent_reports, step_number, %{
+        step_to_update
+        | agents: updated_agents
+      })
+
+    %State{state | agent_reports: updated_agent_reports}
+  end
+
+  defp maybe_set_step_failed(state, result) when result in [:failed, :rolled_back],
+    do: %State{state | step_failed: true}
+
+  defp maybe_set_step_failed(state, _), do: state
+
+  defp via_tuple(group_id),
+    do: {:via, :global, {__MODULE__, group_id}}
+end

--- a/lib/wanda/operations/server_behaviour.ex
+++ b/lib/wanda/operations/server_behaviour.ex
@@ -1,0 +1,40 @@
+defmodule Wanda.Operations.ServerBehaviour do
+  @moduledoc """
+  Operation server API behaviour.
+  """
+
+  alias Wanda.Operations.Catalog.Operation
+  alias Wanda.Operations.OperationTarget
+
+  @callback start_operation(
+              operation_id :: String.t(),
+              group_id :: String.t(),
+              operation :: Operation.t(),
+              targets :: [OperationTarget.t()]
+            ) ::
+              :ok
+              | {:error, :arguments_missing}
+              | {:error, :already_running}
+              | {:error, :operation_not_found}
+
+  @callback start_operation(
+              operation_id :: String.t(),
+              group_id :: String.t(),
+              operation :: Operation.t(),
+              targets :: [OperationTarget.t()],
+              config :: Keyword.t()
+            ) ::
+              :ok
+              | {:error, :arguments_missing}
+              | {:error, :already_running}
+              | {:error, :operation_not_found}
+
+  @callback receive_operation_reports(
+              operation_id :: String.t(),
+              group_id :: String.t(),
+              step_id :: number(),
+              agent_id :: String.t(),
+              operation_result :: :updated | :not_updated | :failed | :rolled_back
+            ) ::
+              :ok | {:error, any}
+end

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -1,0 +1,34 @@
+defmodule Wanda.Operations.State do
+  @moduledoc """
+  State of an operation.
+  """
+
+  alias Wanda.Operations.{OperationTarget, StepReport}
+  alias Wanda.Operations.Catalog.Operation
+
+  defstruct [
+    :engine,
+    :operation_id,
+    :group_id,
+    :operation,
+    :timeout,
+    targets: [],
+    pending_targets_on_step: [],
+    current_step_index: 0,
+    agent_reports: %{},
+    step_failed: false
+  ]
+
+  @type t :: %__MODULE__{
+          engine: Rhai.Engine.t(),
+          operation_id: String.t(),
+          group_id: String.t(),
+          operation: Operation.t(),
+          agent_reports: [StepReport.t()],
+          targets: [OperationTarget.t()],
+          pending_targets_on_step: [String.t()],
+          current_step_index: integer(),
+          step_failed: boolean(),
+          timeout: integer()
+        }
+end

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -4,6 +4,7 @@ defmodule Wanda.Operations.State do
   """
 
   alias Wanda.Operations.{OperationTarget, StepReport}
+
   alias Wanda.Operations.Catalog.Operation
 
   defstruct [

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -1,6 +1,17 @@
 defmodule Wanda.Operations.State do
   @moduledoc """
   State of an operation.
+
+  The state is composed by the next field:
+  - engine: RHAI engine used to run predicate validations
+  - operation_id: Identifier of this operation execution
+  - group_id: Identifier of the group or resource that is under the operation.
+              For example, this can be the identifier of an individual host or a cluster.
+  - operation: Operation to execute
+  - timeout: Timeout to stop the operation
+  - pending_targets_on_step: Target ids which are pending to report back for the current operation step
+  - current_step_index: Current step index being executed
+  - step_failed: Whether the current step has failed in any of the targets executing it
   """
 
   alias Wanda.Operations.{OperationTarget, StepReport}

--- a/lib/wanda/operations/step_report.ex
+++ b/lib/wanda/operations/step_report.ex
@@ -1,0 +1,17 @@
+defmodule Wanda.Operations.StepReport do
+  @moduledoc """
+  Report of all agent execution of an operation step
+  """
+
+  alias Wanda.Operations.AgentReport
+
+  defstruct [
+    :step_number,
+    :agents
+  ]
+
+  @type t :: %__MODULE__{
+          step_number: integer(),
+          agents: [AgentReport.t()]
+        }
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,9 +19,7 @@ defmodule Wanda.Factory do
     Target
   }
 
-  alias Wanda.Operations.{
-    OperationTarget
-  }
+  alias Wanda.Operations.OperationTarget
 
   alias Wanda.Operations.Catalog.{
     Operation,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,6 +19,15 @@ defmodule Wanda.Factory do
     Target
   }
 
+  alias Wanda.Operations.{
+    OperationTarget
+  }
+
+  alias Wanda.Operations.Catalog.{
+    Operation,
+    Step
+  }
+
   def check_factory do
     %Catalog.Check{
       id: UUID.uuid4(),
@@ -181,20 +190,6 @@ defmodule Wanda.Factory do
     }
   end
 
-  defp random_env_value do
-    Faker.Util.pick([
-      Faker.Pokemon.name(),
-      Enum.random(1..10),
-      Enum.random([false, true])
-    ])
-  end
-
-  defp random_checks do
-    1..10
-    |> Enum.map(fn _ -> UUID.uuid4() end)
-    |> Enum.take_random(Enum.random(1..5))
-  end
-
   def check_results_from_targets_factory(attrs) do
     targets = Map.get(attrs, :targets, [])
     result = Map.get(attrs, :result, :passing)
@@ -207,6 +202,43 @@ defmodule Wanda.Factory do
       check_targets = Enum.filter(targets, &(check_id in &1.checks))
       check_result_from_target(check_id, check_targets, result, failure_message)
     end)
+  end
+
+  def operation_factory do
+    %Operation{
+      id: UUID.uuid4(),
+      name: Faker.StarWars.character(),
+      required_args: [],
+      steps: build_list(2, :operation_step)
+    }
+  end
+
+  def operation_step_factory do
+    %Step{
+      operator: Faker.StarWars.planet(),
+      predicate: "*"
+    }
+  end
+
+  def operation_target_factory do
+    %OperationTarget{
+      agent_id: UUID.uuid4(),
+      arguments: %{}
+    }
+  end
+
+  defp random_env_value do
+    Faker.Util.pick([
+      Faker.Pokemon.name(),
+      Enum.random(1..10),
+      Enum.random([false, true])
+    ])
+  end
+
+  defp random_checks do
+    1..10
+    |> Enum.map(fn _ -> UUID.uuid4() end)
+    |> Enum.take_random(Enum.random(1..5))
   end
 
   defp check_result_from_target(check_id, check_targets, result, failure_message) do

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -1,0 +1,390 @@
+defmodule Wanda.Operations.ServerTest do
+  use ExUnit.Case
+
+  import Wanda.Factory
+
+  alias Wanda.EvaluationEngine
+
+  alias Wanda.Operations.{AgentReport, Server, StepReport, State}
+
+  setup_all do
+    engine = EvaluationEngine.new()
+
+    {:ok, %{engine: engine}}
+  end
+
+  describe "start_link/3" do
+    test "should accept all required arguments on start" do
+      group_id = UUID.uuid4()
+      operation = build(:operation)
+      targets = build_list(2, :operation_target)
+
+      assert {:ok, pid} =
+               start_supervised(
+                 {Server,
+                  [
+                    operation_id: UUID.uuid4(),
+                    group_id: group_id,
+                    operation: operation,
+                    targets: targets,
+                    timeout: 5,
+                    current_step_index: 0,
+                    step_failed: false
+                  ]}
+               )
+
+      assert pid == :global.whereis_name({Server, group_id})
+
+      stop_supervised(Server)
+    end
+  end
+
+  describe "receive_operation_reports/5" do
+    test "should receive operation reports properly" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      operation = build(:operation)
+      targets = build_list(2, :operation_target)
+
+      {:ok, _pid} =
+        start_supervised(
+          {Server,
+           [
+             operation_id: operation_id,
+             group_id: group_id,
+             operation: operation,
+             targets: targets,
+             timeout: 5,
+             current_step_index: 0,
+             step_failed: false
+           ]}
+        )
+
+      assert :ok ==
+               Server.receive_operation_reports(operation_id, group_id, 1, UUID.uuid4(), :updated)
+    end
+  end
+
+  describe "start operation" do
+    test "should skip operation if required arguments on targets are missing" do
+      operation = build(:operation, required_args: ["arg1", "arg2"])
+
+      test_targets = [
+        build_list(2, :operation_target),
+        [
+          build(:operation_target, arguments: %{"arg1" => "value"}),
+          build(:operation_target, arguments: %{"arg2" => "value"})
+        ],
+        [
+          build(:operation_target, arguments: %{"arg1" => "value", "arg2" => "value"}),
+          build(:operation_target, arguments: %{"arg2" => "value"})
+        ],
+        [
+          build(:operation_target, arguments: %{"arg1" => "value"}),
+          build(:operation_target, arguments: %{"arg1" => "value", "arg2" => "value"})
+        ]
+      ]
+
+      for targets <- test_targets do
+        assert {:error, :arguments_missing} =
+                 Server.start_operation(
+                   UUID.uuid4(),
+                   UUID.uuid4(),
+                   operation,
+                   targets,
+                   %{}
+                 )
+      end
+    end
+
+    test "should start operation" do
+      group_id = UUID.uuid4()
+      operation = build(:operation)
+
+      [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
+        targets = build_list(2, :operation_target)
+
+      assert :ok =
+               Server.start_operation(
+                 UUID.uuid4(),
+                 group_id,
+                 operation,
+                 targets,
+                 []
+               )
+
+      pid = :global.whereis_name({Server, group_id})
+      %{agent_reports: agent_reports} = :sys.get_state(pid)
+
+      expected_agent_reports = [
+        %StepReport{
+          step_number: 0,
+          agents: [
+            %AgentReport{agent_id: agent_id_1, result: :not_executed},
+            %AgentReport{agent_id: agent_id_2, result: :not_executed}
+          ]
+        },
+        %StepReport{
+          step_number: 1,
+          agents: [
+            %AgentReport{agent_id: agent_id_1, result: :not_executed},
+            %AgentReport{agent_id: agent_id_2, result: :not_executed}
+          ]
+        }
+      ]
+
+      assert agent_reports == expected_agent_reports
+    end
+  end
+
+  describe "execute_step" do
+    test "should stop execution if last step failed" do
+      state = %State{
+        step_failed: true,
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: UUID.uuid4(), result: :failed}]
+          }
+        ]
+      }
+
+      assert {:stop, :normal, ^state} =
+               Server.handle_continue(
+                 :execute_step,
+                 state
+               )
+    end
+
+    test "should finish operation if all steps are completed" do
+      state = %State{
+        current_step_index: 1,
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: UUID.uuid4(), result: :updated}]
+          }
+        ]
+      }
+
+      assert {:stop, :normal, ^state} =
+               Server.handle_continue(
+                 :execute_step,
+                 state
+               )
+    end
+
+    test "should skip step if none of the agents match the predicate", %{engine: engine} do
+      operation =
+        build(:operation, steps: build_list(1, :operation_step, predicate: "true == false"))
+
+      pending_agent_id = UUID.uuid4()
+
+      state = %State{
+        engine: engine,
+        operation: operation,
+        current_step_index: 0,
+        pending_targets_on_step: [pending_agent_id],
+        targets: build_list(1, :operation_target, agent_id: pending_agent_id),
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
+          }
+        ]
+      }
+
+      assert {:noreply, new_state, {:continue, :execute_step}} =
+               Server.handle_continue(
+                 :execute_step,
+                 state
+               )
+
+      assert %State{
+               pending_targets_on_step: [],
+               current_step_index: 1,
+               agent_reports: [
+                 %StepReport{
+                   step_number: 0,
+                   agents: [%AgentReport{agent_id: ^pending_agent_id, result: :skipped}]
+                 }
+               ]
+             } = new_state
+    end
+
+    test "should request operation" do
+      operation =
+        build(:operation, steps: build_list(1, :operation_step, predicate: "*"))
+
+      pending_agent_id = UUID.uuid4()
+
+      state = %State{
+        operation: operation,
+        current_step_index: 0,
+        pending_targets_on_step: [pending_agent_id],
+        targets: build_list(1, :operation_target, agent_id: pending_agent_id),
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
+          }
+        ]
+      }
+
+      assert {:noreply, ^state} =
+               Server.handle_continue(
+                 :execute_step,
+                 state
+               )
+    end
+  end
+
+  describe "receive_reports" do
+    test "should continue to next step when last step is completed updating agent result" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      pending_agent_id = UUID.uuid4()
+
+      state = %State{
+        operation_id: operation_id,
+        group_id: group_id,
+        current_step_index: 0,
+        pending_targets_on_step: [pending_agent_id],
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
+          }
+        ]
+      }
+
+      assert {:noreply, new_state, {:continue, :execute_step}} =
+               Server.handle_cast(
+                 {:receive_reports, operation_id, pending_agent_id, 0, :updated},
+                 state
+               )
+
+      assert %State{
+               operation_id: operation_id,
+               group_id: group_id,
+               pending_targets_on_step: [],
+               current_step_index: 1,
+               step_failed: false,
+               agent_reports: [
+                 %StepReport{
+                   step_number: 0,
+                   agents: [%AgentReport{agent_id: pending_agent_id, result: :updated}]
+                 }
+               ]
+             } == new_state
+    end
+
+    test "should wait on step if some agent is pending to report" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      pending_agent_id_1 = UUID.uuid4()
+      pending_agent_id_2 = UUID.uuid4()
+
+      state = %State{
+        operation_id: operation_id,
+        group_id: group_id,
+        current_step_index: 0,
+        pending_targets_on_step: [pending_agent_id_1, pending_agent_id_2],
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: pending_agent_id_1, result: :not_executed}]
+          }
+        ]
+      }
+
+      assert {:noreply, new_state} =
+               Server.handle_cast(
+                 {:receive_reports, operation_id, pending_agent_id_1, 0, :updated},
+                 state
+               )
+
+      assert %State{
+               operation_id: operation_id,
+               group_id: group_id,
+               pending_targets_on_step: [pending_agent_id_2],
+               current_step_index: 0,
+               step_failed: false,
+               agent_reports: [
+                 %StepReport{
+                   step_number: 0,
+                   agents: [%AgentReport{agent_id: pending_agent_id_1, result: :updated}]
+                 }
+               ]
+             } == new_state
+    end
+
+    test "should set the step as failed of an agent reports with a failed result" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      pending_agent_id = UUID.uuid4()
+
+      state = %State{
+        operation_id: operation_id,
+        group_id: group_id,
+        current_step_index: 0,
+        pending_targets_on_step: [pending_agent_id],
+        agent_reports: [
+          %StepReport{
+            step_number: 0,
+            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
+          }
+        ]
+      }
+
+      assert {:noreply, new_state, {:continue, :execute_step}} =
+               Server.handle_cast(
+                 {:receive_reports, operation_id, pending_agent_id, 0, :failed},
+                 state
+               )
+
+      assert %State{
+               operation_id: operation_id,
+               group_id: group_id,
+               pending_targets_on_step: [],
+               current_step_index: 1,
+               step_failed: true,
+               agent_reports: [
+                 %StepReport{
+                   step_number: 0,
+                   agents: [%AgentReport{agent_id: pending_agent_id, result: :failed}]
+                 }
+               ]
+             } == new_state
+    end
+
+    test "should ignore unexpected step number" do
+      operation_id = UUID.uuid4()
+
+      state = %State{
+        operation_id: operation_id,
+        current_step_index: 0
+      }
+
+      assert {:noreply, ^state} =
+               Server.handle_cast(
+                 {:receive_reports, operation_id, UUID.uuid4(), 1, :update},
+                 state
+               )
+    end
+
+    test "should ignore unexpected operation id" do
+      state = %State{
+        operation_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        current_step_index: 0
+      }
+
+      assert {:noreply, ^state} =
+               Server.handle_cast(
+                 {:receive_reports, UUID.uuid4(), UUID.uuid4(), 0, :update},
+                 state
+               )
+    end
+  end
+end

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -97,7 +97,7 @@ defmodule Wanda.Operations.ServerTest do
       end
     end
 
-    test "should not start opeartion if it is already running for that group_id" do
+    test "should not start operation if it is already running for that group_id" do
       group_id = UUID.uuid4()
 
       {:ok, _pid} =

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -5,7 +5,7 @@ defmodule Wanda.Operations.ServerTest do
 
   alias Wanda.EvaluationEngine
 
-  alias Wanda.Operations.{AgentReport, Server, StepReport, State}
+  alias Wanda.Operations.{AgentReport, Server, State, StepReport}
 
   setup_all do
     engine = EvaluationEngine.new()


### PR DESCRIPTION
# Description

Implement the operation orchestration skeleton.
Operations are defined using actual elixir code. Their are composed basically by a number of steps, that are executed sequentially in all the targets agents. Each step consists of a operator execution (the same way we do with gatherers).

The orchestration works in the next way:
- A operation execution is requested to be executed in some targets. For example, if it is a host operation, we will only have one target. If it is a cluster operation, we will have all the members of the cluster as hosts
- The N step of the operation is executed (starting from the first of course)
- At this point, the operator execution is sent to all targets, it they match the step predicate. This means, that certain steps might be ignored in some hosts.
- Once the operation execution is sent, the server waits to receive the report from each of the hosts.
- When all hosts have reported, the operation continues running the next step, until finalizing all steps.
- If some of the steps fail in a host, the complete operation is aborted.

**The steps are executed sequentially, but the order to executed the operation in all related hosts is parallel.**

I have excluded from this PR everything related to messaging, storing operation results in the database,  and results evaluation.
It only includes the fundamental part of the orchestration.

A solution code can looks something like this:
```
%Operation{
    id: "abcdef",
    name: "saptune solution",
    required_args: ["solution"],
    steps: [
        %Step{
            operator: "saptune solution",
            predicate: "*"
        }
    ]
}
```


## How was this tested?

UT test added

