### PR TITLE
Add customizable key to disable checks customization for certain checks

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -91,6 +91,9 @@
         "name": {
           "type": "string"
         },
+        "customizable": {
+          "type": "boolean"
+        },
         "default": {
           "anyOf": [
             {

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -37,6 +37,9 @@
         "$ref": "#/definitions/Fact"
       }
     },
+    "customizable": {
+      "type": "string"
+    },
     "values": {
       "type": "array",
       "items": {

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -38,7 +38,7 @@
       }
     },
     "customizable": {
-      "type": "string"
+      "type": "boolean"
     },
     "values": {
       "type": "array",

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -353,15 +353,11 @@ Finally, gathered facts, are used in Check's [Expectations](#expectations) to de
 
 ## Customizable
 
-Wanda's built-in checks, which include expected values, are **customizable** by **default**. Users can modify these check values through the [Trento Web console](https://github.com/trento-project/web) to adapt to specific system and environmental configurations.
+Users can modify a check's [expected values](#values) to adapt to specific system and environmental configurations.
+
+Built-in checks are considered **customizable** by **default**, so the `customizable` flag disables customization for a particular check.
 
 To explicitly mark a check as non-customizable, set the `customizable`  key to `false`:
-
-```yaml
-customizable: false
-```
-
-To explicitly mark a check as customizable, set the `customizable` key to `true`:
 
 ```yaml
 customizable: false

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -353,9 +353,15 @@ Finally, gathered facts, are used in Check's [Expectations](#expectations) to de
 
 ## Customizable
 
-Wanda's built-in checks, which include expected values,are **customizable** by **default**. This means you can modify their values in [Trento Web console](https://github.com/trento-project/web).
+Wanda's built-in checks, which include expected values, are **customizable** by **default**. Users can modify these check values through the [Trento Web console](https://github.com/trento-project/web) to adapt to specific system and environmental configurations.
 
-A check can be configured as not customizable by adding the key `customizable`:
+To explicitly mark a check as non-customizable, set the `customizable`  key to `false`:
+
+```yaml
+customizable: false
+```
+
+To explicitly mark a check as customizable, set the `customizable` key to `true`:
 
 ```yaml
 customizable: false

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -358,8 +358,8 @@ Users can modify a check's [expected values](#values) to adapt to specific syste
 
 Built-in checks are considered **customizable** by **default**, so the `customizable` flag disables customization for a particular check.
 
-The customizability flag can be set global in the check and|or in [values](#customizable-values). 
-When both levels are set, the **global** flag takes **precedence**, overriding any value-level customizability.
+The customizability flag can be set globally for a check and|or for [specific values](#customizable-values).
+When customization is globally disabled for a check, marked with `customizable: false`, it overrides any value-specific customizability settings. If global customization is not disabled, the customizability of individual values is then considered.
 
 To explicitly mark a check as non-customizable, set the `customizable`  key to `false`:
 

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -91,6 +91,7 @@ customizable: true
 
 values:
   - name: expected_token_timeout
+    customizable: true
     default: 5000
     conditions:
       - value: 30000
@@ -357,6 +358,9 @@ Users can modify a check's [expected values](#values) to adapt to specific syste
 
 Built-in checks are considered **customizable** by **default**, so the `customizable` flag disables customization for a particular check.
 
+The customizability flag can be set global in the check and|or in [values](#customizable-values). 
+When both levels are set, the **global** flag takes **precedence**, overriding any value-level customizability.
+
 To explicitly mark a check as non-customizable, set the `customizable`  key to `false`:
 
 ```yaml
@@ -475,6 +479,21 @@ Note that `conditions` is a cascading chain of contextual inspection to determin
 - `when` entry [Expression](#expression-language) has [access](#evaluation-scope) to gathered [facts](#facts-1) and [env](#env) evaluation scopes
 
 All the _resolved_ declared values would be registered in the [`values`](#values-1) namespaced evaluation scope.
+
+### Customizable Values
+
+In addition to the global-level [customizability](#customizable), individual check values are also **customizable** by **default**. To provide finer control, a `boolean` customizable entry can be defined on a per-value basis.
+
+```yaml
+values:
+  - name: non_customizable_check_value
+    customizable: false
+    default: 5000
+```
+
+Setting **customizable**: `false` for a specific value prevents the modification of the default value.
+
+Note that if global customizability is set to false, it takes precedence over any value-level customizable settings, disabling customizability for all associated values.
 
 ## Expectations
 

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -87,6 +87,8 @@ facts:
     gatherer: corosync.conf
     argument: totem.token
 
+customizable: true
+
 values:
   - name: expected_token_timeout
     default: 5000
@@ -119,6 +121,7 @@ Following are listed the top level properties of a Check definition yaml.
 | `severity`     | not required          | [see more](#severity)     |
 | `metadata`     | not required          | [see more](#metadata)     |
 | `facts`        | required              | [see more](#facts)        |
+| `customizable` | not required          | [see more](#customizable) |
 | `values`       | not required          | [see more](#values)       |
 | `expectations` | required              | [see more](#expectations) |
 
@@ -347,6 +350,16 @@ facts:
 ```
 
 Finally, gathered facts, are used in Check's [Expectations](#expectations) to determine whether expected conditions are met for the best practice to be adhered.
+
+## Customizable
+
+Wanda's built-in checks, which include expected values,are **customizable** by **default**. This means you can modify their values in [Trento Web console](https://github.com/trento-project/web).
+
+A check can be configured as not customizable by adding the key `customizable`:
+
+```yaml
+customizable: false
+```
 
 ## Values
 


### PR DESCRIPTION
# Description

This PR is one of the first steps to enable users to customize checks. 
It adds a new key "customization" for checks. By default all checks with values are customization. 
In order to disable this behavior it needs to be explicitly set to false . 
This is needed to disable checks  like [3A59DC](https://github.com/trento-project/checks/blob/93beb612654381f06832ea43bf907556686625ed/checks/3A59DC.yaml) as changing it's value may cause issues.

## To Do:

After merging this we need to update [tlint repo  reference](https://github.com/trento-project/tlint/commit/32be1c8e4b672a241d716a5e24eec727f2012f1b)  to the new reference.

