### PR TITLE
Operations controller

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,8 @@ config :rustler_precompiled, :force_build, rhai_rustler: true
 
 config :wanda,
   cors_enabled: true,
-  jwt_authentication_enabled: true
+  jwt_authentication_enabled: true,
+  operations_enabled: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -26,6 +26,9 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   ],
   processor: Wanda.Messaging.Adapters.AMQP.Processor
 
+config :wanda,
+  operations_enabled: false
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -9,8 +9,8 @@ defmodule WandaWeb.V1.OperationController do
   alias WandaWeb.Schemas.NotFound
 
   alias WandaWeb.Schemas.V1.Operation.{
-    OperationResponse,
-    ListOperationsResponse
+    ListOperationsResponse,
+    OperationResponse
   }
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -1,0 +1,69 @@
+defmodule WandaWeb.V1.OperationController do
+  use WandaWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias OpenApiSpex.Schema
+
+  alias Wanda.Operations
+
+  alias WandaWeb.Schemas.NotFound
+
+  alias WandaWeb.Schemas.V1.Operation.{
+    OperationResponse,
+    ListOperationsResponse
+  }
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  action_fallback WandaWeb.FallbackController
+
+  operation :index,
+    summary: "List operations",
+    parameters: [
+      group_id: [
+        in: :query,
+        description: "Filter by group ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ],
+      page: [in: :query, description: "Page", type: :integer, example: 3],
+      items_per_page: [in: :query, description: "Items per page", type: :integer, example: 20]
+    ],
+    responses: [
+      ok: {"List operations response", "application/json", ListOperationsResponse},
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def index(conn, params) do
+    operations = Operations.list_operations(params)
+
+    render(conn, operations: operations)
+  end
+
+  operation :show,
+    summary: "Get an operation by ID",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Operation ID",
+        type: %Schema{
+          type: :string,
+          format: :uuid
+        },
+        example: "00000000-0000-0000-0000-000000000001"
+      ]
+    ],
+    responses: [
+      ok: {"Operation", "application/json", OperationResponse},
+      not_found: NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def show(conn, %{id: operation_id}) do
+    operation = Operations.get_operation!(operation_id)
+
+    render(conn, operation: operation)
+  end
+end

--- a/lib/wanda_web/controllers/v1/operation_json.ex
+++ b/lib/wanda_web/controllers/v1/operation_json.ex
@@ -1,0 +1,38 @@
+defmodule WandaWeb.V1.OperationJSON do
+  alias Wanda.Operations.Operation
+
+  def index(%{operations: operations}) do
+    %{
+      items: Enum.map(operations, &operation/1),
+      total_count: length(operations)
+    }
+  end
+
+  def show(%{operation: operation}) do
+    operation(operation)
+  end
+
+  defp operation(%Operation{
+         operation_id: operation_id,
+         group_id: group_id,
+         result: result,
+         status: status,
+         targets: targets,
+         agent_reports: agent_reports,
+         started_at: started_at,
+         updated_at: updated_at,
+         completed_at: completed_at
+       }) do
+    %{
+      operation_id: operation_id,
+      group_id: group_id,
+      result: result,
+      status: status,
+      targets: targets,
+      agent_reports: agent_reports,
+      started_at: started_at,
+      updated_at: updated_at,
+      completed_at: completed_at
+    }
+  end
+end

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -58,6 +58,14 @@ defmodule WandaWeb.Router do
         post "/executions/start", ExecutionController, :start
         get "/catalog", CatalogController, :catalog
       end
+
+      if Application.compile_env!(:wanda, :operations_enabled) do
+        scope "/operations" do
+          pipe_through [:api_v1, :protected_api]
+
+          resources "/executions", OperationController, only: [:index, :show]
+        end
+      end
     end
 
     scope "/v2", WandaWeb.V2 do

--- a/lib/wanda_web/schemas/v1/operation/agent_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/agent_report.ex
@@ -1,0 +1,24 @@
+defmodule WandaWeb.Schemas.V1.Operation.AgentReport do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require Wanda.Operations.Enums.Result, as: Result
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "AgentReport",
+      description: "Individual agent report of an operation",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+        result: %Schema{type: :string, enum: Result.values()}
+      },
+      required: [:agent_id, :result]
+    },
+    struct?: false
+  )
+end

