### PR TITLE
Enrich catalog operation data

### DIFF
--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -27,8 +27,6 @@ defmodule Wanda.Operations do
   @spec create_operation!(String.t(), String.t(), String.t(), [OperationTarget.t()]) ::
           Operation.t()
   def create_operation!(operation_id, group_id, catalog_operation_id, targets) do
-    Registry.get_operation!(catalog_operation_id)
-
     %Operation{}
     |> Operation.changeset(%{
       operation_id: operation_id,

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -6,6 +6,7 @@ defmodule Wanda.Operations.Catalog.Operation do
 
   alias Wanda.Operations.Catalog.Step
 
+  @derive Jason.Encoder
   defstruct [
     :id,
     :name,

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -16,7 +16,7 @@ defmodule Wanda.Operations.Catalog.Registry do
   """
   @spec get_operations() :: [Operation.t()]
   def get_operations do
-    Map.values(@registry)
+    Map.values(registry())
   end
 
   @doc """
@@ -24,7 +24,7 @@ defmodule Wanda.Operations.Catalog.Registry do
   """
   @spec get_operation(String.t()) :: {:ok, Operation.t()} | {:error, :operation_not_found}
   def get_operation(id) do
-    case Map.get(@registry, id) do
+    case Map.get(registry(), id) do
       nil -> {:error, :operation_not_found}
       operation -> {:ok, operation}
     end
@@ -35,6 +35,10 @@ defmodule Wanda.Operations.Catalog.Registry do
   """
   @spec get_operation!(String.t()) :: Operation.t()
   def get_operation!(id) do
-    Map.fetch!(@registry, id)
+    Map.fetch!(registry(), id)
+  end
+
+  defp registry do
+    Application.get_env(:wanda, :operations_registry, @registry)
   end
 end

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -29,4 +29,12 @@ defmodule Wanda.Operations.Catalog.Registry do
       operation -> {:ok, operation}
     end
   end
+
+  @doc """
+  Get an operation by id, erroring out if the entry doesn't exist
+  """
+  @spec get_operation!(String.t()) :: Operation.t()
+  def get_operation!(id) do
+    Map.fetch!(@registry, id)
+  end
 end

--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -7,6 +7,7 @@ defmodule Wanda.Operations.Catalog.Step do
 
   @default_timeout 5 * 60 * 1_000
 
+  @derive Jason.Encoder
   defstruct [
     :name,
     :operator,

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -7,6 +7,8 @@ defmodule Wanda.Operations.Operation do
 
   import Ecto.Changeset
 
+  alias Wanda.Operations.Catalog.Registry
+
   require Wanda.Operations.Enums.Result, as: Result
   require Wanda.Operations.Enums.Status, as: Status
 
@@ -48,11 +50,22 @@ defmodule Wanda.Operations.Operation do
     |> cast(params, @fields)
     |> cast_embed(:targets, with: &target_changeset/2, required: true)
     |> validate_required(@required_fields)
+    |> validate_change(:catalog_operation_id, &validate_catalog_operation_id/2)
   end
 
   defp target_changeset(target, params) do
     target
     |> cast(params, @target_fields)
     |> validate_required(@targets_required_fields)
+  end
+
+  defp validate_catalog_operation_id(:catalog_operation_id, catalog_operation_id) do
+    case Registry.get_operation(catalog_operation_id) do
+      {:error, :operation_not_found} ->
+        [catalog_operation_id: "not found"]
+
+      _ ->
+        []
+    end
   end
 end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -12,7 +12,7 @@ defmodule Wanda.Operations.Operation do
 
   @type t :: %__MODULE__{}
 
-  @fields ~w(operation_id group_id result status agent_reports started_at updated_at completed_at)a
+  @fields ~w(operation_id group_id result status agent_reports catalog_operation_id started_at updated_at completed_at)a
   @target_fields ~w(agent_id arguments)a
 
   @required_fields ~w(operation_id group_id result status)a
@@ -34,6 +34,9 @@ defmodule Wanda.Operations.Operation do
     end
 
     field :agent_reports, {:array, :map}
+
+    field :catalog_operation_id, :string
+    field :catalog_operation, :map, virtual: true
 
     field :completed_at, :utc_datetime_usec
     timestamps(type: :utc_datetime_usec, inserted_at: :started_at)

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -80,13 +80,16 @@ defmodule Wanda.Operations.Server do
         %State{
           operation_id: operation_id,
           group_id: group_id,
-          targets: targets
+          targets: targets,
+          operation: %Operation{
+            id: catalog_operation_id
+          }
         } = state
       ) do
     engine = EvaluationEngine.new()
     new_state = initialize_report_results(state)
 
-    Operations.create_operation!(operation_id, group_id, targets)
+    Operations.create_operation!(operation_id, group_id, catalog_operation_id, targets)
 
     {:noreply, %State{new_state | engine: engine}, {:continue, :execute_step}}
   end

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -38,8 +38,9 @@ defmodule WandaWeb.V1.OperationController do
 
   def index(conn, params) do
     operations = Operations.list_operations(params)
+    enriched_operations = Enum.map(operations, &Operations.enrich_operation!(&1))
 
-    render(conn, operations: operations)
+    render(conn, operations: enriched_operations)
   end
 
   operation :show,
@@ -62,7 +63,10 @@ defmodule WandaWeb.V1.OperationController do
     ]
 
   def show(conn, %{id: operation_id}) do
-    operation = Operations.get_operation!(operation_id)
+    operation =
+      operation_id
+      |> Operations.get_operation!()
+      |> Operations.enrich_operation!()
 
     render(conn, operation: operation)
   end

--- a/lib/wanda_web/controllers/v1/operation_json.ex
+++ b/lib/wanda_web/controllers/v1/operation_json.ex
@@ -19,6 +19,12 @@ defmodule WandaWeb.V1.OperationJSON do
          status: status,
          targets: targets,
          agent_reports: agent_reports,
+         catalog_operation_id: catalog_operation_id,
+         catalog_operation: %{
+           name: name,
+           description: description,
+           steps: steps
+         },
          started_at: started_at,
          updated_at: updated_at,
          completed_at: completed_at
@@ -29,10 +35,30 @@ defmodule WandaWeb.V1.OperationJSON do
       result: result,
       status: status,
       targets: targets,
-      agent_reports: agent_reports,
+      agent_reports: map_agent_reports(agent_reports, steps),
+      operation: catalog_operation_id,
+      name: name,
+      description: description,
       started_at: started_at,
       updated_at: updated_at,
       completed_at: completed_at
     }
+  end
+
+  defp map_agent_reports(agent_reports, steps) do
+    agent_reports
+    |> Enum.with_index()
+    |> Enum.map(fn {%{"agents" => agents}, index} ->
+      %{name: name, timeout: timeout, operator: operator, predicate: predicate} =
+        Enum.at(steps, index)
+
+      %{
+        agents: agents,
+        name: name,
+        timeout: timeout,
+        operator: operator,
+        predicate: predicate
+      }
+    end)
   end
 end

--- a/lib/wanda_web/schemas/v1/operation/operation_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_response.ex
@@ -35,6 +35,9 @@ defmodule WandaWeb.Schemas.V1.Operation.OperationResponse do
           enum: Result.values(),
           description: "Aggregated result of the operation, unknown for running ones"
         },
