### PR TITLE
Save operations in the database

### DIFF
--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -3,4 +3,71 @@ defmodule Wanda.Operations do
   Operations are combined actions dispatched to different agents in order to apply
   persistent changes on them.
   """
+
+  alias Wanda.Repo
+
+  alias Wanda.Operations.{
+    Operation,
+    OperationTarget,
+    StepReport
+  }
+
+  @doc """
+  Create a new operarion.
+
+  If the operation already exists, it will be returned.
+  """
+  @spec create_operation!(String.t(), String.t(), [OperationTarget.t()]) :: Operation.t()
+  def create_operation!(operation_id, group_id, targets) do
+    %Operation{}
+    |> Operation.changeset(%{
+      operation_id: operation_id,
+      group_id: group_id,
+      status: :running,
+      result: :not_executed,
+      targets: Enum.map(targets, &Map.from_struct/1)
+    })
+    |> Repo.insert!(on_conflict: :nothing)
+  end
+
+  @doc """
+  Get an operation by operation_id.
+  """
+  @spec get_operation!(String.t()) :: Operation.t()
+  def get_operation!(operation_id) do
+    Repo.get!(Operation, operation_id)
+  end
+
+  @doc """
+  Update agent_reports of an operation
+  """
+  @spec update_agent_reports!(String.t(), [StepReport.t()]) ::
+          Operation.t()
+  def update_agent_reports!(operation_id, agent_reports) do
+    Operation
+    |> Repo.get!(operation_id)
+    |> Operation.changeset(%{
+      agent_reports: agent_reports
+    })
+    |> Repo.update!()
+  end
+
+  @doc """
+  Marks a previously started operation as completed
+  """
+  @spec complete_operation!(
+          String.t(),
+          :updated | :not_updated | :failed | :rolled_back | :skipped
+        ) ::
+          Operation.t()
+  def complete_operation!(operation_id, result) do
+    Operation
+    |> Repo.get!(operation_id)
+    |> Operation.changeset(%{
+      result: result,
+      status: :completed,
+      completed_at: DateTime.utc_now()
+    })
+    |> Repo.update!()
+  end
 end

--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -12,6 +12,9 @@ defmodule Wanda.Operations do
     StepReport
   }
 
+  require Wanda.Operations.Enums.Result, as: Result
+  require Wanda.Operations.Enums.Status, as: Status
+
   @doc """
   Create a new operarion.
 
@@ -23,8 +26,8 @@ defmodule Wanda.Operations do
     |> Operation.changeset(%{
       operation_id: operation_id,
       group_id: group_id,
-      status: :running,
-      result: :not_executed,
+      status: Status.running(),
+      result: Result.not_executed(),
       targets: Enum.map(targets, &Map.from_struct/1)
     })
     |> Repo.insert!(on_conflict: :nothing)
@@ -55,17 +58,13 @@ defmodule Wanda.Operations do
   @doc """
   Marks a previously started operation as completed
   """
-  @spec complete_operation!(
-          String.t(),
-          :updated | :not_updated | :failed | :rolled_back | :skipped
-        ) ::
-          Operation.t()
+  @spec complete_operation!(String.t(), Result.t()) :: Operation.t()
   def complete_operation!(operation_id, result) do
     Operation
     |> Repo.get!(operation_id)
     |> Operation.changeset(%{
       result: result,
-      status: :completed,
+      status: Status.completed(),
       completed_at: DateTime.utc_now()
     })
     |> Repo.update!()

--- a/lib/wanda/operations/agent_report.ex
+++ b/lib/wanda/operations/agent_report.ex
@@ -5,6 +5,7 @@ defmodule Wanda.Operations.AgentReport do
 
   require Wanda.Operations.Enums.Result, as: Result
 
