### PR TITLE
Create and use enum modules

### DIFF
--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -15,7 +15,10 @@ defmodule Wanda.Catalog do
 
   require Logger
 
-  @default_severity :critical
+  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+  require Wanda.Catalog.Enums.Severity, as: Severity
+
+  @default_severity Severity.critical()
 
   @doc """
   Get the checks catalog with all checks
@@ -152,14 +155,14 @@ defmodule Wanda.Catalog do
     {:error, :malformed_check}
   end
 
-  defp map_severity(%{"severity" => "critical"}), do: :critical
-  defp map_severity(%{"severity" => "warning"}), do: :warning
+  defp map_severity(%{"severity" => "critical"}), do: Severity.critical()
+  defp map_severity(%{"severity" => "warning"}), do: Severity.warning()
   defp map_severity(_), do: @default_severity
 
   defp map_expectation(%{"name" => name, "expect" => expression} = expectation) do
     %Expectation{
       name: name,
-      type: :expect,
+      type: ExpectType.expect(),
       expression: expression,
       failure_message: Map.get(expectation, "failure_message")
     }
@@ -168,7 +171,7 @@ defmodule Wanda.Catalog do
   defp map_expectation(%{"name" => name, "expect_same" => expression} = expectation) do
     %Expectation{
       name: name,
-      type: :expect_same,
+      type: ExpectType.expect_same(),
       expression: expression,
       failure_message: Map.get(expectation, "failure_message")
     }
@@ -177,7 +180,7 @@ defmodule Wanda.Catalog do
   defp map_expectation(%{"name" => name, "expect_enum" => expression} = expectation) do
     %Expectation{
       name: name,
-      type: :expect_enum,
+      type: ExpectType.expect_enum(),
       expression: expression,
       failure_message: Map.get(expectation, "failure_message"),
       warning_message: Map.get(expectation, "warning_message")

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -3,9 +3,9 @@ defmodule Wanda.Catalog.Check do
   Represents a check.
   """
 
-  require Wanda.Catalog.Enums.Severity, as: Severity
-
   alias Wanda.Catalog.{Expectation, Fact, Value}
