### PR TITLE
Update dockerfiles to use correct elixir/erlang versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM opensuse/tumbleweed AS elixir-build
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-RUN zypper -n in git-core elixir elixir-hex erlang-rebar3 rust cargo
+FROM opensuse/leap:15.6 AS elixir-build
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+RUN zypper ar https://download.opensuse.org/repositories/devel:sap:trento:builddeps/15.6 buildeps
+RUN zypper -n --gpg-auto-import-keys ref
+RUN zypper -n in git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3 rust cargo
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod
@@ -14,10 +16,13 @@ COPY --from=elixir-build /build /build
 WORKDIR /build
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
+ENV MIX_HOME=/usr/bin
+ENV MIX_REBAR3=/usr/bin/rebar3
+ENV MIX_PATH=/usr/lib/elixir/lib/hex/ebin
 RUN mix phx.digest
 RUN mix release
 
-FROM opensuse/tumbleweed AS wanda
+FROM opensuse/leap:15.6
 LABEL org.opencontainers.image.source="https://github.com/trento-project/wanda"
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -5,15 +5,13 @@
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64
 
-FROM bci/rust:1.66 AS release
+FROM registry.suse.com/bci/rust:1.66 AS release
 ADD wanda.tar.gz /build/
-# Workaround for https://github.com/openSUSE/obs-build/issues/487
-RUN zypper --non-interactive in sles-release
-RUN zypper -n in git-core elixir>=1.15 elixir-hex erlang-rebar3
+RUN zypper -n in git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3
 WORKDIR /build/wanda/
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ENV MIX_ENV=prod
 ENV MIX_HOME=/usr/bin
 ENV MIX_REBAR3=/usr/bin/rebar3
@@ -22,13 +20,13 @@ ENV VERSION=%%VERSION%%
 RUN mix phx.digest
 RUN mix release
 
-FROM bci/rust:1.66 AS wanda
+FROM registry.suse.com/bci/rust:1.66
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/wanda"
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 WORKDIR /app
 COPY --from=release /build/wanda/_build/prod/rel/wanda .
 VOLUME /usr/share/trento/checks


### PR DESCRIPTION
# Description

Update dockerfiles to use correct elixir 1.15 and erlang 26 version.
The same as in web: https://github.com/trento-project/web/pull/3217
