### PR TITLE
Operations registry

### DIFF
--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -21,4 +21,14 @@ defmodule Wanda.Operations.Catalog.Operation do
           steps: [Step.t()],
           required_args: [String.t()]
         }
+
+  defmacro __using__(opts) do
+    operation = opts[:operation]
+
+    quote do
+      def operation() do
+        unquote(operation)
+      end
+    end
+  end
 end

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -9,6 +9,7 @@ defmodule Wanda.Operations.Catalog.Operation do
   defstruct [
     :id,
     :name,
+    :description,
     :steps,
     required_args: []
   ]
@@ -16,6 +17,7 @@ defmodule Wanda.Operations.Catalog.Operation do
   @type t :: %__MODULE__{
           id: String.t(),
           name: String.t(),
+          description: String.t(),
           steps: [Step.t()],
           required_args: [String.t()]
         }

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -26,7 +26,7 @@ defmodule Wanda.Operations.Catalog.Operation do
     operation = opts[:operation]
 
     quote do
-      def operation() do
+      def operation do
         unquote(operation)
       end
     end

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -1,0 +1,38 @@
+defmodule Wanda.Operations.Catalog.Registry do
+  @moduledoc """
+  Operations registry where are available operations are listed
+  """
+
+  alias Wanda.Operations.Catalog.{Operation, Step}
+
+  @saptuneapplysolution_v1 %Operation{
+    id: "saptuneapplysolution@v1",
+    name: "Apply saptune solution",
+    description: """
+    This solution applies a saptune solution in the targets.
+    """,
+    required_args: ["solution"],
+    steps: [
+      %Step{
+        name: "Apply solution",
+        operator: "saptuneapplysolution@v1",
+        predicate: "*"
+      }
+    ]
+  }
+
+  @registry %{
+    "saptuneapplysolution@v1" => @saptuneapplysolution_v1
+  }
+
+  @doc """
+  Get an operation by id
+  """
+  @spec get_operation(String.t()) :: {:ok, Operation.t()} | {:error, :operation_not_found}
+  def get_operation(id) do
+    case Map.get(@registry, id) do
+      nil -> {:error, :operation_not_found}
+      operation -> {:ok, operation}
+    end
+  end
+end

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -3,26 +3,12 @@ defmodule Wanda.Operations.Catalog.Registry do
   Operations registry where are available operations are listed
   """
 
-  alias Wanda.Operations.Catalog.{Operation, Step}
+  alias Wanda.Operations.Catalog.Operation
 
-  @saptuneapplysolution_v1 %Operation{
-    id: "saptuneapplysolution@v1",
-    name: "Apply saptune solution",
-    description: """
-    This solution applies a saptune solution in the targets.
-    """,
-    required_args: ["solution"],
-    steps: [
-      %Step{
-        name: "Apply solution",
-        operator: "saptuneapplysolution@v1",
-        predicate: "*"
-      }
-    ]
-  }
+  alias Wanda.Operations.Catalog.SaptuneApplySolutionV1
 
   @registry %{
-    "saptuneapplysolution@v1" => @saptuneapplysolution_v1
+    "saptuneapplysolution@v1" => SaptuneApplySolutionV1.operation()
   }
 
   @doc """

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -12,6 +12,14 @@ defmodule Wanda.Operations.Catalog.Registry do
   }
 
   @doc """
+  Get all operations
+  """
+  @spec get_operations() :: [Operation.t()]
+  def get_operations do
+    Map.values(@registry)
+  end
+
+  @doc """
   Get an operation by id
   """
   @spec get_operation(String.t()) :: {:ok, Operation.t()} | {:error, :operation_not_found}

--- a/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
@@ -1,8 +1,8 @@
 defmodule Wanda.Operations.Catalog.SaptuneApplySolutionV1 do
-  alias Wanda.Operations.Catalog.{Operation, Step}
+  @moduledoc false
 
-  use Operation,
-    operation: %Operation{
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
       id: "saptuneapplysolution@v1",
       name: "Apply saptune solution",
       description: """
@@ -10,7 +10,7 @@ defmodule Wanda.Operations.Catalog.SaptuneApplySolutionV1 do
       """,
       required_args: ["solution"],
       steps: [
-        %Step{
+        %Wanda.Operations.Catalog.Step{
           name: "Apply solution",
           operator: "saptuneapplysolution@v1",
           predicate: "*"

--- a/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
@@ -6,7 +6,7 @@ defmodule Wanda.Operations.Catalog.SaptuneApplySolutionV1 do
       id: "saptuneapplysolution@v1",
       name: "Apply saptune solution",
       description: """
-      This solution applies a saptune solution in the targets.
+      This operation applies a saptune solution in the targets.
       """,
       required_args: ["solution"],
       steps: [

--- a/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
@@ -1,0 +1,20 @@
+defmodule Wanda.Operations.Catalog.SaptuneApplySolutionV1 do
+  alias Wanda.Operations.Catalog.{Operation, Step}
+
+  use Operation,
+    operation: %Operation{
+      id: "saptuneapplysolution@v1",
+      name: "Apply saptune solution",
+      description: """
+      This solution applies a saptune solution in the targets.
+      """,
+      required_args: ["solution"],
+      steps: [
+        %Step{
+          name: "Apply solution",
+          operator: "saptuneapplysolution@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end

--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -6,11 +6,13 @@ defmodule Wanda.Operations.Catalog.Step do
   """
 
   defstruct [
+    :name,
     :operator,
     :predicate
   ]
 
   @type t :: %__MODULE__{
+          name: String.t(),
           operator: String.t(),
           predicate: String.t()
         }

--- a/test/wanda/operations/catalog/registry_test.exs
+++ b/test/wanda/operations/catalog/registry_test.exs
@@ -1,0 +1,26 @@
+defmodule Wanda.Operations.Catalog.RegistryTest do
+  use ExUnit.Case
+
+  alias Wanda.Operations.Catalog.{
+    Operation,
+    Registry
+  }
+
+  describe "operations" do
+    test "should return all existing operations" do
+      Enum.each(Registry.get_operations(), fn op ->
+        assert %Operation{} = op
+      end)
+    end
+
+    test "should return operation by id" do
+      assert {:ok, %Operation{id: "saptuneapplysolution@v1"}} =
+               Registry.get_operation("saptuneapplysolution@v1")
+    end
+
+    test "should return a not found error if operation does not exist" do
+      assert {:error, :operation_not_found} =
+               Registry.get_operation("somenastyoperation")
+    end
+  end
+end


### PR DESCRIPTION
# Description

Create the operations registry to give functionalities to load already existing operations.
Finally, I have decided to put 1 operation per file.
I don't know how this can scale, but it looks simpler to find things.
Besides, I have used meaningful names as `id`, as strange hex values don't say anything, and as this is an internal implementation detail, it looks better.

## How was this tested?
UT
