### PR TITLE
Set operation as aborted

### DIFF
--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -14,7 +14,7 @@ defmodule Wanda.Operations do
     StepReport
   }
 
-  alias Wanda.Operations.Catalog.Registry
+  alias Wanda.Operations.Catalog.{Registry, Step}
 
   require Wanda.Operations.Enums.Result, as: Result
   require Wanda.Operations.Enums.Status, as: Status
@@ -56,6 +56,36 @@ defmodule Wanda.Operations do
 
     %Operation{operation | catalog_operation: catalog_operation}
   end
+
+  @doc """
+  Compute if the operation was aborted using the started_at time and current utc time.
+  This function complements the operation gen servers that were abruptly finished without
+  setting the new status
+  """
+  @spec compute_aborted(Operation.t(), Calendar.datetime()) :: Operation.t()
+  def compute_aborted(
+        %Operation{
+          status: Status.running(),
+          started_at: started_at,
+          catalog_operation: %{steps: steps}
+        } = operation,
+        utc_now
+      ) do
+    total_timeout =
+      Enum.reduce(steps, 0, fn %Step{timeout: timeout}, acc ->
+        acc + timeout
+      end)
+
+    timed_out? = DateTime.before?(DateTime.add(started_at, total_timeout, :millisecond), utc_now)
+
+    if timed_out? do
+      %Operation{operation | status: Status.aborted()}
+    else
+      operation
+    end
+  end
+
+  def compute_aborted(operation, _), do: operation
 
   @doc """
   Get a paginated list of operations.

--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -107,6 +107,19 @@ defmodule Wanda.Operations do
     |> Repo.update!()
   end
 
+  @doc """
+  Marks a previously started operation as aborted
+  """
+  @spec abort_operation!(String.t()) :: Operation.t()
+  def abort_operation!(operation_id) do
+    Operation
+    |> Repo.get!(operation_id)
+    |> Operation.changeset(%{
+      status: Status.aborted()
+    })
+    |> Repo.update!()
+  end
+
   @spec maybe_filter_by_group_id(Ecto.Query.t(), String.t()) :: Ecto.Query.t()
   defp maybe_filter_by_group_id(query, nil), do: query
 

--- a/lib/wanda/operations/enums/status.ex
+++ b/lib/wanda/operations/enums/status.ex
@@ -4,5 +4,5 @@ defmodule Wanda.Operations.Enums.Status do
   """
 
   use Wanda.Support.Enum,
-    values: [:running, :completed]
+    values: [:running, :completed, :aborted]
 end

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -6,7 +6,7 @@ defmodule Wanda.Operations.Server do
 
   @behaviour Wanda.Operations.ServerBehaviour
 
-  use GenServer, restart: :transient
+  use GenServer, restart: :temporary
 
   alias Wanda.Operations
 

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -18,12 +18,15 @@ defmodule Wanda.Operations.State do
 
   alias Wanda.Operations.Catalog.Operation
 
+  require Wanda.Operations.Enums.Status, as: Status
+
   defstruct [
     :engine,
     :operation_id,
     :group_id,
     :operation,
     :timer_ref,
+    status: Status.running(),
     targets: [],
     pending_targets_on_step: [],
     current_step_index: 0,
@@ -36,6 +39,7 @@ defmodule Wanda.Operations.State do
           operation_id: String.t(),
           group_id: String.t(),
           operation: Operation.t(),
+          status: Status.t(),
           agent_reports: [StepReport.t()],
           targets: [OperationTarget.t()],
           pending_targets_on_step: [String.t()],

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -37,10 +37,13 @@ defmodule WandaWeb.V1.OperationController do
     ]
 
   def index(conn, params) do
-    operations = Operations.list_operations(params)
-    enriched_operations = Enum.map(operations, &Operations.enrich_operation!(&1))
+    operations =
+      params
+      |> Operations.list_operations()
+      |> Enum.map(&Operations.enrich_operation!(&1))
+      |> Enum.map(&Operations.compute_aborted(&1, DateTime.utc_now()))
 
-    render(conn, operations: enriched_operations)
+    render(conn, operations: operations)
   end
 
   operation :show,
