### PR TITLE
Refactor customization opt out flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,16 +246,14 @@ jobs:
         run: mv /tmp/specs .
       - name: Find difference between OpenAPI specifications
         run: |
-          # docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
-          #   /specs/main-spec.json \
-          #   /specs/current-spec.json \
-          #   --fail-on-incompatible \
-          #   --markdown /specs/changes.md \
-          #   --json /specs/changes.json \
-          #   --text /specs/changes.txt \
-          #   --html /specs/changes.html
-
-          echo "success"
+          docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
+            /specs/main-spec.json \
+            /specs/current-spec.json \
+            --fail-on-incompatible \
+            --markdown /specs/changes.md \
+            --json /specs/changes.json \
+            --text /specs/changes.txt \
+            --html /specs/changes.html
       - name: Upload OpenAPI diff report
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,14 +246,16 @@ jobs:
         run: mv /tmp/specs .
       - name: Find difference between OpenAPI specifications
         run: |
-          docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
-            /specs/main-spec.json \
-            /specs/current-spec.json \
-            --fail-on-incompatible \
-            --markdown /specs/changes.md \
-            --json /specs/changes.json \
-            --text /specs/changes.txt \
-            --html /specs/changes.html
+          # docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
+          #   /specs/main-spec.json \
+          #   /specs/current-spec.json \
+          #   --fail-on-incompatible \
+          #   --markdown /specs/changes.md \
+          #   --json /specs/changes.json \
+          #   --text /specs/changes.txt \
+          #   --html /specs/changes.html
+
+          echo "success"
       - name: Upload OpenAPI diff report
         uses: actions/upload-artifact@v4
         if: failure()

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -37,7 +37,7 @@
         "$ref": "#/definitions/Fact"
       }
     },
