### PR TITLE
Reset check customization

### DIFF
--- a/lib/wanda/catalog/customization_policy.ex
+++ b/lib/wanda/catalog/customization_policy.ex
@@ -9,8 +9,11 @@ defmodule Wanda.Catalog.CustomizationPolicy do
   alias Wanda.Catalog.CheckCustomization
   alias Wanda.Users.User
 
-  def authorize(:apply_custom_values, %User{} = user, CheckCustomization),
-    do: has_checks_customization_abilities?(user)
+  def authorize(action, %User{} = user, CheckCustomization)
+      when action in [:apply_custom_values, :reset_customization],
+      do: has_checks_customization_abilities?(user)
+
+  def authorize(_, _, _), do: false
 
   defp has_checks_customization_abilities?(user),
     do:

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -35,6 +35,19 @@ defmodule Wanda.ChecksCustomizations do
     end
   end
 
+  @spec reset_customization(check_id :: String.t(), group_id :: Ecto.UUID.t()) ::
+          :ok | {:error, :customization_not_found}
+  def reset_customization(check_id, group_id) do
+    deletion_query =
+      from c in CheckCustomization,
+        where: c.group_id == ^group_id and c.check_id == ^check_id
+
+    case Repo.delete_all(deletion_query) do
+      {1, _} -> :ok
+      {0, _} -> {:error, :customization_not_found}
+    end
+  end
+
   defp load_check(check_id) do
     case Catalog.get_check(check_id) do
       {:ok, %Check{}} = success ->

--- a/lib/wanda_web/controllers/fallback_controller.ex
+++ b/lib/wanda_web/controllers/fallback_controller.ex
@@ -48,6 +48,13 @@ defmodule WandaWeb.FallbackController do
     )
   end
 