@@ -67,6 +70,7 @@ defmodule WandaWeb.V1.OperationController do
       operation_id
       |> Operations.get_operation!()
       |> Operations.enrich_operation!()
+      |> Operations.compute_aborted(DateTime.utc_now())
 
     render(conn, operation: operation)
   end

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -102,6 +102,66 @@ defmodule Wanda.OperationsTest do
     end
   end
 
+  describe "compute aborted" do
+    test "should not change status if the operation is completed" do
+      operation = build(:operation, status: Status.completed())
+
+      assert %Operation{status: Status.completed()} =
+               Operations.compute_aborted(operation, DateTime.utc_now())
+    end
+
+    test "should not change status if the operation is already aborted" do
+      operation = build(:operation, status: Status.aborted())
+
+      assert %Operation{status: Status.aborted()} =
+               Operations.compute_aborted(operation, DateTime.utc_now())
+    end
+
+    test "should not change status if the operation is running but the timeout is not expired" do
+      catalog_operation =
+        build(:catalog_operation,
+          steps: [
+            build(:operation_step, timeout: 15_000),
+            build(:operation_step, timeout: 5_000),
+            build(:operation_step, timeout: 10_000)
+          ]
+        )
+
+      %{started_at: started_at} =
+        operation =
+        build(:operation, catalog_operation: catalog_operation, status: Status.running())
+
+      for added_time <- [0, 15, 30] do
+        assert %Operation{status: Status.running()} =
+                 Operations.compute_aborted(
+                   operation,
+                   DateTime.add(started_at, added_time)
+                 )
+      end
+    end
+
+    test "should change status to aborted if the operation is running and the timeout expired" do
+      catalog_operation =
+        build(:catalog_operation,
+          steps: [
+            build(:operation_step, timeout: 3_000),
+            build(:operation_step, timeout: 5_000),
+            build(:operation_step, timeout: 7_000)
+          ]
+        )
+
+      %{started_at: started_at} =
+        operation =
+        build(:operation, catalog_operation: catalog_operation, status: Status.running())
+
+      assert %Operation{status: Status.aborted()} =
+               Operations.compute_aborted(
+                 operation,
+                 DateTime.add(started_at, 16)
+               )
+    end
+  end
+
   describe "list operations" do
     test "should list all operations sorted by newest to oldest" do
       operations = insert_list(3, :operation)

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -211,6 +211,24 @@ defmodule Wanda.OperationsTest do
     end
   end
 
+  describe "abort an operation" do
+    test "should abort a running operation" do
+      %Operation{
+        operation_id: operation_id,
+        group_id: group_id
+      } = insert(:operation, status: Status.running())
+
+      Operations.abort_operation!(operation_id)
+
+      assert %Operation{
+               operation_id: ^operation_id,
+               group_id: ^group_id,
+               status: Status.aborted(),
+               completed_at: nil
+             } = Repo.get(Operation, operation_id)
+    end
+  end
+
   describe "complete an operation" do
     test "should complete a running operation" do
       %Operation{


### PR DESCRIPTION
# Description

Set the operation as aborted if the gen server handling the operation crashes abnormally.
For that, first of all, the gen server `restart` value is set to `temporary` so it doesn't restart in any circunstance.

Unfortunately, we cannot catch all the crashes in the gen server itself, so the `terminate/2` is a best-effort. It will put operations to aborted if possible.
If this cannot happen (database connection fails, whole application stops abruptly, brutal kill, etc), the functionality is completed in the `operations` code, where we can compute if an operation is aborted calculating its starting time, steps timeouts and current time.
Of course, this has the disadvantage that the database itself is not 100% accurate.

If we want to solve that and have 100% accurate database content, we need to have a recurring job in the system. This job can be as stupid as a super simple GenServer with a `Process.send_after(self(), :sync, @period)` in a `handle_info(:sync...`, which could run `Opeartions.abort_operation` using the same calculation system.

I don't personally like the recurring job options, as it includes more opaque things on the system. It would do background tasks and makes the system less deterministic as the entries change without any real event.

Opinions?

References:
- [terminate](https://hexdocs.pm/elixir/1.12/GenServer.html#c:terminate/2)
- [article](https://alexcastano.com/how-to-stop-a-genserver-in-elixir/)

## How was this tested?

UT