--- a/lib/wanda_web/schemas/v1/operation/list_operations_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/list_operations_response.ex
@@ -1,0 +1,25 @@
+defmodule WandaWeb.Schemas.V1.Operation.ListOperationsResponse do
+  @moduledoc """
+  Operation list response API spec
+  """
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Operation.OperationResponse
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "ListOperationsResponse",
+      description: "The paginated list of operations",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        items: %Schema{type: :array, items: OperationResponse},
+        total_count: %Schema{type: :integer, description: "Total count of operations"}
+      }
+    },
+    struct?: false
+  )
+end

--- a/lib/wanda_web/schemas/v1/operation/operation_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_response.ex
@@ -1,0 +1,60 @@
+defmodule WandaWeb.Schemas.V1.Operation.OperationResponse do
+  @moduledoc """
+  Operation item response API spec
+  """
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Operation.{
+    StepReport,
+    OperationTarget
+  }
+
+  require Wanda.Operations.Enums.Result, as: Result
+  require Wanda.Operations.Enums.Status, as: Status
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "OperationResponse",
+      description: "The representation of an operation, it may be a running or completed one",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        operation_id: %Schema{type: :string, format: :uuid, description: "Operation ID"},
+        group_id: %Schema{type: :string, format: :uuid, description: "Group ID"},
+        status: %Schema{
+          type: :string,
+          enum: Status.values(),
+          description: "The status of the current operation"
+        },
+        result: %Schema{
+          type: :string,
+          nullable: true,
+          enum: Result.values(),
+          description: "Aggregated result of the operation, unknown for running ones"
+        },
+        targets: %Schema{type: :array, items: OperationTarget},
+        agent_reports: %Schema{type: :array, nullable: true, items: StepReport},
+        started_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Operation start time"
+        },
+        updated_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Operation last update time"
+        },
+        completed_at: %Schema{
+          type: :string,
+          nullable: true,
+          format: :"date-time",
+          description: "Operation completion time"
+        }
+      }
+    },
+    struct?: false
+  )
+end

--- a/lib/wanda_web/schemas/v1/operation/operation_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_response.ex
@@ -6,8 +6,8 @@ defmodule WandaWeb.Schemas.V1.Operation.OperationResponse do
   alias OpenApiSpex.Schema
 
   alias WandaWeb.Schemas.V1.Operation.{
-    StepReport,
-    OperationTarget
+    OperationTarget,
+    StepReport
   }
 
   require Wanda.Operations.Enums.Result, as: Result

--- a/lib/wanda_web/schemas/v1/operation/operation_target.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_target.ex
@@ -1,0 +1,32 @@
+defmodule WandaWeb.Schemas.V1.Operation.OperationTarget do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "OperationTarget",
+      description: "Target where operations are executed",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
+        arguments: %Schema{
+          type: :object,
+          description: "Arguments map",
+          additionalProperties: %Schema{
+            oneOf: [
+              %Schema{type: :string},
+              %Schema{type: :integer},
+              %Schema{type: :boolean}
+            ]
+          }
+        }
+      },
+      required: [:agent_id, :arguments]
+    },
+    struct?: false
+  )
+end

--- a/lib/wanda_web/schemas/v1/operation/step_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/step_report.ex
@@ -1,0 +1,24 @@
+defmodule WandaWeb.Schemas.V1.Operation.StepReport do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  alias WandaWeb.Schemas.V1.Operation.AgentReport
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(
+    %{
+      title: "StepReport",
+      description: "Operation step report",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        step_number: %Schema{type: :integer, description: "Step number"},
+        agents: %Schema{type: :array, items: AgentReport}
+      },
+      required: [:step_number, :agents]
+    },
+    struct?: false
+  )
+end

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -56,6 +56,34 @@ defmodule Wanda.OperationsTest do
     end
   end
 
