### PR TITLE
Operations timeout

### DIFF
--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -5,13 +5,17 @@ defmodule Wanda.Operations.Catalog.Step do
   defining if the step needs to be executed in a certain agent.
   """
 
+  @default_timeout 5 * 60 * 1_000
+
   defstruct [
     :operator,
-    :predicate
+    :predicate,
+    timeout: @default_timeout
   ]
 
   @type t :: %__MODULE__{
           operator: String.t(),
-          predicate: String.t()
+          predicate: String.t(),
+          timeout: integer()
         }
 end

--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -16,6 +16,6 @@ defmodule Wanda.Operations.Catalog.Step do
   @type t :: %__MODULE__{
           operator: String.t(),
           predicate: String.t(),
-          timeout: integer()
+          timeout: non_neg_integer()
         }
 end

--- a/lib/wanda/operations/enums/result.ex
+++ b/lib/wanda/operations/enums/result.ex
@@ -4,5 +4,5 @@ defmodule Wanda.Operations.Enums.Result do
   """
 
   use Wanda.Support.Enum,
-    values: [:updated, :not_updated, :failed, :rolled_back, :skipped, :not_executed]
+    values: [:updated, :not_updated, :failed, :rolled_back, :timeout, :skipped, :not_executed]
 end

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -22,7 +22,11 @@ defmodule Wanda.Operations.Server do
   @default_timeout 5 * 60 * 1_000
 
   @impl true
-  def start_operation(operation_id, group_id, operation, targets, config \\ []) do
+  def start_operation(operation_id, group_id, operation, targets, config \\ [])
+
+  def start_operation(_, _, _, [], _), do: {:error, :targets_missing}
+
+  def start_operation(operation_id, group_id, operation, targets, config) do
     %Operation{required_args: required_args} = operation
 
     # Check if all targets have the required arguments

--- a/lib/wanda/operations/server_behaviour.ex
+++ b/lib/wanda/operations/server_behaviour.ex
@@ -17,7 +17,7 @@ defmodule Wanda.Operations.ServerBehaviour do
               :ok
               | {:error, :arguments_missing}
               | {:error, :already_running}
-              | {:error, :operation_not_found}
+              | {:error, :targets_missing}
 
   @callback start_operation(
               operation_id :: String.t(),
@@ -29,7 +29,7 @@ defmodule Wanda.Operations.ServerBehaviour do
               :ok
               | {:error, :arguments_missing}
               | {:error, :already_running}
-              | {:error, :operation_not_found}
+              | {:error, :targets_missing}
 
   @callback receive_operation_reports(
               operation_id :: String.t(),

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -23,7 +23,6 @@ defmodule Wanda.Operations.State do
     :operation_id,
     :group_id,
     :operation,
-    :timeout,
     :timer_ref,
     targets: [],
     pending_targets_on_step: [],
@@ -42,7 +41,6 @@ defmodule Wanda.Operations.State do
           pending_targets_on_step: [String.t()],
           current_step_index: integer(),
           step_failed: boolean(),
-          timeout: integer(),
           timer_ref: reference()
         }
 end

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -24,6 +24,7 @@ defmodule Wanda.Operations.State do
     :group_id,
     :operation,
     :timeout,
+    :timer_ref,
     targets: [],
     pending_targets_on_step: [],
     current_step_index: 0,
@@ -41,6 +42,7 @@ defmodule Wanda.Operations.State do
           pending_targets_on_step: [String.t()],
           current_step_index: integer(),
           step_failed: boolean(),
-          timeout: integer()
+          timeout: integer(),
+          timer_ref: reference()
         }
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -224,7 +224,8 @@ defmodule Wanda.Factory do
   def operation_step_factory do
     %Step{
       operator: Faker.StarWars.planet(),
-      predicate: "*"
+      predicate: "*",
+      timeout: 10_000
     }
   end
 

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -362,7 +362,7 @@ defmodule Wanda.Operations.ServerTest do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
 
-      operation = build(:catalog_operation)
+      operation = build(:catalog_operation, steps: build_list(2, :operation_step, timeout: 0))
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)
@@ -372,7 +372,7 @@ defmodule Wanda.Operations.ServerTest do
         group_id,
         operation,
         targets,
-        [{:timeout, 0}]
+        []
       )
 
       pid = :global.whereis_name({Server, group_id})

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -9,6 +9,19 @@ defmodule Wanda.Operations.ServerTest do
   require Wanda.Operations.Enums.Status, as: Status
 
   describe "operation execution" do
+    test "should not start operation if targets are missing" do
+      catalog_operation = build(:catalog_operation)
+
+      assert {:error, :targets_missing} =
+               Server.start_operation(
+                 UUID.uuid4(),
+                 UUID.uuid4(),
+                 catalog_operation,
+                 [],
+                 %{}
+               )
+    end
+
     test "should not start operation if required arguments on targets are missing" do
       catalog_operation = build(:catalog_operation, required_args: ["arg1", "arg2"])
 


### PR DESCRIPTION
# Description

Handle operation step timeout. When the timeout is reached, the result of missing agent is set to `timeout`.
In order to make it more flexible, the timeout is defined in each step, so we can individualize this value.

By now, the operation is simply terminated. In the future, we can decide to do something else (some sort of rollback, for example)

## How was this tested?

UT added