+  @derive Jason.Encoder
   defstruct [
     :agent_id,
     :result

--- a/lib/wanda/operations/enums/result.ex
+++ b/lib/wanda/operations/enums/result.ex
@@ -1,6 +1,6 @@
 defmodule Wanda.Operations.Enums.Result do
   @moduledoc """
-  Type that represents am operation result.
+  Type that represents an operation result.
   """
 
   use Wanda.Support.Enum,

--- a/lib/wanda/operations/enums/status.ex
+++ b/lib/wanda/operations/enums/status.ex
@@ -1,0 +1,8 @@
+defmodule Wanda.Operations.Enums.Status do
+  @moduledoc """
+  Type that represents an operation execution status.
+  """
+
+  use Wanda.Support.Enum,
+    values: [:running, :completed]
+end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -9,7 +9,7 @@ defmodule Wanda.Operations.Operation do
 
   @type t :: %__MODULE__{}
 
-  @fields ~w(operation_id group_id result status agent_reports started_at completed_at)a
+  @fields ~w(operation_id group_id result status agent_reports started_at updated_at completed_at)a
   @target_fields ~w(agent_id arguments)a
 
   @required_fields ~w(operation_id group_id result status)a
@@ -35,8 +35,8 @@ defmodule Wanda.Operations.Operation do
 
     field :agent_reports, {:array, :map}
 
-    timestamps(type: :utc_datetime_usec, inserted_at: :started_at, updated_at: false)
     field :completed_at, :utc_datetime_usec
+    timestamps(type: :utc_datetime_usec, inserted_at: :started_at)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -7,6 +7,9 @@ defmodule Wanda.Operations.Operation do
 
   import Ecto.Changeset
 
+  require Wanda.Operations.Enums.Result, as: Result
+  require Wanda.Operations.Enums.Status, as: Status
+
   @type t :: %__MODULE__{}
 
   @fields ~w(operation_id group_id result status agent_reports started_at updated_at completed_at)a
@@ -20,11 +23,8 @@ defmodule Wanda.Operations.Operation do
   schema "operations" do
     field :operation_id, Ecto.UUID, primary_key: true
     field :group_id, Ecto.UUID
-
-    field :result, Ecto.Enum,
-      values: [:updated, :not_updated, :failed, :rolled_back, :skipped, :not_executed]
-
-    field :status, Ecto.Enum, values: [:running, :completed]
+    field :result, Ecto.Enum, values: Result.values()
+    field :status, Ecto.Enum, values: Status.values()
 
     embeds_many :targets, Target, primary_key: false do
       @derive Jason.Encoder

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -24,6 +24,8 @@ defmodule Wanda.Operations.Operation do
     field :status, Ecto.Enum, values: [:running, :completed]
 
     embeds_many :targets, Target, primary_key: false do
+      @derive Jason.Encoder
+
       field :agent_id, Ecto.UUID, primary_key: true
       field :arguments, :map
     end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -1,0 +1,47 @@
+defmodule Wanda.Operations.Operation do
+  @moduledoc """
+  Schema of a persisted operation.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @fields ~w(operation_id group_id result status agent_reports started_at completed_at)a
+  @target_fields ~w(agent_id arguments)a
+
+  @derive {Jason.Encoder, [except: [:__meta__]]}
+  @primary_key false
+  schema "operations" do
+    field :operation_id, Ecto.UUID, primary_key: true
+    field :group_id, Ecto.UUID
+
+    field :result, Ecto.Enum,
+      values: [:updated, :not_updated, :failed, :rolled_back, :skipped, :not_executed]
+
+    field :status, Ecto.Enum, values: [:running, :completed]
+
+    embeds_many :targets, Target, primary_key: false do
+      field :agent_id, Ecto.UUID, primary_key: true
+      field :arguments, :map
+    end
+
+    field :agent_reports, {:array, :map}
+
+    timestamps(type: :utc_datetime_usec, inserted_at: :started_at, updated_at: false)
+    field :completed_at, :utc_datetime_usec
+  end
+
+  @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
+  def changeset(operation, params) do
+    operation
+    |> cast(params, @fields)
+    |> cast_embed(:targets, with: &target_changeset/2)
+  end
+
+  defp target_changeset(target, params) do
+    cast(target, params, @target_fields)
+  end
+end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -12,6 +12,9 @@ defmodule Wanda.Operations.Operation do
   @fields ~w(operation_id group_id result status agent_reports started_at completed_at)a
   @target_fields ~w(agent_id arguments)a
 
+  @required_fields ~w(operation_id group_id result status)a
+  @targets_required_fields ~w(agent_id)a
+
   @derive {Jason.Encoder, [except: [:__meta__]]}
   @primary_key false
   schema "operations" do
@@ -40,10 +43,13 @@ defmodule Wanda.Operations.Operation do
   def changeset(operation, params) do
     operation
     |> cast(params, @fields)
-    |> cast_embed(:targets, with: &target_changeset/2)
+    |> cast_embed(:targets, with: &target_changeset/2, required: true)
+    |> validate_required(@required_fields)
   end
 
   defp target_changeset(target, params) do
-    cast(target, params, @target_fields)
+    target
+    |> cast(params, @target_fields)
+    |> validate_required(@targets_required_fields)
   end
 end

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -107,7 +107,7 @@ defmodule Wanda.Operations.Server do
     # Publish results
 
     # Result is failed or rolledback, depending on the evaluation result
-    Operations.complete_operation!(operation_id, :failed)
+    Operations.complete_operation!(operation_id, Result.failed())
 
     {:stop, :normal, state}
   end
@@ -157,7 +157,7 @@ defmodule Wanda.Operations.Server do
     # Publish and store results
 
     # Result based on evaluation result
-    Operations.complete_operation!(operation_id, :updated)
+    Operations.complete_operation!(operation_id, Result.updated())
 
     {:stop, :normal, state}
   end

--- a/lib/wanda/operations/step_report.ex
+++ b/lib/wanda/operations/step_report.ex
@@ -5,6 +5,7 @@ defmodule Wanda.Operations.StepReport do
 
   alias Wanda.Operations.AgentReport
 
+  @derive Jason.Encoder
   defstruct [
     :step_number,
     :agents

--- a/priv/repo/migrations/20250109154813_add_operation.exs
+++ b/priv/repo/migrations/20250109154813_add_operation.exs
@@ -7,8 +7,8 @@ defmodule Wanda.Repo.Migrations.AddOperation do
       add :group_id, :uuid, null: false
       add :result, :string, null: false
       add :status, :string, null: false
-      add :targets, :map, null: false, default: "[]"
-      add :agent_reports, :map, null: false, default: "[]"
+      add :targets, :jsonb, null: false, default: "[]"
+      add :agent_reports, :jsonb, null: false, default: "[]"
       add :completed_at, :utc_datetime_usec
       timestamps(type: :utc_datetime_usec, inserted_at: :started_at)
     end

--- a/priv/repo/migrations/20250109154813_add_operation.exs
+++ b/priv/repo/migrations/20250109154813_add_operation.exs
@@ -1,0 +1,20 @@
+defmodule Wanda.Repo.Migrations.AddOperation do
+  use Ecto.Migration
+
+  def change do
+    create table(:operations, primary_key: false) do
+      add :operation_id, :uuid, primary_key: true
+      add :group_id, :uuid, null: false
+      add :result, :string, null: false
+      add :status, :string, null: false
+      add :targets, :map, null: false, default: "[]"
+      add :agent_reports, :map, null: false, default: "[]"
+
+      timestamps(type: :utc_datetime_usec, inserted_at: :started_at, updated_at: false)
+      add :completed_at, :utc_datetime_usec
+    end
+
+    create index(:operations, [:group_id])
+    create unique_index(:operations, [:operation_id, :group_id])
+  end
+end

--- a/priv/repo/migrations/20250109154813_add_operation.exs
+++ b/priv/repo/migrations/20250109154813_add_operation.exs
@@ -9,9 +9,8 @@ defmodule Wanda.Repo.Migrations.AddOperation do
       add :status, :string, null: false
       add :targets, :map, null: false, default: "[]"
       add :agent_reports, :map, null: false, default: "[]"
-
-      timestamps(type: :utc_datetime_usec, inserted_at: :started_at, updated_at: false)
       add :completed_at, :utc_datetime_usec
+      timestamps(type: :utc_datetime_usec, inserted_at: :started_at)
     end
 
     create index(:operations, [:group_id])

--- a/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
+++ b/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
@@ -1,0 +1,13 @@
+defmodule Wanda.Repo.Migrations.AddOperationJsonbIndexes do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE INDEX operation_targets ON operations USING GIN(targets)")
+    execute("CREATE INDEX operation_agent_reports ON operations USING GIN(agent_reports)")
+  end
+
+  def down do
+    execute("DROP INDEX operation_targets")
+    execute("DROP INDEX operation_agent_reports")
+  end
+end

--- a/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
+++ b/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
@@ -1,13 +1,8 @@
 defmodule Wanda.Repo.Migrations.AddOperationJsonbIndexes do
   use Ecto.Migration
 
-  def up do
-    execute("CREATE INDEX operation_targets ON operations USING GIN(targets)")
-    execute("CREATE INDEX operation_agent_reports ON operations USING GIN(agent_reports)")
-  end
-
-  def down do
-    execute("DROP INDEX operation_targets")
-    execute("DROP INDEX operation_agent_reports")
+  def change do
+    create index(:operations, ["targets jsonb_path_ops"], using: "GIN")
+    create index(:operations, ["agent_reports jsonb_path_ops"], using: "GIN")
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,12 +19,15 @@ defmodule Wanda.Factory do
     Target
   }
 
-  alias Wanda.Operations.OperationTarget
-
-  alias Wanda.Operations.Catalog.{
+  alias Wanda.Operations.{
+    AgentReport,
     Operation,
-    Step
+    OperationTarget,
+    StepReport
   }
+
+  alias Wanda.Operations.Catalog.Operation, as: CatalogOperation
+  alias Wanda.Operations.Catalog.Step
 
   def check_factory do
     %Catalog.Check{
@@ -202,8 +205,8 @@ defmodule Wanda.Factory do
     end)
   end
 
-  def operation_factory do
-    %Operation{
+  def catalog_operation_factory do
+    %CatalogOperation{
       id: UUID.uuid4(),
       name: Faker.StarWars.character(),
       required_args: [],
@@ -218,10 +221,44 @@ defmodule Wanda.Factory do
     }
   end
 
+  def operation_factory do
+    targets =
+      1..5
+      |> Enum.random()
+      |> build_list(:operation_target)
+      |> Enum.map(fn %{agent_id: id, arguments: args} ->
+        %Operation.Target{agent_id: id, arguments: args}
+      end)
+
+    %Operation{
+      operation_id: UUID.uuid4(),
+      group_id: UUID.uuid4(),
+      result: :not_executed,
+      status: :running,
+      targets: targets,
+      agent_reports: [],
+      started_at: DateTime.utc_now()
+    }
+  end
+
   def operation_target_factory do
     %OperationTarget{
       agent_id: UUID.uuid4(),
       arguments: %{}
+    }
+  end
+
+  def step_report_factory do
+    %StepReport{
+      step_number: Enum.random(1..10),
+      agents: build_list(2, :agent_report)
+    }
+  end
+
+  def agent_report_factory do
+    %AgentReport{
+      agent_id: UUID.uuid4(),
+      result: :updated
     }
   end
 

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -1,5 +1,5 @@
 defmodule Wanda.Operations.ServerTest do
-  use ExUnit.Case
+  use Wanda.DataCase
 
   import Wanda.Factory
 
@@ -16,7 +16,7 @@ defmodule Wanda.Operations.ServerTest do
   describe "start_link/3" do
     test "should accept all required arguments on start" do
       group_id = UUID.uuid4()
-      operation = build(:operation)
+      operation = build(:catalog_operation)
       targets = build_list(2, :operation_target)
 
       assert {:ok, pid} =
@@ -43,7 +43,7 @@ defmodule Wanda.Operations.ServerTest do
     test "should receive operation reports properly" do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      operation = build(:operation)
+      operation = build(:catalog_operation)
       targets = build_list(2, :operation_target)
 
       {:ok, _pid} =
@@ -106,7 +106,7 @@ defmodule Wanda.Operations.ServerTest do
            [
              operation_id: UUID.uuid4(),
              group_id: group_id,
-             operation: build(:operation),
+             operation: build(:catalog_operation),
              targets: build_list(2, :operation_target),
              timeout: 5,
              current_step_index: 0,
@@ -118,7 +118,7 @@ defmodule Wanda.Operations.ServerTest do
                Server.start_operation(
                  UUID.uuid4(),
                  group_id,
-                 build(:operation),
+                 build(:catalog_operation),
                  build_list(2, :operation_target),
                  []
                )
@@ -126,7 +126,7 @@ defmodule Wanda.Operations.ServerTest do
 
     test "should start operation" do
       group_id = UUID.uuid4()
-      operation = build(:operation)
+      operation = build(:catalog_operation)
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -3,72 +3,10 @@ defmodule Wanda.Operations.ServerTest do
 
   import Wanda.Factory
 
-  alias Wanda.EvaluationEngine
+  alias Wanda.Operations.{Operation, Server}
 
-  alias Wanda.Operations.{AgentReport, Operation, Server, State, StepReport}
-
-  setup_all do
-    engine = EvaluationEngine.new()
-
-    {:ok, %{engine: engine}}
-  end
-
-  describe "start_link/3" do
-    test "should accept all required arguments on start" do
-      group_id = UUID.uuid4()
-      operation = build(:catalog_operation)
-      targets = build_list(2, :operation_target)
-
-      assert {:ok, pid} =
-               start_supervised(
-                 {Server,
-                  [
-                    operation_id: UUID.uuid4(),
-                    group_id: group_id,
-                    operation: operation,
-                    targets: targets,
-                    timeout: 5,
-                    current_step_index: 0,
-                    step_failed: false
-                  ]}
-               )
-
-      assert pid == :global.whereis_name({Server, group_id})
-
-      stop_supervised!(Server)
-    end
-  end
-
-  describe "receive_operation_reports/5" do
-    test "should receive operation reports properly" do
-      operation_id = UUID.uuid4()
-      group_id = UUID.uuid4()
-      operation = build(:catalog_operation)
-      targets = build_list(2, :operation_target)
-
-      {:ok, _pid} =
-        start_supervised(
-          {Server,
-           [
-             operation_id: operation_id,
-             group_id: group_id,
-             operation: operation,
-             targets: targets,
-             timeout: 5,
-             current_step_index: 0,
-             step_failed: false
-           ]}
-        )
-
-      assert :ok ==
-               Server.receive_operation_reports(operation_id, group_id, 1, UUID.uuid4(), :updated)
-
-      stop_supervised!(Server)
-    end
-  end
-
-  describe "start operation" do
-    test "should skip operation if required arguments on targets are missing" do
+  describe "operation execution" do
+    test "should not start operation if required arguments on targets are missing" do
       catalog_operation = build(:catalog_operation, required_args: ["arg1", "arg2"])
 
       test_targets = [
@@ -102,19 +40,15 @@ defmodule Wanda.Operations.ServerTest do
     test "should not start operation if it is already running for that group_id" do
       group_id = UUID.uuid4()
 
-      {:ok, _pid} =
-        start_supervised(
-          {Server,
-           [
-             operation_id: UUID.uuid4(),
-             group_id: group_id,
-             operation: build(:catalog_operation),
-             targets: build_list(2, :operation_target),
-             timeout: 5,
-             current_step_index: 0,
-             step_failed: false
-           ]}
-        )
+      Server.start_operation(
+        UUID.uuid4(),
+        group_id,
+        build(:catalog_operation),
+        build_list(2, :operation_target),
+        []
+      )
+
+      pid = :global.whereis_name({Server, group_id})
 
       assert {:error, :already_running} =
                Server.start_operation(
@@ -125,317 +59,279 @@ defmodule Wanda.Operations.ServerTest do
                  []
                )
 
-      stop_supervised!(Server)
+      GenServer.stop(pid)
     end
 
-    test "should start operation" do
+    test "should stop execution if last step failed" do
+      operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
       operation = build(:catalog_operation)
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)
 
-      assert :ok =
-               Server.start_operation(
-                 UUID.uuid4(),
-                 group_id,
-                 operation,
-                 targets,
-                 []
-               )
+      Server.start_operation(
+        operation_id,
+        group_id,
+        operation,
+        targets,
+        []
+      )
 
       pid = :global.whereis_name({Server, group_id})
-      %{agent_reports: agent_reports} = :sys.get_state(pid)
+      ref = Process.monitor(pid)
+
+      Server.receive_operation_reports(operation_id, group_id, 0, agent_id_1, :updated)
+      Server.receive_operation_reports(operation_id, group_id, 0, agent_id_2, :failed)
+
+      assert_receive {:DOWN, ^ref, _, ^pid, :normal}, 500
+
+      %{result: :failed, status: :completed, agent_reports: agent_reports} =
+        Repo.get(Operation, operation_id)
 
       expected_agent_reports = [
-        %StepReport{
-          step_number: 0,
-          agents: [
-            %AgentReport{agent_id: agent_id_1, result: :not_executed},
-            %AgentReport{agent_id: agent_id_2, result: :not_executed}
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "updated"},
+            %{"agent_id" => agent_id_2, "result" => "failed"}
           ]
         },
-        %StepReport{
-          step_number: 1,
-          agents: [
-            %AgentReport{agent_id: agent_id_1, result: :not_executed},
-            %AgentReport{agent_id: agent_id_2, result: :not_executed}
+        %{
+          "step_number" => 1,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "not_executed"},
+            %{"agent_id" => agent_id_2, "result" => "not_executed"}
           ]
         }
       ]
 
-      assert agent_reports == expected_agent_reports
-
-      GenServer.stop(pid)
-    end
-  end
-
-  describe "execute_step" do
-    test "should stop execution if last step failed" do
-      %Operation{operation_id: operation_id} = insert(:operation)
-
-      state = %State{
-        operation_id: operation_id,
-        step_failed: true,
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: UUID.uuid4(), result: :failed}]
-          }
-        ]
-      }
-
-      assert {:stop, :normal, ^state} =
-               Server.handle_continue(
-                 :execute_step,
-                 state
-               )
+      assert expected_agent_reports == agent_reports
     end
 
-    test "should finish operation if all steps are completed" do
-      %Operation{operation_id: operation_id} = insert(:operation)
+    test "should complete execution when all steps are executed in the targets" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
 
-      state = %State{
-        operation_id: operation_id,
-        current_step_index: 1,
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: UUID.uuid4(), result: :updated}]
-          }
-        ]
-      }
-
-      assert {:stop, :normal, ^state} =
-               Server.handle_continue(
-                 :execute_step,
-                 state
-               )
-    end
-
-    test "should skip step if none of the agents match the predicate", %{engine: engine} do
-      %Operation{operation_id: operation_id} = insert(:operation)
-
-      catalog_operation =
+      operation =
         build(:catalog_operation,
-          steps: build_list(1, :operation_step, predicate: "true == false")
+          steps: [
+            build(:operation_step, predicate: "*"),
+            build(:operation_step, predicate: "")
+          ]
         )
 
-      pending_agent_id = UUID.uuid4()
+      [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
+        targets = build_list(2, :operation_target)
 
-      state = %State{
-        engine: engine,
-        operation_id: operation_id,
-        operation: catalog_operation,
-        current_step_index: 0,
-        pending_targets_on_step: [pending_agent_id],
-        targets: build_list(1, :operation_target, agent_id: pending_agent_id),
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
-          }
-        ]
-      }
+      Server.start_operation(
+        operation_id,
+        group_id,
+        operation,
+        targets,
+        []
+      )
 
-      assert {:noreply, new_state, {:continue, :execute_step}} =
-               Server.handle_continue(
-                 :execute_step,
-                 state
-               )
+      pid = :global.whereis_name({Server, group_id})
+      ref = Process.monitor(pid)
 
-      assert %State{
-               pending_targets_on_step: [],
-               current_step_index: 1,
-               agent_reports: [
-                 %StepReport{
-                   step_number: 0,
-                   agents: [%AgentReport{agent_id: ^pending_agent_id, result: :skipped}]
-                 }
-               ]
-             } = new_state
+      # Getting the state of the GenServer make the test wait until the genserver has changed it
+      # internal state. It is just a better way of waiting until the process moved on rather
+      # than having a fixed sleep code
+      :sys.get_state(pid)
+
+      %{status: :running, agent_reports: initial_agent_reports} =
+        Repo.get(Operation, operation_id)
+
+      expected_initial_agent_reports = [
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "not_executed"},
+            %{"agent_id" => agent_id_2, "result" => "not_executed"}
+          ]
+        },
+        %{
+          "step_number" => 1,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "not_executed"},
+            %{"agent_id" => agent_id_2, "result" => "not_executed"}
+          ]
+        }
+      ]
+
+      assert expected_initial_agent_reports == initial_agent_reports
+
+      Server.receive_operation_reports(operation_id, group_id, 0, agent_id_1, :updated)
+      Server.receive_operation_reports(operation_id, group_id, 0, agent_id_2, :not_updated)
+
+      :sys.get_state(pid)
+
+      %{status: :running, agent_reports: agent_reports} = Repo.get(Operation, operation_id)
+
+      expected_agent_reports = [
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "updated"},
+            %{"agent_id" => agent_id_2, "result" => "not_updated"}
+          ]
+        },
+        %{
+          "step_number" => 1,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "not_executed"},
+            %{"agent_id" => agent_id_2, "result" => "not_executed"}
+          ]
+        }
+      ]
+
+      assert expected_agent_reports == agent_reports
+
+      Server.receive_operation_reports(operation_id, group_id, 1, agent_id_1, :updated)
+      Server.receive_operation_reports(operation_id, group_id, 1, agent_id_2, :updated)
+
+      assert_receive {:DOWN, ^ref, _, ^pid, :normal}, 500
+
+      %{result: :updated, status: :completed, agent_reports: final_agent_reports} =
+        Repo.get(Operation, operation_id)
+
+      expected_final_agent_reports = [
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "updated"},
+            %{"agent_id" => agent_id_2, "result" => "not_updated"}
+          ]
+        },
+        %{
+          "step_number" => 1,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "updated"},
+            %{"agent_id" => agent_id_2, "result" => "updated"}
+          ]
+        }
+      ]
+
+      assert expected_final_agent_reports == final_agent_reports
     end
 
-    test "should request operation", %{engine: engine} do
-      %Operation{operation_id: operation_id} = insert(:operation)
-      pending_agent_id = UUID.uuid4()
-
-      state = %State{
-        engine: engine,
-        operation_id: operation_id,
-        current_step_index: 0,
-        pending_targets_on_step: [pending_agent_id],
-        targets: build_list(1, :operation_target, agent_id: pending_agent_id),
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
-          }
-        ]
-      }
-
-      predicates = ["*", "", "true == true"]
-
-      for predicate <- predicates do
-        catalog_operation =
-          build(:catalog_operation, steps: build_list(1, :operation_step, predicate: predicate))
-
-        state = %State{state | operation: catalog_operation}
-
-        assert {:noreply, ^state} =
-                 Server.handle_continue(
-                   :execute_step,
-                   state
-                 )
-      end
-    end
-  end
-
-  describe "receive_reports" do
-    test "should continue to next step when last step is completed updating agent result" do
-      %Operation{operation_id: operation_id, group_id: group_id} = insert(:operation)
-
-      pending_agent_id = UUID.uuid4()
-
-      state = %State{
-        operation_id: operation_id,
-        group_id: group_id,
-        current_step_index: 0,
-        pending_targets_on_step: [pending_agent_id],
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
-          }
-        ]
-      }
-
-      assert {:noreply, new_state, {:continue, :execute_step}} =
-               Server.handle_cast(
-                 {:receive_reports, operation_id, pending_agent_id, 0, :updated},
-                 state
-               )
-
-      assert %State{
-               operation_id: operation_id,
-               group_id: group_id,
-               pending_targets_on_step: [],
-               current_step_index: 1,
-               step_failed: false,
-               agent_reports: [
-                 %StepReport{
-                   step_number: 0,
-                   agents: [%AgentReport{agent_id: pending_agent_id, result: :updated}]
-                 }
-               ]
-             } == new_state
-    end
-
-    test "should wait on step if some agent is pending to report" do
-      %Operation{operation_id: operation_id, group_id: group_id} = insert(:operation)
-
-      pending_agent_id_1 = UUID.uuid4()
-      pending_agent_id_2 = UUID.uuid4()
-
-      state = %State{
-        operation_id: operation_id,
-        group_id: group_id,
-        current_step_index: 0,
-        pending_targets_on_step: [pending_agent_id_1, pending_agent_id_2],
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: pending_agent_id_1, result: :not_executed}]
-          }
-        ]
-      }
-
-      assert {:noreply, new_state} =
-               Server.handle_cast(
-                 {:receive_reports, operation_id, pending_agent_id_1, 0, :updated},
-                 state
-               )
-
-      assert %State{
-               operation_id: operation_id,
-               group_id: group_id,
-               pending_targets_on_step: [pending_agent_id_2],
-               current_step_index: 0,
-               step_failed: false,
-               agent_reports: [
-                 %StepReport{
-                   step_number: 0,
-                   agents: [%AgentReport{agent_id: pending_agent_id_1, result: :updated}]
-                 }
-               ]
-             } == new_state
-    end
-
-    test "should set the step as failed of an agent reports with a failed result" do
-      %Operation{operation_id: operation_id, group_id: group_id} = insert(:operation)
-      pending_agent_id = UUID.uuid4()
-
-      state = %State{
-        operation_id: operation_id,
-        group_id: group_id,
-        current_step_index: 0,
-        pending_targets_on_step: [pending_agent_id],
-        agent_reports: [
-          %StepReport{
-            step_number: 0,
-            agents: [%AgentReport{agent_id: pending_agent_id, result: :not_executed}]
-          }
-        ]
-      }
-
-      assert {:noreply, new_state, {:continue, :execute_step}} =
-               Server.handle_cast(
-                 {:receive_reports, operation_id, pending_agent_id, 0, :failed},
-                 state
-               )
-
-      assert %State{
-               operation_id: operation_id,
-               group_id: group_id,
-               pending_targets_on_step: [],
-               current_step_index: 1,
-               step_failed: true,
-               agent_reports: [
-                 %StepReport{
-                   step_number: 0,
-                   agents: [%AgentReport{agent_id: pending_agent_id, result: :failed}]
-                 }
-               ]
-             } == new_state
-    end
-
-    test "should ignore unexpected step number" do
+    test "should skip operation in agent if predicate is false" do
       operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
 
-      state = %State{
-        operation_id: operation_id,
-        current_step_index: 0
-      }
+      operation =
+        build(:catalog_operation, steps: build_list(1, :operation_step, predicate: "value == 5"))
 
-      assert {:noreply, ^state} =
-               Server.handle_cast(
-                 {:receive_reports, operation_id, UUID.uuid4(), 1, :update},
-                 state
-               )
+      [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
+        targets = [
+          build(:operation_target, arguments: %{"value" => 5}),
+          build(:operation_target, arguments: %{"value" => 10})
+        ]
+
+      Server.start_operation(
+        operation_id,
+        group_id,
+        operation,
+        targets,
+        []
+      )
+
+      pid = :global.whereis_name({Server, group_id})
+      ref = Process.monitor(pid)
+
+      Server.receive_operation_reports(operation_id, group_id, 0, agent_id_1, :updated)
+
+      assert_receive {:DOWN, ^ref, _, ^pid, :normal}, 500
+
+      %{result: :updated, status: :completed, agent_reports: agent_reports} =
+        Repo.get(Operation, operation_id)
+
+      expected_agent_reports = [
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "updated"},
+            %{"agent_id" => agent_id_2, "result" => "skipped"}
+          ]
+        }
+      ]
+
+      assert expected_agent_reports == agent_reports
     end
 
-    test "should ignore unexpected operation id" do
-      state = %State{
-        operation_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        current_step_index: 0
-      }
+    test "should move to the next step if the predicate is false in all agents" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
 
-      assert {:noreply, ^state} =
-               Server.handle_cast(
-                 {:receive_reports, UUID.uuid4(), UUID.uuid4(), 0, :update},
-                 state
-               )
+      operation =
+        build(:catalog_operation, steps: build_list(1, :operation_step, predicate: "value == 5"))
+
+      [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
+        targets = [
+          build(:operation_target, arguments: %{"value" => 10}),
+          build(:operation_target, arguments: %{"value" => 10})
+        ]
+
+      Server.start_operation(
+        operation_id,
+        group_id,
+        operation,
+        targets,
+        []
+      )
+
+      pid = :global.whereis_name({Server, group_id})
+      ref = Process.monitor(pid)
+
+      assert_receive {:DOWN, ^ref, _, ^pid, :normal}, 500
+
+      %{result: :updated, status: :completed, agent_reports: agent_reports} =
+        Repo.get(Operation, operation_id)
+
+      expected_agent_reports = [
+        %{
+          "step_number" => 0,
+          "agents" => [
+            %{"agent_id" => agent_id_1, "result" => "skipped"},
+            %{"agent_id" => agent_id_2, "result" => "skipped"}
+          ]
+        }
+      ]
+
+      assert expected_agent_reports == agent_reports
+    end
+
+    test "should ignore unrecognized operation and step reports" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      operation = build(:catalog_operation)
+
+      [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
+        targets = build_list(2, :operation_target)
+
+      Server.start_operation(
+        operation_id,
+        group_id,
+        operation,
+        targets,
+        []
+      )
+
+      pid = :global.whereis_name({Server, group_id})
+      :sys.get_state(pid)
+
+      operation_state = Repo.get(Operation, operation_id)
+
+      Server.receive_operation_reports(UUID.uuid4(), group_id, 0, agent_id_1, :updated)
+      Server.receive_operation_reports(operation_id, group_id, 1, agent_id_2, :updated)
+
+      :sys.get_state(pid)
+
+      assert operation_state == Repo.get(Operation, operation_id)
+
+      GenServer.stop(pid)
     end
   end
 end

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -1,0 +1,157 @@
+defmodule Wanda.OperationsTest do
+  use ExUnit.Case
+  use Wanda.DataCase
+
+  import Wanda.Factory
+
+  alias Wanda.Operations
+  alias Wanda.Operations.{AgentReport, Operation, OperationTarget, StepReport}
+
+  describe "create an operation" do
+    test "should create a running operation" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      [
+        %OperationTarget{
+          agent_id: agent_id_1,
+          arguments: args_1
+        },
+        %OperationTarget{
+          agent_id: agent_id_2,
+          arguments: args_2
+        }
+      ] = targets = build_list(2, :operation_target)
+
+      Operations.create_operation!(operation_id, group_id, targets)
+
+      assert %Operation{
+               operation_id: ^operation_id,
+               group_id: ^group_id,
+               result: :not_executed,
+               status: :running,
+               targets: [
+                 %{
+                   agent_id: ^agent_id_1,
+                   arguments: ^args_1
+                 },
+                 %{
+                   agent_id: ^agent_id_2,
+                   arguments: ^args_2
+                 }
+               ],
+               agent_reports: []
+             } = Repo.get(Operation, operation_id)
+    end
+  end
+
+  describe "get operation" do
+    test "should return an existing operation" do
+      %Operation{operation_id: operation_id} = operation = insert(:operation)
+
+      assert operation == Operations.get_operation!(operation_id)
+    end
+  end
+
+  describe "update agent reports" do
+    test "should update agent reports on a running operation" do
+      %Operation{
+        operation_id: operation_id,
+        group_id: group_id
+      } = insert(:operation, status: :running)
+
+      [
+        %StepReport{
+          step_number: step_number_1,
+          agents: [
+            %AgentReport{
+              agent_id: agent_id_1,
+              result: agent_result_1
+            },
+            %AgentReport{
+              agent_id: agent_id_2,
+              result: agent_result_2
+            }
+          ]
+        },
+        %StepReport{
+          step_number: step_number_2,
+          agents: [
+            %AgentReport{
+              agent_id: agent_id_3,
+              result: agent_result_3
+            },
+            %AgentReport{
+              agent_id: agent_id_4,
+              result: agent_result_4
+            }
+          ]
+        }
+      ] = agent_reports = build_list(2, :step_report, agents: build_list(2, :agent_report))
+
+      Operations.update_agent_reports!(operation_id, agent_reports)
+
+      result_1 = to_string(agent_result_1)
+      result_2 = to_string(agent_result_2)
+      result_3 = to_string(agent_result_3)
+      result_4 = to_string(agent_result_4)
+
+      assert %Operation{
+               operation_id: ^operation_id,
+               group_id: ^group_id,
+               result: :not_executed,
+               status: :running,
+               agent_reports: [
+                 %{
+                   "step_number" => ^step_number_1,
+                   "agents" => [
+                     %{
+                       "agent_id" => ^agent_id_1,
+                       "result" => ^result_1
+                     },
+                     %{
+                       "agent_id" => ^agent_id_2,
+                       "result" => ^result_2
+                     }
+                   ]
+                 },
+                 %{
+                   "step_number" => ^step_number_2,
+                   "agents" => [
+                     %{
+                       "agent_id" => ^agent_id_3,
+                       "result" => ^result_3
+                     },
+                     %{
+                       "agent_id" => ^agent_id_4,
+                       "result" => ^result_4
+                     }
+                   ]
+                 }
+               ],
+               completed_at: nil
+             } = Repo.get(Operation, operation_id)
+    end
+  end
+
+  describe "complete an operation" do
+    test "should complete a running operation" do
+      %Operation{
+        operation_id: operation_id,
+        group_id: group_id
+      } = insert(:operation, status: :running)
+
+      Operations.complete_operation!(operation_id, :updated)
+
+      assert %Operation{
+               operation_id: ^operation_id,
+               group_id: ^group_id,
+               result: :updated,
+               status: :completed,
+               completed_at: completed_at
+             } = Repo.get(Operation, operation_id)
+
+      assert nil !== completed_at
+    end
+  end
+end

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -7,6 +7,9 @@ defmodule Wanda.OperationsTest do
   alias Wanda.Operations
   alias Wanda.Operations.{AgentReport, Operation, OperationTarget, StepReport}
 
+  require Wanda.Operations.Enums.Result, as: Result
+  require Wanda.Operations.Enums.Status, as: Status
+
   describe "create an operation" do
     test "should create a running operation" do
       operation_id = UUID.uuid4()
@@ -28,8 +31,8 @@ defmodule Wanda.OperationsTest do
       assert %Operation{
                operation_id: ^operation_id,
                group_id: ^group_id,
-               result: :not_executed,
-               status: :running,
+               result: Result.not_executed(),
+               status: Status.running(),
                targets: [
                  %{
                    agent_id: ^agent_id_1,
@@ -58,7 +61,7 @@ defmodule Wanda.OperationsTest do
       %Operation{
         operation_id: operation_id,
         group_id: group_id
-      } = insert(:operation, status: :running)
+      } = insert(:operation, status: Status.running())
 
       [
         %StepReport{
@@ -99,8 +102,8 @@ defmodule Wanda.OperationsTest do
       assert %Operation{
                operation_id: ^operation_id,
                group_id: ^group_id,
-               result: :not_executed,
-               status: :running,
+               result: Result.not_executed(),
+               status: Status.running(),
                agent_reports: [
                  %{
                    "step_number" => ^step_number_1,
@@ -139,15 +142,15 @@ defmodule Wanda.OperationsTest do
       %Operation{
         operation_id: operation_id,
         group_id: group_id
-      } = insert(:operation, status: :running)
+      } = insert(:operation, status: Status.running())
 
-      Operations.complete_operation!(operation_id, :updated)
+      Operations.complete_operation!(operation_id, Result.updated())
 
       assert %Operation{
                operation_id: ^operation_id,
                group_id: ^group_id,
-               result: :updated,
-               status: :completed,
+               result: Result.updated(),
+               status: Status.completed(),
                completed_at: completed_at
              } = Repo.get(Operation, operation_id)
 


### PR DESCRIPTION
# Description

Save the operation progress in the database during the orchestration. It saves the initial, intermediate and final states.
This way, the operation are permanently stored and we can expose them in the http API.
Besides that, they can be used to recover ongoing operations if the APP crashes and we need to resume ongoing operations.

PD: I have taken the advantage to refactor the tests. Now, the tests don't relay that much in implementation details. So attachment is needed, to improve the timing of the database queries (instead of relaying in static sleeps).

## How was this tested?
Tested with new UT