+  describe "list operations" do
+    test "should list all operations sorted by newest to oldest" do
+      operations = insert_list(3, :operation)
+
+      assert Enum.reverse(operations) == Operations.list_operations()
+    end
+
+    test "should list operations grouped by group_id" do
+      group_id = UUID.uuid4()
+      insert_list(3, :operation, group_id: UUID.uuid4())
+      operations = insert_list(3, :operation, group_id: group_id)
+      insert_list(3, :operation, group_id: UUID.uuid4())
+
+      assert Enum.reverse(operations) == Operations.list_operations(%{group_id: group_id})
+    end
+
+    test "should list operations paginated and with items per page" do
+      operations = insert_list(10, :operation)
+
+      expected_operartions =
+        operations
+        |> Enum.reverse()
+        |> Enum.slice(3, 3)
+
+      assert expected_operartions == Operations.list_operations(%{page: 2, items_per_page: 3})
+    end
+  end
+
   describe "update agent reports" do
     test "should update agent reports on a running operation" do
       %Operation{

--- a/test/wanda_web/controllers/v1/operation_controller_test.exs
+++ b/test/wanda_web/controllers/v1/operation_controller_test.exs
@@ -1,0 +1,55 @@
+defmodule WandaWeb.V1.OperationControllerTest do
+  use WandaWeb.ConnCase, async: true
+
+  import OpenApiSpex.TestAssertions
+  import Wanda.Factory
+
+  alias WandaWeb.Schemas.V1.ApiSpec
+
+  describe "list operations" do
+    test "should return a list of operations", %{conn: conn} do
+      insert_list(5, :operation)
+
+      json =
+        conn
+        |> get("/api/v1/operations/executions")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "ListOperationsResponse", api_spec)
+    end
+
+    test "should return a 422 status code if an invalid paramaters is passed", %{conn: conn} do
+      conn = get(conn, "/api/v1/operations/executions?limit=invalid")
+
+      assert 422 == conn.status
+    end
+  end
+
+  describe "get operation" do
+    test "should return an operation", %{conn: conn} do
+      %{operation_id: operation_id} = insert(:operation)
+
+      json =
+        conn
+        |> get("/api/v1/operations/executions/#{operation_id}")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "OperationResponse", api_spec)
+    end
+
+    test "should return an operation with agent reports", %{conn: conn} do
+      %{operation_id: operation_id} =
+        insert(:operation, agent_reports: build_list(2, :step_report))
+
+      json =
+        conn
+        |> get("/api/v1/operations/executions/#{operation_id}")
+        |> json_response(200)
+
+      api_spec = ApiSpec.spec()
+      assert_schema(json, "OperationResponse", api_spec)
+    end
+  end
+end

--- a/test/wanda_web/controllers/v1/operation_json_test.exs
+++ b/test/wanda_web/controllers/v1/operation_json_test.exs
@@ -1,0 +1,31 @@
+defmodule WandaWeb.V1.OperationJSONTest do
+  use ExUnit.Case, async: true
+
+  import Wanda.Factory
+
+  alias WandaWeb.V1.OperationJSON
+
+  describe "OperationJSON" do
+    test "renders index.json" do
+      operations = build_list(5, :operation)
+
+      expected_operations =
+        Enum.map(operations, fn operation -> Map.drop(operation, [:__meta__, :__struct__]) end)
+
+      assert %{
+               items: ^expected_operations,
+               total_count: 5
+             } =
+               OperationJSON.index(%{
+                 operations: operations
+               })
+    end
+
+    test "renders show.json for a running execution" do
+      operation = build(:operation)
+      expected_operation = Map.drop(operation, [:__meta__, :__struct__])
+
+      assert ^expected_operation = OperationJSON.show(%{operation: operation})
+    end
+  end
+end


### PR DESCRIPTION
# Description

Expose the operations through the http api.
I have chosen `/api/v1/operations/executions` for no particular reason. I didn't want to put simply `/api/v1/operations`, as maybe we want to add other things to operations. Anyway, this is guarded with a compilation environment, so we can change without any real consequence by now.

The `operations_enable` configuration entry is to avoid shipping this to prod before we have all the features in place

## How was this tested?

UT