+
+  require Wanda.Catalog.Enums.Severity, as: Severity
 
   @derive Jason.Encoder
   defstruct [

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Catalog.Check do
   Represents a check.
   """
 
+  require Wanda.Catalog.Enums.Severity, as: Severity
+
   alias Wanda.Catalog.{Expectation, Fact, Value}
 
   @derive Jason.Encoder
@@ -27,7 +29,7 @@ defmodule Wanda.Catalog.Check do
           description: String.t(),
           remediation: String.t(),
           metadata: map(),
-          severity: :warning | :critical,
+          severity: Severity.t(),
           facts: [Fact.t()],
           values: [Value.t()],
           expectations: [Expectation.t()],

--- a/lib/wanda/catalog/enums/expect_type.ex
+++ b/lib/wanda/catalog/enums/expect_type.ex
@@ -1,0 +1,7 @@
+defmodule Wanda.Catalog.Enums.ExpectType do
+  @moduledoc """
+  Type that represents a check expectation type.
+  """
+
+  use Wanda.Support.Enum, values: [:expect, :expect_same, :expect_enum]
+end

--- a/lib/wanda/catalog/enums/severity.ex
+++ b/lib/wanda/catalog/enums/severity.ex
@@ -1,0 +1,7 @@
+defmodule Wanda.Catalog.Enums.Severity do
+  @moduledoc """
+  Type that represents a check severity.
+  """
+
+  use Wanda.Support.Enum, values: [:warning, :critical]
+end

--- a/lib/wanda/catalog/expectation.ex
+++ b/lib/wanda/catalog/expectation.ex
@@ -3,12 +3,14 @@ defmodule Wanda.Catalog.Expectation do
   Represents an expectation.
   """
 
+  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+
   @derive Jason.Encoder
   defstruct [:name, :type, :expression, :failure_message, :warning_message]
 
   @type t :: %__MODULE__{
           name: String.t(),
-          type: :expect | :expect_same | :expect_enum,
+          type: ExpectType.t(),
           expression: String.t(),
           failure_message: String.t(),
           warning_message: String.t()

--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -5,7 +5,7 @@ defmodule Wanda.Executions do
 
   import Ecto.Query
 
-  require Wanda.Expectations.Enums.Status, as: Status
+  require Wanda.Executions.Enums.Status, as: Status
 
   alias Wanda.Repo
 

--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -5,8 +5,6 @@ defmodule Wanda.Executions do
 
   import Ecto.Query
 
-  require Wanda.Executions.Enums.Status, as: Status
-
   alias Wanda.Repo
 
   alias Wanda.Executions.{
@@ -14,6 +12,8 @@ defmodule Wanda.Executions do
     Result,
     Target
   }
+
+  require Wanda.Executions.Enums.Status, as: Status
 
   @doc """
   Create a new execution.

--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -5,6 +5,8 @@ defmodule Wanda.Executions do
 
   import Ecto.Query
 
+  require Wanda.Expectations.Enums.Status, as: Status
+
   alias Wanda.Repo
 
   alias Wanda.Executions.{
@@ -24,7 +26,7 @@ defmodule Wanda.Executions do
     |> Execution.changeset(%{
       execution_id: execution_id,
       group_id: group_id,
-      status: :running,
+      status: Status.running(),
       targets: Enum.map(targets, &Map.from_struct/1)
     })
     |> Repo.insert!(on_conflict: :nothing)
@@ -93,7 +95,7 @@ defmodule Wanda.Executions do
     |> Repo.get!(execution_id)
     |> Execution.changeset(%{
       result: result,
-      status: :completed,
+      status: Status.completed(),
       completed_at: DateTime.utc_now()
     })
     |> Repo.update!()

--- a/lib/wanda/executions/check_result.ex
+++ b/lib/wanda/executions/check_result.ex
@@ -3,9 +3,9 @@ defmodule Wanda.Executions.CheckResult do
   Represents the result of a check.
   """
 
-  require Wanda.Executions.Enums.Result, as: Result
-
   alias Wanda.Executions.{AgentCheckError, AgentCheckResult, ExpectationResult}
+
+  require Wanda.Executions.Enums.Result, as: Result
 
   @derive Jason.Encoder
   defstruct [

--- a/lib/wanda/executions/check_result.ex
+++ b/lib/wanda/executions/check_result.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Executions.CheckResult do
   Represents the result of a check.
   """
 
+  require Wanda.Expectations.Enums.Result, as: Result
+
   alias Wanda.Executions.{AgentCheckError, AgentCheckResult, ExpectationResult}
 
   @derive Jason.Encoder
@@ -17,6 +19,6 @@ defmodule Wanda.Executions.CheckResult do
           check_id: String.t(),
           expectation_results: [ExpectationResult.t()],
           agents_check_results: [AgentCheckResult.t() | AgentCheckError.t()],
-          result: :passing | :warning | :critical
+          result: Result.t()
         }
 end

--- a/lib/wanda/executions/check_result.ex
+++ b/lib/wanda/executions/check_result.ex
@@ -3,7 +3,7 @@ defmodule Wanda.Executions.CheckResult do
   Represents the result of a check.
   """
 
-  require Wanda.Expectations.Enums.Result, as: Result
+  require Wanda.Executions.Enums.Result, as: Result
 
   alias Wanda.Executions.{AgentCheckError, AgentCheckResult, ExpectationResult}
 

--- a/lib/wanda/executions/enums/result.ex
+++ b/lib/wanda/executions/enums/result.ex
@@ -1,0 +1,7 @@
+defmodule Wanda.Expectations.Enums.Result do
+  @moduledoc """
+  Type that represents a check execution result.
+  """
+
+  use Wanda.Support.Enum, values: [:passing, :warning, :critical]
+end

--- a/lib/wanda/executions/enums/result.ex
+++ b/lib/wanda/executions/enums/result.ex
@@ -1,4 +1,4 @@
-defmodule Wanda.Expectations.Enums.Result do
+defmodule Wanda.Executions.Enums.Result do
   @moduledoc """
   Type that represents a check execution result.
   """

--- a/lib/wanda/executions/enums/status.ex
+++ b/lib/wanda/executions/enums/status.ex
@@ -1,0 +1,7 @@
+defmodule Wanda.Expectations.Enums.Status do
+  @moduledoc """
+  Type that represents a check execution status.
+  """
+
+  use Wanda.Support.Enum, values: [:running, :completed]
+end

--- a/lib/wanda/executions/enums/status.ex
+++ b/lib/wanda/executions/enums/status.ex
@@ -1,4 +1,4 @@
-defmodule Wanda.Expectations.Enums.Status do
+defmodule Wanda.Executions.Enums.Status do
   @moduledoc """
   Type that represents a check execution status.
   """

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -4,7 +4,7 @@ defmodule Wanda.Executions.Evaluation do
   """
 
   require Wanda.Catalog.Enums.ExpectType, as: ExpectType
-  require Wanda.Expectations.Enums.Result, as: ResultEnum
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   alias Wanda.Catalog.{Check, Condition, Expectation}
   alias Wanda.Catalog.Value, as: CatalogValue

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -3,9 +3,6 @@ defmodule Wanda.Executions.Evaluation do
   Evaluation functional core.
   """
 
-  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
-  require Wanda.Executions.Enums.Result, as: ResultEnum
-
   alias Wanda.Catalog.{Check, Condition, Expectation}
   alias Wanda.Catalog.Value, as: CatalogValue
 
@@ -22,6 +19,9 @@ defmodule Wanda.Executions.Evaluation do
   }
 
   alias Wanda.EvaluationEngine
+
+  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_failure_message "Expectation not met"
 

--- a/lib/wanda/executions/execution.ex
+++ b/lib/wanda/executions/execution.ex
@@ -7,7 +7,7 @@ defmodule Wanda.Executions.Execution do
 
   import Ecto.Changeset
 
-  require Wanda.Expectations.Enums.Status, as: Status
+  require Wanda.Executions.Enums.Status, as: Status
 
   @type t :: %__MODULE__{}
 

--- a/lib/wanda/executions/execution.ex
+++ b/lib/wanda/executions/execution.ex
@@ -7,6 +7,8 @@ defmodule Wanda.Executions.Execution do
 
   import Ecto.Changeset
 
+  require Wanda.Expectations.Enums.Status, as: Status
+
   @type t :: %__MODULE__{}
 
   @fields ~w(execution_id group_id result status started_at completed_at)a
@@ -18,7 +20,7 @@ defmodule Wanda.Executions.Execution do
     field :execution_id, Ecto.UUID, primary_key: true
     field :group_id, Ecto.UUID
     field :result, :map, default: %{}
-    field :status, Ecto.Enum, values: [:running, :completed]
+    field :status, Ecto.Enum, values: Status.values()
 
     embeds_many :targets, Target do
       @derive {Jason.Encoder, [except: [:id]]}

--- a/lib/wanda/executions/expectation_evaluation.ex
+++ b/lib/wanda/executions/expectation_evaluation.ex
@@ -4,7 +4,7 @@ defmodule Wanda.Executions.ExpectationEvaluation do
   """
 
   require Wanda.Catalog.Enums.ExpectType, as: ExpectType
-  require Wanda.Expectations.Enums.Result, as: Result
+  require Wanda.Executions.Enums.Result, as: Result
 
   @derive Jason.Encoder
   defstruct [

--- a/lib/wanda/executions/expectation_evaluation.ex
+++ b/lib/wanda/executions/expectation_evaluation.ex
@@ -3,6 +3,9 @@ defmodule Wanda.Executions.ExpectationEvaluation do
   Represents the evaluation of an expectation.
   """
 
+  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+  require Wanda.Expectations.Enums.Result, as: Result
+
   @derive Jason.Encoder
   defstruct [
     :name,
@@ -13,8 +16,8 @@ defmodule Wanda.Executions.ExpectationEvaluation do
 
   @type t :: %__MODULE__{
           name: String.t(),
-          return_value: number() | boolean() | String.t() | :passing | :warning | :critical,
-          type: :expect | :expect_same | :expect_enum,
+          return_value: number() | boolean() | String.t() | Result.t(),
+          type: ExpectType.t(),
           failure_message: String.t() | nil
         }
 end

--- a/lib/wanda/executions/expectation_result.ex
+++ b/lib/wanda/executions/expectation_result.ex
@@ -4,7 +4,7 @@ defmodule Wanda.Executions.ExpectationResult do
   """
 
   require Wanda.Catalog.Enums.ExpectType, as: ExpectType
-  require Wanda.Expectations.Enums.Result, as: Result
+  require Wanda.Executions.Enums.Result, as: Result
 
   @derive Jason.Encoder
   defstruct [

--- a/lib/wanda/executions/expectation_result.ex
+++ b/lib/wanda/executions/expectation_result.ex
@@ -3,6 +3,9 @@ defmodule Wanda.Executions.ExpectationResult do
   Represents the result of an expectation.
   """
 
+  require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+  require Wanda.Expectations.Enums.Result, as: Result
+
   @derive Jason.Encoder
   defstruct [
     :name,
@@ -13,8 +16,8 @@ defmodule Wanda.Executions.ExpectationResult do
 
   @type t :: %__MODULE__{
           name: String.t(),
-          result: boolean() | :passing | :warning | :critical,
-          type: :expect | :expect_same | :expect_enum,
+          result: boolean() | Result.t(),
+          type: ExpectType.t(),
           failure_message: String.t() | nil
         }
 end

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -3,7 +3,7 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
-  require Wanda.Expectations.Enums.Result, as: ResultEnum
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   alias Wanda.Executions.CheckResult
 

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -3,9 +3,9 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
-  require Wanda.Executions.Enums.Result, as: ResultEnum
-
   alias Wanda.Executions.CheckResult
+
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @derive Jason.Encoder
   defstruct [

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
+  require Wanda.Expectations.Enums.Result, as: ResultEnum
+
   alias Wanda.Executions.CheckResult
 
   @derive Jason.Encoder
@@ -19,6 +21,6 @@ defmodule Wanda.Executions.Result do
           group_id: String.t(),
           check_results: [CheckResult.t()],
           timeout: [String.t()],
-          result: :passing | :warning | :critical
+          result: ResultEnum.t()
         }
 end

--- a/lib/wanda/operations/agent_report.ex
+++ b/lib/wanda/operations/agent_report.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Operations.AgentReport do
   Report of an executed operation from an individual agent
   """
 
+  require Wanda.Operations.Enums.Result, as: Result
+
   defstruct [
     :agent_id,
     :result
@@ -10,6 +12,6 @@ defmodule Wanda.Operations.AgentReport do
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          result: :updated | :not_updated | :failed | :rolled_back | :skipped | :not_executed
+          result: Result.t()
         }
 end

--- a/lib/wanda/operations/enums/result.ex
+++ b/lib/wanda/operations/enums/result.ex
@@ -1,0 +1,8 @@
+defmodule Wanda.Operations.Enums.Result do
+  @moduledoc """
+  Type that represents am operation result.
+  """
+
+  use Wanda.Support.Enum,
+    values: [:updated, :not_updated, :failed, :rolled_back, :skipped, :not_executed]
+end

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -8,6 +8,8 @@ defmodule Wanda.Operations.Server do
 
   use GenServer, restart: :transient
 
+  require Wanda.Operations.Enums.Result, as: Result
+
   alias Wanda.Operations.{AgentReport, OperationTarget, State, StepReport, Supervisor}
   alias Wanda.Operations.Catalog.{Operation, Step}
 
@@ -228,7 +230,7 @@ defmodule Wanda.Operations.Server do
        ) do
     not_executed_agent_reports =
       Enum.map(targets, fn %OperationTarget{agent_id: agent_id} ->
-        %AgentReport{agent_id: agent_id, result: :not_executed}
+        %AgentReport{agent_id: agent_id, result: Result.not_executed()}
       end)
 
     agent_reports =
@@ -284,7 +286,7 @@ defmodule Wanda.Operations.Server do
     targets
     |> Enum.filter(fn %OperationTarget{agent_id: agent_id} -> agent_id not in pending_targets end)
     |> Enum.reduce(state, fn %OperationTarget{agent_id: agent_id}, acc ->
-      update_report_results(acc, step_number, agent_id, :skipped)
+      update_report_results(acc, step_number, agent_id, Result.skipped())
     end)
   end
 
@@ -337,8 +339,9 @@ defmodule Wanda.Operations.Server do
     %State{state | agent_reports: updated_agent_reports}
   end
 
-  defp maybe_set_step_failed(state, result) when result in [:failed, :rolled_back],
-    do: %State{state | step_failed: true}
+  defp maybe_set_step_failed(state, result)
+       when result in [Result.failed(), Result.rolled_back()],
+       do: %State{state | step_failed: true}
 
   defp maybe_set_step_failed(state, _), do: state
 

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -8,12 +8,12 @@ defmodule Wanda.Operations.Server do
 
   use GenServer, restart: :transient
 
-  require Wanda.Operations.Enums.Result, as: Result
-
   alias Wanda.Operations.{AgentReport, OperationTarget, State, StepReport, Supervisor}
   alias Wanda.Operations.Catalog.{Operation, Step}
 
   alias Wanda.EvaluationEngine
+
+  require Wanda.Operations.Enums.Result, as: Result
 
   require Logger
 

--- a/lib/wanda/operations/server_behaviour.ex
+++ b/lib/wanda/operations/server_behaviour.ex
@@ -3,6 +3,8 @@ defmodule Wanda.Operations.ServerBehaviour do
   Operation server API behaviour.
   """
 
+  require Wanda.Operations.Enums.Result, as: Result
+
   alias Wanda.Operations.Catalog.Operation
   alias Wanda.Operations.OperationTarget
 
@@ -34,7 +36,7 @@ defmodule Wanda.Operations.ServerBehaviour do
               group_id :: String.t(),
               step_id :: number(),
               agent_id :: String.t(),
-              operation_result :: :updated | :not_updated | :failed | :rolled_back
+              operation_result :: Result.t()
             ) ::
               :ok | {:error, any}
 end

--- a/lib/wanda/operations/server_behaviour.ex
+++ b/lib/wanda/operations/server_behaviour.ex
@@ -3,10 +3,10 @@ defmodule Wanda.Operations.ServerBehaviour do
   Operation server API behaviour.
   """
 
-  require Wanda.Operations.Enums.Result, as: Result
-
   alias Wanda.Operations.Catalog.Operation
   alias Wanda.Operations.OperationTarget
+
+  require Wanda.Operations.Enums.Result, as: Result
 
   @callback start_operation(
               operation_id :: String.t(),

--- a/lib/wanda/support/enum.ex
+++ b/lib/wanda/support/enum.ex
@@ -1,0 +1,24 @@
+defmodule Wanda.Support.Enum do
+  @moduledoc """
+  Enum  module with added macros to define a type,
+  check supported values and validate possible values
+  """
+
+  defmacro __using__(opts) do
+    values = Keyword.fetch!(opts, :values)
+
+    quote do
+      @type t :: unquote(Enum.reduce(values, &{:|, [], [&1, &2]}))
+
+      defmacro values, do: unquote(values)
+
+      unquote(
+        Enum.map(values, fn value ->
+          quote do
+            defmacro unquote(value)(), do: unquote(value)
+          end
+        end)
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Description

Create and use enum modules.
We already have this piece of code in `web`, which is pretty nice.
This simply uses this module, without adding any new change.

