### PR TITLE
relax rust requirement to allow for patch updates

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -29,7 +29,7 @@ BuildRequires:  erlang == 24
 BuildRequires:  elixir-hex
 BuildRequires:  erlang-rebar3
 BuildRequires:  git-core
-BuildRequires:  rust+cargo == 1.81
+BuildRequires:  rust+cargo >= 1.81, rust-cargo < 1.82
 Requires:       trento-checks
 
 %description


### PR DESCRIPTION
of course the OBS build now fails because 1.81.0 was just pushed out by openSUSE maintainers.