### PR TITLE
Retrieve customizations for a specific execution group

### DIFF
--- a/lib/wanda/catalog/check_customization.ex
+++ b/lib/wanda/catalog/check_customization.ex
@@ -17,7 +17,7 @@ defmodule Wanda.Catalog.CheckCustomization do
     field :check_id, :string, primary_key: true
     field :group_id, Ecto.UUID, primary_key: true
 
-    field :custom_values, {:array, :map}
+    field :custom_values, Wanda.Support.Ecto.Json
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -20,8 +20,7 @@ defmodule Wanda.ChecksCustomizations do
   def get_customizations(group_id) do
     Repo.all(
       from c in CheckCustomization,
-        where: c.group_id == ^group_id,
-        select: c
+        where: c.group_id == ^group_id
     )
   end
 

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -3,6 +3,8 @@ defmodule Wanda.ChecksCustomizations do
   Customization features.
   """
 
+  import Ecto.Query
+
   alias Wanda.Catalog
   alias Wanda.Catalog.{Check, Value}
   alias Wanda.Catalog.CheckCustomization
@@ -13,6 +15,15 @@ defmodule Wanda.ChecksCustomizations do
           name: String.t(),
           value: any()
         }
+
+  @spec get_customizations(Ecto.UUID.t()) :: [CheckCustomization.t()]
+  def get_customizations(group_id) do
+    Repo.all(
+      from c in CheckCustomization,
+        where: c.group_id == ^group_id,
+        select: c
+    )
+  end
 
   @spec customize(check_id :: String.t(), group_id :: Ecto.UUID.t(), [custom_value()]) ::
           {:ok, CheckCustomization.t()}
@@ -78,6 +89,10 @@ defmodule Wanda.ChecksCustomizations do
       end
     )
   end
+
+  defp match_value_type(specified_value, custom_value)
+       when is_integer(specified_value) and is_integer(custom_value),
+       do: true
 
   defp match_value_type(specified_value, custom_value)
        when is_number(specified_value) and is_number(custom_value),

--- a/lib/wanda/support/ecto/json.ex
+++ b/lib/wanda/support/ecto/json.ex
@@ -19,10 +19,12 @@ defmodule Wanda.Support.Ecto.Json do
   def dump(_), do: :error
 
   defp atomize_map_keys(map) when is_map(map) do
-    Map.new(map, fn {k, v} -> {String.to_existing_atom(k), v} end)
+    Map.new(map, fn {k, v} -> {String.to_existing_atom(k), atomize_map_keys(v)} end)
   end
 
   defp atomize_map_keys(map) when is_list(map) do
     Enum.map(map, &atomize_map_keys/1)
   end
+
+  defp atomize_map_keys(value), do: value
 end

--- a/lib/wanda/support/ecto/json.ex
+++ b/lib/wanda/support/ecto/json.ex
@@ -1,0 +1,28 @@
+defmodule Wanda.Support.Ecto.Json do
+  @moduledoc """
+  Ecto Type that represents JSON data.
+  """
+
+  use Ecto.Type
+
+  def type, do: {:array, :map}
+
+  def cast(data) when is_list(data) or is_map(data), do: {:ok, data}
+
+  def cast(_), do: :error
+
+  def load(data) when is_list(data) or is_map(data) do
+    {:ok, atomize_map_keys(data)}
+  end
+
+  def dump(data) when is_list(data) or is_map(data), do: {:ok, data}
+  def dump(_), do: :error
+
+  defp atomize_map_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {String.to_existing_atom(k), v} end)
+  end
+
+  defp atomize_map_keys(map) when is_list(map) do
+    Enum.map(map, &atomize_map_keys/1)
+  end
+end

--- a/test/wanda/checks_customizations_test.exs
+++ b/test/wanda/checks_customizations_test.exs
@@ -203,4 +203,69 @@ defmodule Wanda.ChecksCustomizationsTest do
       end
     end
   end
+
+  describe "retrieving checks customizations" do
+    test "should return an empty list when there are no customizations available for a group" do
+      assert [] == ChecksCustomizations.get_customizations(Faker.UUID.v4())
+    end
+
+    test "should return customizations available for a group" do
+      group_id = Faker.UUID.v4()
+
+      [
+        %{
+          name: name1,
+          value: value1
+        },
+        %{
+          name: name2,
+          value: value2
+        }
+      ] = custom_values1 = build_list(2, :custom_value)
+
+      %{
+        name: name3,
+        value: value3
+      } = custom_values2 = build(:custom_value)
+
+      %{check_id: check_id_1} =
+        insert(:check_customization,
+          group_id: group_id,
+          custom_values: custom_values1
+        )
+
+      %{check_id: check_id_2} =
+        insert(:check_customization,
+          group_id: group_id,
+          custom_values: [custom_values2]
+        )
+
+      assert [
+               %CheckCustomization{
+                 check_id: ^check_id_1,
+                 group_id: ^group_id,
+                 custom_values: [
+                   %{
+                     name: ^name1,
+                     value: ^value1
+                   },
+                   %{
+                     name: ^name2,
+                     value: ^value2
+                   }
+                 ]
+               },
+               %CheckCustomization{
+                 check_id: ^check_id_2,
+                 group_id: ^group_id,
+                 custom_values: [
+                   %{
+                     name: ^name3,
+                     value: ^value3
+                   }
+                 ]
+               }
+             ] = ChecksCustomizations.get_customizations(group_id)
+    end
+  end
 end


### PR DESCRIPTION
# Description

This PR adds the ability to load the customizations applied for a specific checks execution group.