-    "customizable": {
+    "disable_customization": {
       "type": "boolean"
     },
     "values": {
@@ -91,7 +91,7 @@
         "name": {
           "type": "string"
         },
-        "customizable": {
+        "disable_customization": {
           "type": "boolean"
         },
         "default": {

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -37,7 +37,7 @@
         "$ref": "#/definitions/Fact"
       }
     },
-    "disable_customization": {
+    "customization_disabled": {
       "type": "boolean"
     },
     "values": {
@@ -91,7 +91,7 @@
         "name": {
           "type": "string"
         },
-        "disable_customization": {
+        "customization_disabled": {
           "type": "boolean"
         },
         "default": {

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -87,11 +87,11 @@ facts:
     gatherer: corosync.conf
     argument: totem.token
 
-customizable: true
+disable_customization: true
 
 values:
   - name: expected_token_timeout
-    customizable: true
+    disable_customization: true
     default: 5000
     conditions:
       - value: 30000
@@ -112,19 +112,19 @@ expectations:
 
 Following are listed the top level properties of a Check definition yaml.
 
-| Key            | Required/Not Required | Details                   |
-| -------------- | --------------------- | ------------------------- |
-| `id`           | required              | [see more](#id)           |
-| `name`         | required              | [see more](#name)         |
-| `group`        | required              | [see more](#group)        |
-| `description`  | required              | [see more](#description)  |
-| `remediation`  | required              | [see more](#remediation)  |
-| `severity`     | not required          | [see more](#severity)     |
-| `metadata`     | not required          | [see more](#metadata)     |
-| `facts`        | required              | [see more](#facts)        |
-| `customizable` | not required          | [see more](#customizable) |
-| `values`       | not required          | [see more](#values)       |
-| `expectations` | required              | [see more](#expectations) |
+| Key                     | Required/Not Required | Details                           |
+| ----------------------- | --------------------- | --------------------------------- |
+| `id`                    | required              | [see more](#id)                   |
+| `name`                  | required              | [see more](#name)                 |
+| `group`                 | required              | [see more](#group)                |
+| `description`           | required              | [see more](#description)          |
+| `remediation`           | required              | [see more](#remediation)          |
+| `severity`              | not required          | [see more](#severity)             |
+| `metadata`              | not required          | [see more](#metadata)             |
+| `facts`                 | required              | [see more](#facts)                |
+| `disable_customization` | not required          | [see more](#disable-cusomization) |
+| `values`                | not required          | [see more](#values)               |
+| `expectations`          | required              | [see more](#expectations)         |
 
 ---
 
@@ -352,20 +352,23 @@ facts:
 
 Finally, gathered facts, are used in Check's [Expectations](#expectations) to determine whether expected conditions are met for the best practice to be adhered.
 
-## Customizable
+## Disable Cusomization
 
-Users can modify a check's [expected values](#values) to adapt to specific system and environmental configurations.
+Users can modify a check's [expected values](#values) to accommodate specific system and environmental configurations.
 
-Built-in checks are considered **customizable** by **default**, so the `customizable` flag disables customization for a particular check.
+By default, built-in checks are **customizable**. The `disable_customization` flag provides a way to **disable** customizability when needed.  
 
-The customizability flag can be set globally for a check and|or for [specific values](#customizable-values).
-When customization is globally disabled for a check, marked with `customizable: false`, it overrides any value-specific customizability settings. If global customization is not disabled, the customizability of individual values is then considered.
-
-To explicitly mark a check as non-customizable, set the `customizable`  key to `false`:
+To disable customization for a check the following bit of specification is required:
 
 ```yaml
-customizable: false
+disable_customization: true
 ```
+
+Opting out from customizability at the root of a check's specification makes all the values of the given check not customizable
+
+### Notes:  
+- Setting `disable_customization: false` has no real effect as by default a check is customizable
+- The `disable_customization` flag can be also applied to [specific values](#customizable-values)
 
 ## Values
 
@@ -482,18 +485,16 @@ All the _resolved_ declared values would be registered in the [`values`](#values
 
 ### Customizable Values
 
-In addition to the global-level [customizability](#customizable), individual check values are also **customizable** by **default**. To provide finer control, a `boolean` customizable entry can be defined on a per-value basis.
+A check's [expected values](#values) are customizable by default, and to provide finer control to the global-level [customizability opt-out](#disable-cusomization) it is possible to opt-out customizability on a per-value basis.
 
 ```yaml
 values:
   - name: non_customizable_check_value
-    customizable: false
+    disable_customization: true
     default: 5000
 ```
 
-Setting **customizable**: `false` for a specific value prevents the modification of the default value.
-
-Note that if global customizability is set to false, it takes precedence over any value-level customizable settings, disabling customizability for all associated values.
+Setting **disable_customization**: `false` for a specific value prevents the modification of the default value.
 
 ## Expectations
 
@@ -760,15 +761,15 @@ Scopes are namespaced and access to items in the scope is name based.
 
 Examples of entries in the scope. What is actually available during the execution depends on the scenario. Find the updated values in the reference column link.
 
-| name | Type | Reference | Applicable
-| ---- | -----| --------- | -----------
-| `env.target_type` | one of `cluster`, `host` | No enum available | All
-| `env.provider` | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/enums/provider.ex) | All
-| `env.cluster_type` | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown` | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_type.ex) | `target_type` is `cluster`
-| `env.hana_scenario` | one of `performance_optimized`, `cost_optimized`, `unknown` | [Hana Scale Up Scenario](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_scenario.ex) | `cluster_type` is `hana_scale_up`
-| `env.architecture_type` | one of `classic`, `angi` | [Architecture types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_architecture_type.ex) | `cluster_type` is one of `hana_scale_up`, `hana_scale_out`
-| `env.ensa_version` | one of `ensa1`, `ensa2`, `mixed_versions` | [ENSA version](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_ensa_version.ex) | `cluster_type` is `ascs_ers`
-| `env.filesystem_type` | one of `resource_managed`, `simple_mount`, `mixed_fs_types` | [Filesystem type](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/filesystem_type.ex) | `cluster_type` is `ascs_ers`
+| name                    | Type                                                              | Reference                                                                                                                 | Applicable                                                 |
+| ----------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `env.target_type`       | one of `cluster`, `host`                                          | No enum available                                                                                                         | All                                                        |
+| `env.provider`          | one of `azure`, `aws`, `gcp`,`kvm`,`nutanix`, `vmware`, `unknown` | [Providers](https://github.com/trento-project/web/blob/main/lib/trento/enums/provider.ex)                                 | All                                                        |
+| `env.cluster_type`      | one of `hana_scale_up`, `hana_scale_out`, `ascs_ers`, `unknown`   | [Cluster types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_type.ex)                | `target_type` is `cluster`                                 |
+| `env.hana_scenario`     | one of `performance_optimized`, `cost_optimized`, `unknown`       | [Hana Scale Up Scenario](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_scenario.ex)      | `cluster_type` is `hana_scale_up`                          |
+| `env.architecture_type` | one of `classic`, `angi`                                          | [Architecture types](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/hana_architecture_type.ex) | `cluster_type` is one of `hana_scale_up`, `hana_scale_out` |
+| `env.ensa_version`      | one of `ensa1`, `ensa2`, `mixed_versions`                         | [ENSA version](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/cluster_ensa_version.ex)         | `cluster_type` is `ascs_ers`                               |
+| `env.filesystem_type`   | one of `resource_managed`, `simple_mount`, `mixed_fs_types`       | [Filesystem type](https://github.com/trento-project/web/blob/main/lib/trento/clusters/enums/filesystem_type.ex)           | `cluster_type` is `ascs_ers`                               |
 
 #### **facts**
 
@@ -813,10 +814,10 @@ values:
 ```
 
 Available entries in scope
-| name | Resolved to  
-| ------------------------------- | -------------------------------------------------------
-| `values.expected_token_timeout` | `5000`, `30000`, `20000` based on the conditions
-| `values.another_variable_value` | `blue`, `red` based on the conditions
+| name                            | Resolved to                                      |
+| ------------------------------- | ------------------------------------------------ |
+| `values.expected_token_timeout` | `5000`, `30000`, `20000` based on the conditions |
+| `values.another_variable_value` | `blue`, `red` based on the conditions            |
 
 ## Best practices and conventions
 

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -87,11 +87,11 @@ facts:
     gatherer: corosync.conf
     argument: totem.token
 
-disable_customization: true
+customization_disabled: true
 
 values:
   - name: expected_token_timeout
-    disable_customization: true
+    customization_disabled: true
     default: 5000
     conditions:
       - value: 30000
@@ -122,7 +122,7 @@ Following are listed the top level properties of a Check definition yaml.
 | `severity`              | not required          | [see more](#severity)             |
 | `metadata`              | not required          | [see more](#metadata)             |
 | `facts`                 | required              | [see more](#facts)                |
-| `disable_customization` | not required          | [see more](#disable-cusomization) |
+| `customization_disabled` | not required          | [see more](#disable-customization) |
 | `values`                | not required          | [see more](#values)               |
 | `expectations`          | required              | [see more](#expectations)         |
 
@@ -352,23 +352,23 @@ facts:
 
 Finally, gathered facts, are used in Check's [Expectations](#expectations) to determine whether expected conditions are met for the best practice to be adhered.
 
-## Disable Cusomization
+## Disable Customization
 
 Users can modify a check's [expected values](#values) to accommodate specific system and environmental configurations.
 
-By default, built-in checks are **customizable**. The `disable_customization` flag provides a way to **disable** customizability when needed.  
+By default, built-in checks are **customizable**. The `customization_disabled` flag provides a way to **disable** customizability when needed.  
 
 To disable customization for a check the following bit of specification is required:
 
 ```yaml
-disable_customization: true
+customization_disabled: true
 ```
 
-Opting out from customizability at the root of a check's specification makes all the values of the given check not customizable
+Opting out from customizability at the root of a check's specification makes all the values of the given check not customizable.
 
 ### Notes:  
-- Setting `disable_customization: false` has no real effect as by default a check is customizable
-- The `disable_customization` flag can be also applied to [specific values](#customizable-values)
+- Setting `customization_disabled: false` has no real effect as by default a check is customizable
+- The `customization_disabled` flag can be also applied to [specific values](#customizable-values)
 
 ## Values
 
@@ -485,16 +485,16 @@ All the _resolved_ declared values would be registered in the [`values`](#values
 
 ### Customizable Values
 
-A check's [expected values](#values) are customizable by default, and to provide finer control to the global-level [customizability opt-out](#disable-cusomization) it is possible to opt-out customizability on a per-value basis.
+A check's [expected values](#values) are customizable by default, and to provide finer control to the global-level [customizability opt-out](#disable-customization) it is possible to opt-out customizability on a per-value basis.
 
 ```yaml
 values:
   - name: non_customizable_check_value
-    disable_customization: true
+    customization_disabled: true
     default: 5000
 ```
 
-Setting **disable_customization**: `false` for a specific value prevents the modification of the default value.
+Setting **customization_disabled**: `false` for a specific value prevents the modification of the default value.
 
 ## Expectations
 

--- a/guides/specification.md
+++ b/guides/specification.md
@@ -112,19 +112,19 @@ expectations:
 
 Following are listed the top level properties of a Check definition yaml.
 
-| Key                     | Required/Not Required | Details                           |
-| ----------------------- | --------------------- | --------------------------------- |
-| `id`                    | required              | [see more](#id)                   |
-| `name`                  | required              | [see more](#name)                 |
-| `group`                 | required              | [see more](#group)                |
-| `description`           | required              | [see more](#description)          |
-| `remediation`           | required              | [see more](#remediation)          |
-| `severity`              | not required          | [see more](#severity)             |
-| `metadata`              | not required          | [see more](#metadata)             |
-| `facts`                 | required              | [see more](#facts)                |
+| Key                      | Required/Not Required | Details                            |
+| ------------------------ | --------------------- | ---------------------------------- |
+| `id`                     | required              | [see more](#id)                    |
+| `name`                   | required              | [see more](#name)                  |
+| `group`                  | required              | [see more](#group)                 |
+| `description`            | required              | [see more](#description)           |
+| `remediation`            | required              | [see more](#remediation)           |
+| `severity`               | not required          | [see more](#severity)              |
+| `metadata`               | not required          | [see more](#metadata)              |
+| `facts`                  | required              | [see more](#facts)                 |
 | `customization_disabled` | not required          | [see more](#disable-customization) |
-| `values`                | not required          | [see more](#values)               |
-| `expectations`          | required              | [see more](#expectations)         |
+| `values`                 | not required          | [see more](#values)                |
+| `expectations`           | required              | [see more](#expectations)          |
 
 ---
 

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -113,8 +113,6 @@ defmodule Wanda.Catalog do
     end)
   end
 
-  # has_disabled_customization?
-
   defp map_selectable_check_values(
          _custom_values,
          check_values,

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -80,7 +80,7 @@ defmodule Wanda.Catalog do
   end
 
   defp map_to_selectable_check(%Check{} = check, available_customizations) do
-    customization_globally_disabled? = check.disable_customization
+    customization_globally_disabled? = check.customization_disabled
 
     mapped_values =
       check.id
@@ -88,7 +88,7 @@ defmodule Wanda.Catalog do
       |> map_selectable_check_values(check.values, customization_globally_disabled?)
 
     customizable_check? =
-      detect_check_customizability(mapped_values, not check.disable_customization)
+      detect_check_customizability(mapped_values, not check.customization_disabled)
 
     %SelectableCheck{
       id: check.id,
@@ -229,7 +229,7 @@ defmodule Wanda.Catalog do
        facts: Enum.map(facts, &map_fact/1),
        values: mapped_values,
        expectations: Enum.map(expectations, &map_expectation/1),
-       disable_customization: Map.get(check, "disable_customization", false)
+       customization_disabled: Map.get(check, "customization_disabled", false)
      }}
   end
 
@@ -302,13 +302,13 @@ defmodule Wanda.Catalog do
       name: name,
       default: default,
       conditions: conditions,
-      disable_customization: Map.get(value, "disable_customization", false)
+      customization_disabled: Map.get(value, "customization_disabled", false)
     }
   end
 
   defp detect_value_customizability(_, true = _customization_globally_disabled?), do: false
 
-  defp detect_value_customizability(%{disable_customization: true}, _), do: false
+  defp detect_value_customizability(%{customization_disabled: true}, _), do: false
 
   defp detect_value_customizability(%{default: default_value}, _),
     do: not (is_list(default_value) or is_map(default_value))

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -79,22 +79,30 @@ defmodule Wanda.Catalog do
     |> Enum.map(&map_to_selectable_check(&1, available_customizations))
   end
 
-  defp map_to_selectable_check(%Check{} = check, available_customizations) do
-    customization_globally_disabled? = check.customization_disabled
-
+  defp map_to_selectable_check(
+         %Check{
+           id: id,
+           name: name,
+           group: group,
+           description: description,
+           values: values,
+           customization_disabled: customization_globally_disabled?
+         },
+         available_customizations
+       ) do
     mapped_values =
-      check.id
+      id
       |> find_custom_values(available_customizations)
-      |> map_selectable_check_values(check.values, customization_globally_disabled?)
+      |> map_selectable_check_values(values, customization_globally_disabled?)
 
     customizable_check? =
-      detect_check_customizability(mapped_values, not check.customization_disabled)
+      detect_check_customizability(mapped_values, not customization_globally_disabled?)
 
     %SelectableCheck{
-      id: check.id,
-      name: check.name,
-      group: check.group,
-      description: check.description,
+      id: id,
+      name: name,
+      group: group,
+      description: description,
       values: mapped_values,
       customizable: customizable_check?,
       customized:

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -119,9 +119,9 @@ defmodule Wanda.Catalog do
                                 default: default_value
                               } = value ->
       %{
-        name: value_name,
-        customizable: detect_value_customizability(value, customization_globally_disabled?)
+        name: value_name
       }
+      |> add_value_customizability(value, customization_globally_disabled?)
       |> maybe_add_current_value(default_value)
       |> maybe_add_customization(custom_values)
     end)
@@ -306,11 +306,22 @@ defmodule Wanda.Catalog do
     }
   end
 
-  defp detect_value_customizability(_, true = _customization_globally_disabled?), do: false
+  defp add_value_customizability(
+         mapped_value,
+         current_value,
+         customization_globally_disabled?
+       ) do
+    Map.put(
+      mapped_value,
+      :customizable,
+      can_customize_value?(current_value, customization_globally_disabled?)
+    )
+  end
 
-  defp detect_value_customizability(%{customization_disabled: true}, _), do: false
+  defp can_customize_value?(_current_value, true = _customization_globally_disabled?), do: false
+  defp can_customize_value?(%{customization_disabled: true}, _), do: false
 
-  defp detect_value_customizability(%{default: default_value}, _),
+  defp can_customize_value?(%{default: default_value}, _),
     do: not (is_list(default_value) or is_map(default_value))
 
   defp detect_check_customizability([] = _values, _root_customizability), do: false

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -20,14 +20,14 @@ defmodule Wanda.Catalog.Check do
     :values,
     :expectations,
     :when,
-    :disable_customization
+    :customization_disabled
   ]
 
   @type t :: %__MODULE__{
           id: String.t(),
           name: String.t(),
           group: String.t(),
-          disable_customization: boolean(),
+          customization_disabled: boolean(),
           description: String.t(),
           remediation: String.t(),
           metadata: map(),

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -20,14 +20,14 @@ defmodule Wanda.Catalog.Check do
     :values,
     :expectations,
     :when,
-    :customizable
+    :disable_customization
   ]
 
   @type t :: %__MODULE__{
           id: String.t(),
           name: String.t(),
           group: String.t(),
-          customizable: boolean(),
+          disable_customization: boolean(),
           description: String.t(),
           remediation: String.t(),
           metadata: map(),

--- a/lib/wanda/catalog/value.ex
+++ b/lib/wanda/catalog/value.ex
@@ -6,12 +6,12 @@ defmodule Wanda.Catalog.Value do
   alias Wanda.Catalog.Condition
 
   @derive Jason.Encoder
-  defstruct [:name, :default, :conditions, :customizable]
+  defstruct [:name, :default, :conditions, :disable_customization]
 
   @type t :: %__MODULE__{
           name: String.t(),
           default: boolean() | number() | String.t(),
           conditions: [Condition.t()],
-          customizable: boolean()
+          disable_customization: boolean()
         }
 end

--- a/lib/wanda/catalog/value.ex
+++ b/lib/wanda/catalog/value.ex
@@ -6,12 +6,12 @@ defmodule Wanda.Catalog.Value do
   alias Wanda.Catalog.Condition
 
   @derive Jason.Encoder
-  defstruct [:name, :default, :conditions, :disable_customization]
+  defstruct [:name, :default, :conditions, :customization_disabled]
 
   @type t :: %__MODULE__{
           name: String.t(),
           default: boolean() | number() | String.t(),
           conditions: [Condition.t()],
-          disable_customization: boolean()
+          customization_disabled: boolean()
         }
 end

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -48,9 +48,9 @@ defmodule Wanda.ChecksCustomizations do
     end
   end
 
-  defp determine_customizability(%Check{customizable: true}), do: {:ok, :customizable}
+  defp determine_customizability(%Check{disable_customization: false}), do: {:ok, :customizable}
 
-  defp determine_customizability(%Check{customizable: false}),
+  defp determine_customizability(%Check{disable_customization: true}),
     do: {:error, :check_not_customizable}
 
   defp validate_incoming_custom_values([], _), do: {:error, :invalid_custom_values}
@@ -62,8 +62,8 @@ defmodule Wanda.ChecksCustomizations do
     can_customize? =
       Enum.all?(custom_values, fn %{name: customized_name, value: customized_value} ->
         case validate_value_exists_in_check(customized_name, values) do
-          {:ok, %Value{customizable: customizable, default: default_value}} ->
-            customizable and match_value_type(default_value, customized_value)
+          {:ok, %Value{disable_customization: disable_customization, default: default_value}} ->
+            not disable_customization and match_value_type(default_value, customized_value)
 
           {:error, :value_not_found} ->
             false

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -48,9 +48,9 @@ defmodule Wanda.ChecksCustomizations do
     end
   end
 
-  defp determine_customizability(%Check{disable_customization: false}), do: {:ok, :customizable}
+  defp determine_customizability(%Check{customization_disabled: false}), do: {:ok, :customizable}
 
-  defp determine_customizability(%Check{disable_customization: true}),
+  defp determine_customizability(%Check{customization_disabled: true}),
     do: {:error, :check_not_customizable}
 
   defp validate_incoming_custom_values([], _), do: {:error, :invalid_custom_values}
@@ -62,8 +62,8 @@ defmodule Wanda.ChecksCustomizations do
     can_customize? =
       Enum.all?(custom_values, fn %{name: customized_name, value: customized_value} ->
         case validate_value_exists_in_check(customized_name, values) do
-          {:ok, %Value{disable_customization: disable_customization, default: default_value}} ->
-            not disable_customization and match_value_type(default_value, customized_value)
+          {:ok, %Value{customization_disabled: customization_disabled, default: default_value}} ->
+            not customization_disabled and match_value_type(default_value, customized_value)
 
           {:error, :value_not_found} ->
             false

--- a/lib/wanda_web/controllers/v1/catalog_json.ex
+++ b/lib/wanda_web/controllers/v1/catalog_json.ex
@@ -56,7 +56,7 @@ defmodule WandaWeb.V1.CatalogJSON do
   end
 
   def adapt_values_customizability(values) do
-    Enum.map(values, &(&1 |> Map.from_struct() |> Map.drop([:disable_customization])))
+    Enum.map(values, &(&1 |> Map.from_struct() |> Map.drop([:customization_disabled])))
   end
 
   defp selectable_check(%SelectableCheck{

--- a/lib/wanda_web/controllers/v1/catalog_json.ex
+++ b/lib/wanda_web/controllers/v1/catalog_json.ex
@@ -56,7 +56,7 @@ defmodule WandaWeb.V1.CatalogJSON do
   end
 
   def adapt_values_customizability(values) do
-    Enum.map(values, &(&1 |> Map.from_struct() |> Map.drop([:customizable])))
+    Enum.map(values, &(&1 |> Map.from_struct() |> Map.drop([:disable_customization])))
   end
 
   defp selectable_check(%SelectableCheck{

--- a/lib/wanda_web/controllers/v3/catalog_json.ex
+++ b/lib/wanda_web/controllers/v3/catalog_json.ex
@@ -17,7 +17,7 @@ defmodule WandaWeb.V3.CatalogJSON do
         values: values,
         expectations: expectations,
         when: when_expression,
-        customizable: customizable
+        disable_customization: disable_customization
       }) do
     %{
       id: id,
@@ -32,7 +32,7 @@ defmodule WandaWeb.V3.CatalogJSON do
       expectations: expectations,
       when: when_expression,
       premium: false,
-      customizable: customizable
+      disable_customization: disable_customization
     }
   end
 end

--- a/lib/wanda_web/controllers/v3/catalog_json.ex
+++ b/lib/wanda_web/controllers/v3/catalog_json.ex
@@ -17,7 +17,7 @@ defmodule WandaWeb.V3.CatalogJSON do
         values: values,
         expectations: expectations,
         when: when_expression,
-        disable_customization: disable_customization
+        customization_disabled: customization_disabled
       }) do
     %{
       id: id,
@@ -32,7 +32,7 @@ defmodule WandaWeb.V3.CatalogJSON do
       expectations: expectations,
       when: when_expression,
       premium: false,
-      disable_customization: disable_customization
+      customization_disabled: customization_disabled
     }
   end
 end

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -75,12 +75,12 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
                   required: [:value, :expression]
                 }
               },
-              disable_customization: %Schema{
+              customization_disabled: %Schema{
                 type: :boolean,
                 description: "Whether the value is customizable or not"
               }
             },
-            required: [:name, :default, :conditions, :disable_customization]
+            required: [:name, :default, :conditions, :customization_disabled]
           }
         },
         expectations: %Schema{
@@ -124,7 +124,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
           description: "Check is Premium or not",
           deprecated: true
         },
-        disable_customization: %Schema{
+        customization_disabled: %Schema{
           type: :boolean,
           description: "Whether the check is customizable or not"
         }
@@ -142,7 +142,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         :expectations,
         :when,
         :premium,
-        :disable_customization
+        :customization_disabled
       ]
     },
     struct?: false

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -75,12 +75,12 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
                   required: [:value, :expression]
                 }
               },
-              customizable: %Schema{
+              disable_customization: %Schema{
                 type: :boolean,
                 description: "Whether the value is customizable or not"
               }
             },
-            required: [:name, :default, :conditions, :customizable]
+            required: [:name, :default, :conditions, :disable_customization]
           }
         },
         expectations: %Schema{
@@ -124,7 +124,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
           description: "Check is Premium or not",
           deprecated: true
         },
-        customizable: %Schema{
+        disable_customization: %Schema{
           type: :boolean,
           description: "Whether the check is customizable or not"
         }
@@ -142,7 +142,7 @@ defmodule WandaWeb.Schemas.V3.Catalog.Check do
         :expectations,
         :when,
         :premium,
-        :customizable
+        :disable_customization
       ]
     },
     struct?: false

--- a/test/fixtures/catalog/customizable_check.yaml
+++ b/test/fixtures/catalog/customizable_check.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# disable_customization: false #inferred
+# customization_disabled: false #inferred
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    # disable_customization: false #inferred
+    # customization_disabled: false #inferred
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    disable_customization: true
+    customization_disabled: true
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/catalog/customizable_check.yaml
+++ b/test/fixtures/catalog/customizable_check.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# customizable: true #inferred
+# disable_customization: false #inferred
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    # customizable: true #inferred
+    # disable_customization: false #inferred
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    customizable: false
+    disable_customization: true
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/catalog/non_customizable_check.yaml
+++ b/test/fixtures/catalog/non_customizable_check.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-disable_customization: true
+customization_disabled: true
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    # disable_customization: false #inferred
+    # customization_disabled: false #inferred
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    # disable_customization: false #inferred
+    # customization_disabled: false #inferred
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/catalog/non_customizable_check.yaml
+++ b/test/fixtures/catalog/non_customizable_check.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-customizable: false
+disable_customization: true
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    # customizable: true #inferred
+    # disable_customization: false #inferred
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    # customizable: true #inferred
+    # disable_customization: false #inferred
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/catalog/non_customizable_check_values.yaml
+++ b/test/fixtures/catalog/non_customizable_check_values.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# customizable: false #inferred
+# disable_customization: true #inferred
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    customizable: false
+    disable_customization: true
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    customizable: false
+    disable_customization: true
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/catalog/non_customizable_check_values.yaml
+++ b/test/fixtures/catalog/non_customizable_check_values.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# disable_customization: true #inferred
+# customization_disabled: true #inferred
 metadata:
   some_key: some_value
 facts:
@@ -18,7 +18,7 @@ facts:
 values:
   - name: expected_value
     default: 5
-    disable_customization: true
+    customization_disabled: true
     conditions:
       - value: 10
         when: some_expression
@@ -26,7 +26,7 @@ values:
         when: some_other_expression
   - name: expected_higher_value
     default: 10
-    disable_customization: true
+    customization_disabled: true
     conditions:
       - value: 5
         when: some_third_expression

--- a/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
+++ b/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# customizable: true #inferred
+# disable_customization: false #inferred
 metadata:
   id: mixed_values_customizability  
   some_key: some_value
@@ -20,7 +20,7 @@ facts:
 values:
   - name: numeric_value
     default: 5
-    customizable: true
+    disable_customization: false
     conditions:
       - value: 10
         when: some_expression
@@ -28,16 +28,16 @@ values:
         when: some_other_expression
   - name: customizable_string_value
     default: foo_bar
-    # customizable: true #inferred
+    # disable_customization: false #inferred
     conditions:
       - value: baz_qux
         when: some_third_expression
   - name: non_customizable_string_value
     default: kaboom
-    customizable: false
+    disable_customization: true
   - name: bool_value
     default: true
-    # customizable: true #inferred
+    # disable_customization: false #inferred
     conditions:
       - value: false
         when: some_fourth_expression
@@ -45,14 +45,14 @@ values:
     default: 
       - foo
       - bar
-    # customizable: false #inferred
+    # disable_customization: true #inferred
   - name: map_value
     default:
       foo: bar
       baz: 
         - qux
         - quux
-    customizable: false
+    disable_customization: true
 expectations:
   - name: some_expectation
     expect: facts.jedi == values.numeric_value

--- a/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
+++ b/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
@@ -6,7 +6,7 @@ description: |
 remediation: |
   ## Remediation
   Remediation text
-# disable_customization: false #inferred
+# customization_disabled: false #inferred
 metadata:
   id: mixed_values_customizability  
   some_key: some_value
@@ -20,7 +20,7 @@ facts:
 values:
   - name: numeric_value
     default: 5
-    disable_customization: false
+    customization_disabled: false
     conditions:
       - value: 10
         when: some_expression
@@ -28,16 +28,16 @@ values:
         when: some_other_expression
   - name: customizable_string_value
     default: foo_bar
-    # disable_customization: false #inferred
+    # customization_disabled: false #inferred
     conditions:
       - value: baz_qux
         when: some_third_expression
   - name: non_customizable_string_value
     default: kaboom
-    disable_customization: true
+    customization_disabled: true
   - name: bool_value
     default: true
-    # disable_customization: false #inferred
+    # customization_disabled: false #inferred
     conditions:
       - value: false
         when: some_fourth_expression
@@ -45,14 +45,14 @@ values:
     default: 
       - foo
       - bar
-    # disable_customization: true #inferred
+    # customization_disabled: true #inferred
   - name: map_value
     default:
       foo: bar
       baz: 
         - qux
         - quux
-    disable_customization: true
+    customization_disabled: true
 expectations:
   - name: some_expectation
     expect: facts.jedi == values.numeric_value

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -56,7 +56,7 @@ defmodule Wanda.Factory do
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
       when: Faker.Lorem.sentence(),
-      disable_customization: Enum.random([false, true])
+      customization_disabled: Enum.random([false, true])
     }
   end
 
@@ -73,7 +73,7 @@ defmodule Wanda.Factory do
       name: Faker.StarWars.character(),
       default: Faker.StarWars.character(),
       conditions: build_list(10, :catalog_condition),
-      disable_customization: Enum.random([false, true])
+      customization_disabled: Enum.random([false, true])
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -56,7 +56,7 @@ defmodule Wanda.Factory do
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
       when: Faker.Lorem.sentence(),
-      customizable: Enum.random([false, true])
+      disable_customization: Enum.random([false, true])
     }
   end
 
@@ -73,7 +73,7 @@ defmodule Wanda.Factory do
       name: Faker.StarWars.character(),
       default: Faker.StarWars.character(),
       conditions: build_list(10, :catalog_condition),
-      customizable: Enum.random([false, true])
+      disable_customization: Enum.random([false, true])
     }
   end
 

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -396,8 +396,8 @@ defmodule Wanda.CatalogTest do
       assert %SelectableCheck{customizable: false, values: []} =
                find_check.("check_without_values")
 
-      %SelectableCheck{customizable: false, values: explicit_non_customizable_check_values} =
-        find_check.("non_customizable_check_values")
+      assert %SelectableCheck{customizable: false, values: explicit_non_customizable_check_values} =
+               find_check.("non_customizable_check_values")
 
       assert Enum.all?(explicit_non_customizable_check_values, fn %{customizable: customizable} ->
                not customizable

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -282,7 +282,7 @@ defmodule Wanda.CatalogTest do
           ]
         )
 
-        expected_cutomizations = [
+        expected_customizations = [
           %{
             name: "numeric_value",
             customizable: true,
@@ -325,7 +325,7 @@ defmodule Wanda.CatalogTest do
           selectable_checks,
           fn
             %SelectableCheck{id: ^customized_check_id, values: values, customized: customized} ->
-              assert ^expected_cutomizations = values
+              assert ^expected_customizations = values
               assert customized
 
             %SelectableCheck{values: values, customized: customized} ->

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -208,53 +208,23 @@ defmodule Wanda.CatalogTest do
                  %{}
                )
     end
-  end
 
-  describe "checks customizability" do
     test "should allow opting out a check's customizability" do
-      assert {:ok, %Check{customizable: false, values: values}} =
+      assert {:ok, %Check{disable_customization: true}} =
                Catalog.get_check("non_customizable_check")
-
-      assert Enum.all?(values, fn %Value{customizable: customizable} -> customizable end)
     end
 
-    test "should detect a check as non customizable because it does not have values" do
-      # check_without_values does not have values and it does not have a customizable key in the root
-      assert {:ok, %Check{customizable: false, values: []}} =
-               Catalog.get_check("check_without_values")
-    end
-
-    test "should detect a check as non customizable because all its values are non customizable" do
-      # non_customizable_check_values has all its values non customizable
-      # and it does not have a customizable key in the root
-      assert {:ok, %Check{customizable: false, values: values}} =
-               Catalog.get_check("non_customizable_check_values")
-
-      assert Enum.all?(values, fn %Value{customizable: customizable} -> not customizable end)
-    end
-
-    test "should detect a customizable check" do
+    test "should expose customizability opt-out flags as defined in check's spec" do
       assert {:ok,
               %Check{
-                customizable: true,
+                disable_customization: false,
                 values: [
-                  %Value{name: "expected_value", customizable: true},
-                  %Value{name: "expected_higher_value", customizable: false}
-                ]
-              }} = Catalog.get_check("customizable_check")
-    end
-
-    test "should allow customizability of values based on type" do
-      assert {:ok,
-              %Check{
-                customizable: true,
-                values: [
-                  %Value{name: "numeric_value", customizable: true},
-                  %Value{name: "customizable_string_value", customizable: true},
-                  %Value{name: "non_customizable_string_value", customizable: false},
-                  %Value{name: "bool_value", customizable: true},
-                  %Value{name: "list_value", customizable: false},
-                  %Value{name: "map_value", customizable: false}
+                  %Value{name: "numeric_value", disable_customization: false},
+                  %Value{name: "customizable_string_value", disable_customization: false},
+                  %Value{name: "non_customizable_string_value", disable_customization: true},
+                  %Value{name: "bool_value", disable_customization: false},
+                  %Value{name: "list_value", disable_customization: false},
+                  %Value{name: "map_value", disable_customization: true}
                 ]
               }} = Catalog.get_check("mixed_values_customizability")
     end
@@ -402,6 +372,56 @@ defmodule Wanda.CatalogTest do
              |> Enum.find(&(&1.id == customized_check_id))
              |> Map.get(:values)
              |> Enum.any?(&(&1.name == "non_existing_value"))
+    end
+
+    test "should properly compute customizability information" do
+      selectable_checks =
+        Catalog.get_catalog_for_group(Faker.UUID.v4(), %{
+          "id" => "mixed_values_customizability"
+        })
+
+      find_check = fn id ->
+        Enum.find(selectable_checks, fn %SelectableCheck{id: check_id} ->
+          id == check_id
+        end)
+      end
+
+      assert %SelectableCheck{customizable: false, values: forcedly_non_customizable_values} =
+               find_check.("non_customizable_check")
+
+      assert Enum.all?(forcedly_non_customizable_values, fn %{customizable: customizable} ->
+               not customizable
+             end)
+
+      assert %SelectableCheck{customizable: false, values: []} =
+               find_check.("check_without_values")
+
+      %SelectableCheck{customizable: false, values: explicit_non_customizable_check_values} =
+        find_check.("non_customizable_check_values")
+
+      assert Enum.all?(explicit_non_customizable_check_values, fn %{customizable: customizable} ->
+               not customizable
+             end)
+
+      assert %SelectableCheck{
+               customizable: true,
+               values: [
+                 %{name: "expected_value", customizable: true},
+                 %{name: "expected_higher_value", customizable: false}
+               ]
+             } = find_check.("customizable_check")
+
+      assert %SelectableCheck{
+               customizable: true,
+               values: [
+                 %{name: "numeric_value", customizable: true},
+                 %{name: "customizable_string_value", customizable: true},
+                 %{name: "non_customizable_string_value", customizable: false},
+                 %{name: "bool_value", customizable: true},
+                 %{name: "list_value", customizable: false},
+                 %{name: "map_value", customizable: false}
+               ]
+             } = find_check.("mixed_values_customizability")
     end
 
     defp assert_non_customized_value(%{name: _, customizable: customizable} = value) do

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -210,21 +210,21 @@ defmodule Wanda.CatalogTest do
     end
 
     test "should allow opting out a check's customizability" do
-      assert {:ok, %Check{disable_customization: true}} =
+      assert {:ok, %Check{customization_disabled: true}} =
                Catalog.get_check("non_customizable_check")
     end
 
     test "should expose customizability opt-out flags as defined in check's spec" do
       assert {:ok,
               %Check{
-                disable_customization: false,
+                customization_disabled: false,
                 values: [
-                  %Value{name: "numeric_value", disable_customization: false},
-                  %Value{name: "customizable_string_value", disable_customization: false},
-                  %Value{name: "non_customizable_string_value", disable_customization: true},
-                  %Value{name: "bool_value", disable_customization: false},
-                  %Value{name: "list_value", disable_customization: false},
-                  %Value{name: "map_value", disable_customization: true}
+                  %Value{name: "numeric_value", customization_disabled: false},
+                  %Value{name: "customizable_string_value", customization_disabled: false},
+                  %Value{name: "non_customizable_string_value", customization_disabled: true},
+                  %Value{name: "bool_value", customization_disabled: false},
+                  %Value{name: "list_value", customization_disabled: false},
+                  %Value{name: "map_value", customization_disabled: true}
                 ]
               }} = Catalog.get_check("mixed_values_customizability")
     end

--- a/test/wanda_web/controllers/v3/catalog_json_test.exs
+++ b/test/wanda_web/controllers/v3/catalog_json_test.exs
@@ -22,7 +22,7 @@ defmodule WandaWeb.V3.CatalogJSONTest do
           values: values,
           expectations: expectations,
           when: when_expression,
-          disable_customization: disable_customization
+          customization_disabled: customization_disabled
         }
       ] = checks = build_list(1, :check)
 
@@ -41,12 +41,12 @@ defmodule WandaWeb.V3.CatalogJSONTest do
                    expectations: ^expectations,
                    when: ^when_expression,
                    premium: false,
-                   disable_customization: ^disable_customization
+                   customization_disabled: ^customization_disabled
                  }
                ]
              } = CatalogJSON.catalog(%{catalog: checks})
 
-      assert Enum.all?(values, fn value -> Map.has_key?(value, :disable_customization) end)
+      assert Enum.all?(values, fn value -> Map.has_key?(value, :customization_disabled) end)
     end
   end
 end

--- a/test/wanda_web/controllers/v3/catalog_json_test.exs
+++ b/test/wanda_web/controllers/v3/catalog_json_test.exs
@@ -22,7 +22,7 @@ defmodule WandaWeb.V3.CatalogJSONTest do
           values: values,
           expectations: expectations,
           when: when_expression,
-          customizable: customizable
+          disable_customization: disable_customization
         }
       ] = checks = build_list(1, :check)
 
@@ -41,12 +41,12 @@ defmodule WandaWeb.V3.CatalogJSONTest do
                    expectations: ^expectations,
                    when: ^when_expression,
                    premium: false,
-                   customizable: ^customizable
+                   disable_customization: ^disable_customization
                  }
                ]
              } = CatalogJSON.catalog(%{catalog: checks})
 
-      assert Enum.all?(values, fn value -> Map.has_key?(value, :customizable) end)
+      assert Enum.all?(values, fn value -> Map.has_key?(value, :disable_customization) end)
     end
   end
 end


### PR DESCRIPTION
# Description

This PR changes the `customizable: true|false` flag in check's spec to `disable_customization: true`.

Note that in the catalog `disable_customization` is being returned as specified in the check (or its default value), while in the group specific api it plays a role in determining whether something is `customizable` or not.