+        name: %Schema{type: :string, description: "Operation name"},
+        description: %Schema{type: :string, description: "Operation description"},
+        operation: %Schema{type: :string, description: "Executed operation"},
         targets: %Schema{type: :array, items: OperationTarget},
         agent_reports: %Schema{type: :array, nullable: true, items: StepReport},
         started_at: %Schema{

--- a/lib/wanda_web/schemas/v1/operation/step_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/step_report.ex
@@ -14,10 +14,13 @@ defmodule WandaWeb.Schemas.V1.Operation.StepReport do
       type: :object,
       additionalProperties: false,
       properties: %{
-        step_number: %Schema{type: :integer, description: "Step number"},
+        name: %Schema{type: :string, description: "Operation step tname"},
+        operator: %Schema{type: :string, description: "Operation step operator"},
+        predicate: %Schema{type: :string, description: "Operation step predicate"},
+        timeout: %Schema{type: :integer, description: "Operation step timeout"},
         agents: %Schema{type: :array, items: AgentReport}
       },
-      required: [:step_number, :agents]
+      required: [:name, :operator, :predicate, :timeout, :agents]
     },
     struct?: false
   )

--- a/priv/repo/migrations/20250123143407_add_catalog_operation_id_to_operation.exs
+++ b/priv/repo/migrations/20250123143407_add_catalog_operation_id_to_operation.exs
@@ -1,0 +1,9 @@
+defmodule Wanda.Repo.Migrations.AddCatalogOperationIdToOperation do
+  use Ecto.Migration
+
+  def change do
+    alter table(:operations) do
+      add :catalog_operation_id, :string, null: false
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -244,7 +244,7 @@ defmodule Wanda.Factory do
     %Operation{
       operation_id: UUID.uuid4(),
       group_id: UUID.uuid4(),
-      catalog_operation_id: "saptuneapplysolution@v1",
+      catalog_operation_id: "testoperation@v1",
       result: OpeartionResult.not_executed(),
       status: OpeartionStatus.running(),
       targets: targets,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -242,6 +242,7 @@ defmodule Wanda.Factory do
     %Operation{
       operation_id: UUID.uuid4(),
       group_id: UUID.uuid4(),
+      catalog_operation_id: "saptuneapplysolution@v1",
       result: OpeartionResult.not_executed(),
       status: OpeartionStatus.running(),
       targets: targets,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -217,6 +217,7 @@ defmodule Wanda.Factory do
     %CatalogOperation{
       id: UUID.uuid4(),
       name: Faker.StarWars.character(),
+      description: Faker.StarWars.quote(),
       required_args: [],
       steps: build_list(2, :operation_step)
     }
@@ -224,6 +225,7 @@ defmodule Wanda.Factory do
 
   def operation_step_factory do
     %Step{
+      name: Faker.StarWars.character(),
       operator: Faker.StarWars.planet(),
       predicate: "*",
       timeout: 10_000

--- a/test/support/operations/test_registry.ex
+++ b/test/support/operations/test_registry.ex
@@ -1,0 +1,23 @@
+defmodule Wanda.Operations.Catalog.TestRegistry do
+  @moduledoc false
+
+  def test_registry do
+    %{
+      "testoperation@v1" => %Wanda.Operations.Catalog.Operation{
+        id: "testoperation@v1",
+        name: "Test operation",
+        description: """
+        A test operation.
+        """,
+        required_args: ["arg"],
+        steps: [
+          %Wanda.Operations.Catalog.Step{
+            name: "First step",
+            operator: "test@v1",
+            predicate: "*"
+          }
+        ]
+      }
+    }
+  end
+end

--- a/test/wanda/operations/catalog/registry_test.exs
+++ b/test/wanda/operations/catalog/registry_test.exs
@@ -6,13 +6,15 @@ defmodule Wanda.Operations.Catalog.RegistryTest do
     Registry
   }
 
-  describe "operations" do
+  describe "get_operations/0" do
     test "should return all existing operations" do
       Enum.each(Registry.get_operations(), fn op ->
         assert %Operation{} = op
       end)
     end
+  end
 
+  describe "get_operation/1" do
     test "should return operation by id" do
       assert {:ok, %Operation{id: "saptuneapplysolution@v1"}} =
                Registry.get_operation("saptuneapplysolution@v1")
@@ -21,6 +23,19 @@ defmodule Wanda.Operations.Catalog.RegistryTest do
     test "should return a not found error if operation does not exist" do
       assert {:error, :operation_not_found} =
                Registry.get_operation("somenastyoperation")
+    end
+  end
+
+  describe "get_operation!/1" do
+    test "should directly return operation by id" do
+      assert %Operation{id: "saptuneapplysolution@v1"} =
+               Registry.get_operation!("saptuneapplysolution@v1")
+    end
+
+    test "should bang if operation does not exist" do
+      assert_raise KeyError, fn ->
+        Registry.get_operation!("somenastyoperation")
+      end
     end
   end
 end

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -5,10 +5,19 @@ defmodule Wanda.Operations.ServerTest do
 
   alias Wanda.Operations.{Operation, Server}
 
+  alias Wanda.Operations.Catalog.TestRegistry
+
   require Wanda.Operations.Enums.Result, as: Result
   require Wanda.Operations.Enums.Status, as: Status
 
-  @existing_catalog_operation_id "saptuneapplysolution@v1"
+  @existing_catalog_operation_id "testoperation@v1"
+
+  setup do
+    Application.put_env(:wanda, :operations_registry, TestRegistry.test_registry())
+    on_exit(fn -> Application.delete_env(:wanda, :operations_registry) end)
+
+    {:ok, []}
+  end
 
   describe "operation execution" do
     test "should not start operation if targets are missing" do

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -8,6 +8,8 @@ defmodule Wanda.Operations.ServerTest do
   require Wanda.Operations.Enums.Result, as: Result
   require Wanda.Operations.Enums.Status, as: Status
 
+  @existing_catalog_operation_id "saptuneapplysolution@v1"
+
   describe "operation execution" do
     test "should not start operation if targets are missing" do
       catalog_operation = build(:catalog_operation)
@@ -59,7 +61,7 @@ defmodule Wanda.Operations.ServerTest do
       Server.start_operation(
         UUID.uuid4(),
         group_id,
-        build(:catalog_operation),
+        build(:catalog_operation, id: @existing_catalog_operation_id),
         build_list(2, :operation_target),
         []
       )
@@ -81,7 +83,7 @@ defmodule Wanda.Operations.ServerTest do
     test "should stop execution if last step failed" do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
-      operation = build(:catalog_operation)
+      operation = build(:catalog_operation, id: @existing_catalog_operation_id)
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)
@@ -131,6 +133,7 @@ defmodule Wanda.Operations.ServerTest do
 
       operation =
         build(:catalog_operation,
+          id: @existing_catalog_operation_id,
           steps: [
             build(:operation_step, predicate: "*"),
             build(:operation_step, predicate: "")
@@ -245,7 +248,10 @@ defmodule Wanda.Operations.ServerTest do
       group_id = UUID.uuid4()
 
       operation =
-        build(:catalog_operation, steps: build_list(1, :operation_step, predicate: "value == 5"))
+        build(:catalog_operation,
+          id: @existing_catalog_operation_id,
+          steps: build_list(1, :operation_step, predicate: "value == 5")
+        )
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = [
@@ -289,7 +295,10 @@ defmodule Wanda.Operations.ServerTest do
       group_id = UUID.uuid4()
 
       operation =
-        build(:catalog_operation, steps: build_list(1, :operation_step, predicate: "value == 5"))
+        build(:catalog_operation,
+          id: @existing_catalog_operation_id,
+          steps: build_list(1, :operation_step, predicate: "value == 5")
+        )
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = [
@@ -330,7 +339,7 @@ defmodule Wanda.Operations.ServerTest do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
 
-      operation = build(:catalog_operation)
+      operation = build(:catalog_operation, id: @existing_catalog_operation_id)
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)
@@ -362,7 +371,11 @@ defmodule Wanda.Operations.ServerTest do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()
 
-      operation = build(:catalog_operation, steps: build_list(2, :operation_step, timeout: 0))
+      operation =
+        build(:catalog_operation,
+          id: @existing_catalog_operation_id,
+          steps: build_list(2, :operation_step, timeout: 0)
+        )
 
       [%{agent_id: agent_id_1}, %{agent_id: agent_id_2}] =
         targets = build_list(2, :operation_target)
@@ -409,6 +422,7 @@ defmodule Wanda.Operations.ServerTest do
 
       operation =
         build(:catalog_operation,
+          id: @existing_catalog_operation_id,
           steps: [
             build(:operation_step, timeout: 10_000),
             build(:operation_step, timeout: 0)

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -7,8 +7,19 @@ defmodule Wanda.OperationsTest do
   alias Wanda.Operations
   alias Wanda.Operations.{AgentReport, Operation, OperationTarget, StepReport}
 
+  alias Wanda.Operations.Catalog.TestRegistry
+
   require Wanda.Operations.Enums.Result, as: Result
   require Wanda.Operations.Enums.Status, as: Status
+
+  @existing_catalog_operation_id "testoperation@v1"
+
+  setup do
+    Application.put_env(:wanda, :operations_registry, TestRegistry.test_registry())
+    on_exit(fn -> Application.delete_env(:wanda, :operations_registry) end)
+
+    {:ok, []}
+  end
 
   describe "create an operation" do
     test "should create a running operation" do
@@ -26,14 +37,19 @@ defmodule Wanda.OperationsTest do
         }
       ] = targets = build_list(2, :operation_target)
 
-      Operations.create_operation!(operation_id, group_id, "saptuneapplysolution@v1", targets)
+      Operations.create_operation!(
+        operation_id,
+        group_id,
+        @existing_catalog_operation_id,
+        targets
+      )
 
       assert %Operation{
                operation_id: ^operation_id,
                group_id: ^group_id,
                result: Result.not_executed(),
                status: Status.running(),
-               catalog_operation_id: "saptuneapplysolution@v1",
+               catalog_operation_id: @existing_catalog_operation_id,
                targets: [
                  %{
                    agent_id: ^agent_id_1,

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -26,13 +26,14 @@ defmodule Wanda.OperationsTest do
         }
       ] = targets = build_list(2, :operation_target)
 
-      Operations.create_operation!(operation_id, group_id, targets)
+      Operations.create_operation!(operation_id, group_id, "saptuneapplysolution@v1", targets)
 
       assert %Operation{
                operation_id: ^operation_id,
                group_id: ^group_id,
                result: Result.not_executed(),
                status: Status.running(),
+               catalog_operation_id: "saptuneapplysolution@v1",
                targets: [
                  %{
                    agent_id: ^agent_id_1,
@@ -46,6 +47,16 @@ defmodule Wanda.OperationsTest do
                agent_reports: []
              } = Repo.get(Operation, operation_id)
     end
+
+    test "should bang creating operation if catalog operation does not exist" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      targets = build_list(2, :operation_target)
+
+      assert_raise KeyError, fn ->
+        Operations.create_operation!(operation_id, group_id, "foo", targets)
+      end
+    end
   end
 
   describe "get operation" do
@@ -53,6 +64,25 @@ defmodule Wanda.OperationsTest do
       %Operation{operation_id: operation_id} = operation = insert(:operation)
 
       assert operation == Operations.get_operation!(operation_id)
+    end
+  end
+
+  describe "enrich operation" do
+    test "should enrich an existing operation" do
+      operation = insert(:operation)
+
+      assert %Operation{catalog_operation: catalog_operation} =
+               Operations.enrich_operation!(operation)
+
+      refute catalog_operation == nil
+    end
+
+    test "should bang enrichment if catalog operation does not exist" do
+      operation = insert(:operation, catalog_operation_id: "bar")
+
+      assert_raise KeyError, fn ->
+        Operations.enrich_operation!(operation)
+      end
     end
   end
 

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -53,7 +53,7 @@ defmodule Wanda.OperationsTest do
       group_id = UUID.uuid4()
       targets = build_list(2, :operation_target)
 
-      assert_raise KeyError, fn ->
+      assert_raise Ecto.InvalidChangesetError, fn ->
         Operations.create_operation!(operation_id, group_id, "foo", targets)
       end
     end

--- a/test/wanda_web/controllers/v1/operation_controller_test.exs
+++ b/test/wanda_web/controllers/v1/operation_controller_test.exs
@@ -8,7 +8,7 @@ defmodule WandaWeb.V1.OperationControllerTest do
 
   describe "list operations" do
     test "should return a list of operations", %{conn: conn} do
-      insert_list(5, :operation)
+      insert_list(5, :operation, catalog_operation_id: "saptuneapplysolution@v1")
 
       json =
         conn
@@ -28,7 +28,8 @@ defmodule WandaWeb.V1.OperationControllerTest do
 
   describe "get operation" do
     test "should return an operation", %{conn: conn} do
-      %{operation_id: operation_id} = insert(:operation)
+      %{operation_id: operation_id} =
+        insert(:operation, catalog_operation_id: "saptuneapplysolution@v1")
 
       json =
         conn
@@ -41,7 +42,10 @@ defmodule WandaWeb.V1.OperationControllerTest do
 
     test "should return an operation with agent reports", %{conn: conn} do
       %{operation_id: operation_id} =
-        insert(:operation, agent_reports: build_list(2, :step_report))
+        insert(:operation,
+          catalog_operation_id: "saptuneapplysolution@v1",
+          agent_reports: build_list(1, :step_report)
+        )
 
       json =
         conn
@@ -50,6 +54,12 @@ defmodule WandaWeb.V1.OperationControllerTest do
 
       api_spec = ApiSpec.spec()
       assert_schema(json, "OperationResponse", api_spec)
+    end
+
+    test "should return a 404", %{conn: conn} do
+      assert_error_sent(404, fn ->
+        get(conn, "/api/v1/operations/executions/#{UUID.uuid4()}")
+      end)
     end
   end
 end

--- a/test/wanda_web/controllers/v1/operation_controller_test.exs
+++ b/test/wanda_web/controllers/v1/operation_controller_test.exs
@@ -6,9 +6,20 @@ defmodule WandaWeb.V1.OperationControllerTest do
 
   alias WandaWeb.Schemas.V1.ApiSpec
 
+  alias Wanda.Operations.Catalog.TestRegistry
+
+  @existing_catalog_operation_id "testoperation@v1"
+
+  setup do
+    Application.put_env(:wanda, :operations_registry, TestRegistry.test_registry())
+    on_exit(fn -> Application.delete_env(:wanda, :operations_registry) end)
+
+    {:ok, []}
+  end
+
   describe "list operations" do
     test "should return a list of operations", %{conn: conn} do
-      insert_list(5, :operation, catalog_operation_id: "saptuneapplysolution@v1")
+      insert_list(5, :operation, catalog_operation_id: @existing_catalog_operation_id)
 
       json =
         conn
@@ -29,7 +40,7 @@ defmodule WandaWeb.V1.OperationControllerTest do
   describe "get operation" do
     test "should return an operation", %{conn: conn} do
       %{operation_id: operation_id} =
-        insert(:operation, catalog_operation_id: "saptuneapplysolution@v1")
+        insert(:operation, catalog_operation_id: @existing_catalog_operation_id)
 
       json =
         conn
@@ -43,7 +54,7 @@ defmodule WandaWeb.V1.OperationControllerTest do
     test "should return an operation with agent reports", %{conn: conn} do
       %{operation_id: operation_id} =
         insert(:operation,
-          catalog_operation_id: "saptuneapplysolution@v1",
+          catalog_operation_id: @existing_catalog_operation_id,
           agent_reports: build_list(1, :step_report)
         )
 

--- a/test/wanda_web/controllers/v1/operation_json_test.exs
+++ b/test/wanda_web/controllers/v1/operation_json_test.exs
@@ -7,14 +7,22 @@ defmodule WandaWeb.V1.OperationJSONTest do
 
   describe "OperationJSON" do
     test "renders index.json" do
-      operations = build_list(5, :operation)
+      %{id: catalog_operation_id, name: operation_name} =
+        catalog_operation = build(:catalog_operation)
 
-      expected_operations =
-        Enum.map(operations, fn operation -> Map.drop(operation, [:__meta__, :__struct__]) end)
+      [%{operation_id: id_1}, %{operation_id: id_2}, %{operation_id: id_3}] =
+        operations =
+        3
+        |> build_list(:operation, catalog_operation_id: catalog_operation_id)
+        |> Enum.map(fn operation -> %{operation | catalog_operation: catalog_operation} end)
 
       assert %{
-               items: ^expected_operations,
-               total_count: 5
+               items: [
+                 %{operation_id: ^id_1, name: ^operation_name},
+                 %{operation_id: ^id_2, name: ^operation_name},
+                 %{operation_id: ^id_3, name: ^operation_name}
+               ],
+               total_count: 3
              } =
                OperationJSON.index(%{
                  operations: operations
@@ -22,10 +30,81 @@ defmodule WandaWeb.V1.OperationJSONTest do
     end
 
     test "renders show.json for a running execution" do
-      operation = build(:operation)
-      expected_operation = Map.drop(operation, [:__meta__, :__struct__])
+      %{
+        id: catalog_operation_id,
+        name: operation_name,
+        description: operation_description,
+        steps: [
+          %{
+            name: step_name_1,
+            timeout: step_timeout_1,
+            operator: step_operator_1,
+            predicate: step_predicate_1
+          },
+          %{
+            name: step_name_2,
+            timeout: step_timeout_2,
+            operator: step_operator_2,
+            predicate: step_predicate_2
+          }
+        ]
+      } = catalog_operation = build(:catalog_operation)
 
-      assert ^expected_operation = OperationJSON.show(%{operation: operation})
+      agent_reports = build_list(2, :step_report)
+
+      [%{"agents" => agents_1}, %{"agents" => agents_2}] =
+        string_agents = agent_reports |> Jason.encode!() |> Jason.decode!()
+
+      %{
+        operation_id: operation_id,
+        group_id: group_id,
+        targets: targets,
+        started_at: started_at,
+        updated_at: updated_at,
+        completed_at: completed_at,
+        result: result,
+        status: status
+      } =
+        operation =
+        build(:operation,
+          catalog_operation_id: catalog_operation_id,
+          agent_reports: string_agents
+        )
+
+      operation = %{operation | catalog_operation: catalog_operation}
+
+      expected_operation =
+        %{
+          operation_id: operation_id,
+          group_id: group_id,
+          targets: targets,
+          started_at: started_at,
+          updated_at: updated_at,
+          completed_at: completed_at,
+          result: result,
+          status: status,
+          name: operation_name,
+          description: operation_description,
+          operation: catalog_operation_id,
+          agent_reports: [
+            %{
+              name: step_name_1,
+              timeout: step_timeout_1,
+              operator: step_operator_1,
+              predicate: step_predicate_1,
+              agents: agents_1
+            },
+            %{
+              name: step_name_2,
+              timeout: step_timeout_2,
+              operator: step_operator_2,
+              predicate: step_predicate_2,
+              agents: agents_2
+            }
+          ]
+        }
+
+      assert expected_operation == OperationJSON.show(%{operation: operation})
     end
   end
 end


### PR DESCRIPTION
# Description

Enrich operations executions data with the used operation.
This is helpful to display additional data to the frontend by now.
In the future, this is a requirement if at some point we want to resume the "aborted" operations again, as we need to get the operation data.

PD: I know the API check if failing, but honestly, i don't care. I want to remove the `step_number` field, as it doesn't add any real value (as the step number is the position of the element in the list).
I executed the `mix test`, `mix credo --strict` and `mix dialyzer` locally and all green.
The [test coverage](https://coveralls.io/builds/71933743) is not affected neither (I have executed one run disabling the API check)

## How was this tested?

UT