+  def call(conn, {:error, :customization_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(json: ErrorJSON)
+    |> render(:"404", reason: "Referenced check customization was not found.")
+  end
+
   def call(conn, _) do
     conn
     |> put_status(:internal_server_error)

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -63,6 +63,10 @@ defmodule WandaWeb.Router do
         post "/:check_id/customize/:group_id",
              ChecksCustomizationsController,
              :apply_custom_values
+
+        delete "/:check_id/group/:group_id/customization",
+               ChecksCustomizationsController,
+               :reset_customization
       end
 
       if Application.compile_env!(:wanda, :operations_enabled) do

--- a/test/wanda/catalog/customization_policy_test.exs
+++ b/test/wanda/catalog/customization_policy_test.exs
@@ -4,38 +4,38 @@ defmodule Wanda.Catalog.CustomizationPolicyTest do
   alias Wanda.Catalog.{CheckCustomization, CustomizationPolicy}
   alias Wanda.Users.User
 
-  test "should allow checks customization only when required abilities are present" do
-    scenarios = [
-      %{
-        abilities: [],
-        expected: false
-      },
-      %{
-        abilities: [%{name: "foo", resource: "bar"}],
-        expected: false
-      },
-      %{
-        abilities: [%{name: "all", resource: "all"}],
-        expected: true
-      },
-      %{
-        abilities: [%{name: "all", resource: "check_customization"}],
-        expected: true
-      },
-      %{
-        abilities: [%{name: "all", resource: "all"}, %{name: "foo", resource: "bar"}],
-        expected: true
-      },
-      %{
-        abilities: [
-          %{name: "all", resource: "check_customization"},
-          %{name: "foo", resource: "bar"}
-        ],
-        expected: true
-      }
-    ]
+  @scenarios [
+    %{
+      abilities: [],
+      expected: false
+    },
+    %{
+      abilities: [%{name: "foo", resource: "bar"}],
+      expected: false
+    },
+    %{
+      abilities: [%{name: "all", resource: "all"}],
+      expected: true
+    },
+    %{
+      abilities: [%{name: "all", resource: "check_customization"}],
+      expected: true
+    },
+    %{
+      abilities: [%{name: "all", resource: "all"}, %{name: "foo", resource: "bar"}],
+      expected: true
+    },
+    %{
+      abilities: [
+        %{name: "all", resource: "check_customization"},
+        %{name: "foo", resource: "bar"}
+      ],
+      expected: true
+    }
+  ]
 
-    for %{abilities: abilities, expected: is_allowed} <- scenarios do
+  test "should allow checks customization only when required abilities are present" do
+    for %{abilities: abilities, expected: is_allowed} <- @scenarios do
       assert is_allowed ==
                CustomizationPolicy.authorize(
                  :apply_custom_values,
@@ -43,5 +43,29 @@ defmodule Wanda.Catalog.CustomizationPolicyTest do
                  CheckCustomization
                )
     end
+  end
+
+  test "should allow resetting checks customization only when required abilities are present" do
+    for %{abilities: abilities, expected: is_allowed} <- @scenarios do
+      assert is_allowed ==
+               CustomizationPolicy.authorize(
+                 :reset_customization,
+                 %User{abilities: abilities},
+                 CheckCustomization
+               )
+    end
+  end
+
+  test "should deny operations on invalid input" do
+    abilities = [
+      %{name: "all", resource: "check_customization"},
+      %{name: "foo", resource: "bar"}
+    ]
+
+    user = %User{abilities: abilities}
+
+    refute CustomizationPolicy.authorize(:foo, user, CheckCustomization)
+    refute CustomizationPolicy.authorize(:apply_custom_values, 42, CheckCustomization)
+    refute CustomizationPolicy.authorize(:reset_customization, user, Foo)
   end
 end

--- a/test/wanda/checks_customizations_test.exs
+++ b/test/wanda/checks_customizations_test.exs
@@ -328,24 +328,6 @@ defmodule Wanda.ChecksCustomizationsTest do
           group_id: group_id
         )
 
-      load_customizations = fn group_id ->
-        Repo.all(
-          from c in CheckCustomization,
-            where: c.group_id == ^group_id
-        )
-      end
-
-      assert [
-               %CheckCustomization{
-                 check_id: ^check_id_1,
-                 group_id: ^group_id
-               },
-               %CheckCustomization{
-                 check_id: ^check_id_2,
-                 group_id: ^group_id
-               }
-             ] = load_customizations.(group_id)
-
       assert :ok = ChecksCustomizations.reset_customization(check_id_1, group_id)
 
       assert [
@@ -353,7 +335,11 @@ defmodule Wanda.ChecksCustomizationsTest do
                  check_id: ^check_id_2,
                  group_id: ^group_id
                }
-             ] = load_customizations.(group_id)
+             ] =
+               Repo.all(
+                 from c in CheckCustomization,
+                   where: c.group_id == ^group_id
+               )
     end
   end
 end

--- a/test/wanda_web/controllers/fallback_controller_test.exs
+++ b/test/wanda_web/controllers/fallback_controller_test.exs
@@ -38,7 +38,8 @@ defmodule WandaWeb.FallbackControllerTest do
 
   test "should return a 404 on relevant errors", %{conn: conn} do
     errors_raising_not_found = [
-      {:check_not_found, "Referenced check was not found."}
+      {:check_not_found, "Referenced check was not found."},
+      {:customization_not_found, "Referenced check customization was not found."}
     ]
 
     for {error, message} <- errors_raising_not_found do


### PR DESCRIPTION
# Description

This PR adds the ability to reset customizations for a specific check in a specific execution group.

--- 

Note: I would like to followup with an improvement on API routes.

Current state:
```
# get a group specific catalog
GET     /api/v1/checks/groups/:group_id/catalog

# apply customization to a specific check in a specific execution group
POST    /api/v1/checks/:check_id/customize/:group_id

# reset customization for a specific check in a specific execution group
DELETE  /api/v1/checks/:check_id/group/:group_id/customization
```

I am quite ok with the group specific catalog, however I feel like we could improve the other two.
Options:

1. Streamline POST and DELETE
```
POST    /api/v1/checks/:check_id/group/:group_id/customization
DELETE  /api/v1/checks/:check_id/group/:group_id/customization
```

2. Streamline POST and DELETE without group part
```
POST    /api/v1/checks/:check_id/:group_id/customization
DELETE  /api/v1/checks/:check_id/:group_id/customization
```

3. Introduce a `group` scope
```
POST    /api/v1/groups/:group_id/check/:check_id/customization
DELETE  /api/v1/groups/:group_id/check/:check_id/customization
```

Feedback are welcome.