### PR TITLE
Using custom values in checks executions

### DIFF
--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -30,13 +30,13 @@ defmodule Wanda.Executions.FakeServer do
       ) do
     env = Map.put(env, "target_type", target_type)
 
-    checks =
+    selected_checks =
       targets
       |> Executions.Target.get_checks_from_targets()
       |> Catalog.get_current_selection(group_id, env)
 
     gathered_facts =
-      checks
+      selected_checks
       |> SelectedCheck.extract_specs()
       |> FakeGatheredFacts.get_demo_gathered_facts(targets)
 
@@ -50,7 +50,7 @@ defmodule Wanda.Executions.FakeServer do
       Evaluation.execute(
         execution_id,
         group_id,
-        checks,
+        selected_checks,
         gathered_facts,
         env,
         EvaluationEngine.new()

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -5,6 +5,7 @@ defmodule Wanda.Executions.FakeServer do
   """
   @behaviour Wanda.Executions.ServerBehaviour
 
+  alias Wanda.Catalog.SelectedCheck
   alias Wanda.EvaluationEngine
   alias Wanda.Executions.{Evaluation, FakeGatheredFacts}
 
@@ -32,9 +33,12 @@ defmodule Wanda.Executions.FakeServer do
     checks =
       targets
       |> Executions.Target.get_checks_from_targets()
-      |> Catalog.get_checks(env)
+      |> Catalog.get_current_selection(group_id, env)
 
-    gathered_facts = FakeGatheredFacts.get_demo_gathered_facts(checks, targets)
+    gathered_facts =
+      checks
+      |> SelectedCheck.extract_specs()
+      |> FakeGatheredFacts.get_demo_gathered_facts(targets)
 
     Executions.create_execution!(execution_id, group_id, targets)
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -33,7 +33,8 @@ defmodule Wanda.Executions.FakeServer do
     selected_checks =
       targets
       |> Executions.Target.get_checks_from_targets()
-      |> Catalog.get_current_selection(group_id, env)
+      |> Catalog.get_checks(env)
+      |> Catalog.to_selected_checks(group_id)
 
     gathered_facts =
       selected_checks

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -82,13 +82,11 @@ defmodule Wanda.Catalog do
     |> Enum.map(&map_to_selectable_check(&1, available_customizations))
   end
 
-  @spec get_current_selection([String.t()], String.t(), map()) :: [SelectedCheck.t()]
-  def get_current_selection(ids, group_id, env \\ %{}) do
+  @spec to_selected_checks([Check.t()], String.t()) :: [SelectedCheck.t()]
+  def to_selected_checks(checks, group_id) do
     available_customizations = ChecksCustomizations.get_customizations(group_id)
 
-    ids
-    |> get_checks(env)
-    |> Enum.map(&map_to_selected_check(&1, available_customizations))
+    Enum.map(checks, &map_to_selected_check(&1, available_customizations))
   end
 
   defp map_to_selectable_check(

--- a/lib/wanda/catalog/customized_value.ex
+++ b/lib/wanda/catalog/customized_value.ex
@@ -1,0 +1,19 @@
+defmodule Wanda.Catalog.CustomizedValue do
+  @moduledoc """
+  Represents a check's customized value.
+  """
+
+  defstruct [:name, :value]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          value: boolean() | number() | String.t()
+        }
+
+  def from_custom_value(%{name: name, value: value}) do
+    %__MODULE__{
+      name: name,
+      value: value
+    }
+  end
+end

--- a/lib/wanda/catalog/selected_check.ex
+++ b/lib/wanda/catalog/selected_check.ex
@@ -1,0 +1,26 @@
+defmodule Wanda.Catalog.SelectedCheck do
+  @moduledoc """
+  Represents a selected check used during a check execution.
+
+  It carries information about the check specification and its available customizations.
+  """
+
+  alias Wanda.Catalog.{Check, CustomizedValue}
+
+  defstruct [
+    :id,
+    :spec,
+    :customized,
+    :customizations
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          spec: Check.t(),
+          customized: boolean(),
+          customizations: [CustomizedValue.t()]
+        }
+
+  @spec extract_specs([t]) :: [Check.t()]
+  def extract_specs(selected_checks), do: Enum.map(selected_checks, & &1.spec)
+end

--- a/lib/wanda/executions/check_result.ex
+++ b/lib/wanda/executions/check_result.ex
@@ -11,6 +11,7 @@ defmodule Wanda.Executions.CheckResult do
   defstruct [
     :check_id,
     :result,
+    :customized,
     agents_check_results: [],
     expectation_results: []
   ]

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -131,9 +131,9 @@ defmodule Wanda.Executions.Evaluation do
 
       resolved_values =
         Enum.map(spec_values, fn %CatalogValue{name: name} = specified_value ->
-          customization = Enum.find(customizations, &(&1.name == name))
-
-          eval_value(specified_value, customization, value_evaluation_scope, engine)
+          customizations
+          |> Enum.find(specified_value, &(&1.name == name))
+          |> eval_value(value_evaluation_scope, engine)
         end)
 
       expectation_evaluation_scope =
@@ -172,7 +172,6 @@ defmodule Wanda.Executions.Evaluation do
            default: default,
            conditions: conditions
          },
-         nil = _customization,
          evaluation_scope,
          engine
        ) do
@@ -184,9 +183,6 @@ defmodule Wanda.Executions.Evaluation do
   end
 
   defp eval_value(
-         %CatalogValue{
-           name: name
-         },
          %CustomizedValue{name: name, value: custom_value},
          _,
          _

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -8,6 +8,8 @@ defmodule Wanda.Executions.Server do
 
   use GenServer, restart: :transient
 
+  alias Wanda.Catalog.SelectedCheck
+
   alias Wanda.Executions.{
     Evaluation,
     Gathering,
@@ -45,7 +47,7 @@ defmodule Wanda.Executions.Server do
     checks =
       targets
       |> Target.get_checks_from_targets()
-      |> Catalog.get_checks(env)
+      |> Catalog.get_current_selection(group_id, env)
 
     checks_ids = Enum.map(checks, & &1.id)
 
@@ -99,8 +101,10 @@ defmodule Wanda.Executions.Server do
       ) do
     engine = EvaluationEngine.new()
 
+    specs = SelectedCheck.extract_specs(checks)
+
     facts_gathering_requested =
-      Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, targets, checks)
+      Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, targets, specs)
 
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -47,7 +47,8 @@ defmodule Wanda.Executions.Server do
     checks =
       targets
       |> Target.get_checks_from_targets()
-      |> Catalog.get_current_selection(group_id, env)
+      |> Catalog.get_checks(env)
+      |> Catalog.to_selected_checks(group_id)
 
     checks_ids = Enum.map(checks, & &1.id)
 

--- a/lib/wanda/executions/state.ex
+++ b/lib/wanda/executions/state.ex
@@ -3,7 +3,7 @@ defmodule Wanda.Executions.State do
   State of an execution.
   """
 
-  alias Wanda.Catalog
+  alias Wanda.Catalog.SelectedCheck
   alias Wanda.Executions.Target
 
   defstruct [
@@ -24,7 +24,7 @@ defmodule Wanda.Executions.State do
           group_id: String.t(),
           timeout: integer(),
           targets: [Target.t()],
-          checks: [Catalog.Check.t()],
+          checks: [SelectedCheck.t()],
           env: %{String.t() => boolean() | number() | String.t()},
           gathered_facts: map(),
           agents_gathered: [String.t()]

--- a/lib/wanda/executions/value.ex
+++ b/lib/wanda/executions/value.ex
@@ -7,11 +7,13 @@ defmodule Wanda.Executions.Value do
   @derive Jason.Encoder
   defstruct [
     :name,
-    :value
+    :value,
+    :customized
   ]
 
   @type t :: %__MODULE__{
           name: String.t(),
-          value: boolean() | number() | String.t()
+          value: boolean() | number() | String.t(),
+          customized: boolean()
         }
 end

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -6,7 +6,8 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
   alias WandaWeb.Schemas.V1.Execution.{
     ExpectationEvaluation,
     ExpectationEvaluationError,
-    Fact
+    Fact,
+    Value
   }
 
   require OpenApiSpex
@@ -19,6 +20,11 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
       properties: %{
         agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
         facts: %Schema{type: :array, items: Fact, description: "Facts gathered from the targets"},
+        values: %Schema{
+          type: :array,
+          items: Value,
+          description: "Values resolved for the current execution"
+        },
         expectation_evaluations: %Schema{
           type: :array,
           items: %Schema{

--- a/lib/wanda_web/schemas/v1/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/check_result.ex
@@ -19,6 +19,7 @@ defmodule WandaWeb.Schemas.V1.Execution.CheckResult do
       additionalProperties: false,
       properties: %{
         check_id: %Schema{type: :string, description: "Check ID"},
+        customized: %Schema{type: :boolean, description: "Whether the check has been customized"},
         expectation_results: %Schema{type: :array, items: ExpectationResult},
         agents_check_results: %Schema{
           type: :array,

--- a/lib/wanda_web/schemas/v1/execution/value.ex
+++ b/lib/wanda_web/schemas/v1/execution/value.ex
@@ -16,7 +16,8 @@ defmodule WandaWeb.Schemas.V1.Execution.Value do
         value: %Schema{
           oneOf: [%Schema{type: :string}, %Schema{type: :number}, %Schema{type: :boolean}],
           description: "Value"
-        }
+        },
+        customized: %Schema{type: :boolean, description: "Whether the value has been customized"}
       },
       required: [:check_id, :name, :value]
     },

--- a/lib/wanda_web/schemas/v2/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/check_result.ex
@@ -17,6 +17,7 @@ defmodule WandaWeb.Schemas.V2.Execution.CheckResult do
       additionalProperties: false,
       properties: %{
         check_id: %Schema{type: :string, description: "Check ID"},
+        customized: %Schema{type: :boolean, description: "Whether the check has been customized"},
         expectation_results: %Schema{type: :array, items: ExpectationResult},
         agents_check_results: %Schema{
           type: :array,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,7 @@ defmodule Wanda.Factory do
   use ExMachina.Ecto, repo: Wanda.Repo
 
   alias Wanda.Catalog
-  alias Wanda.Catalog.CheckCustomization
+  alias Wanda.Catalog.{CheckCustomization, CustomizedValue, SelectedCheck}
 
   alias Wanda.Executions.{
     AgentCheckError,
@@ -156,6 +156,7 @@ defmodule Wanda.Factory do
     %CheckResult{
       agents_check_results: build_list(5, :agent_check_result),
       check_id: UUID.uuid4(),
+      customized: Enum.random([false, true]),
       expectation_results: build_list(5, :expectation_result),
       result: ExecutionResult.passing()
     }
@@ -304,6 +305,26 @@ defmodule Wanda.Factory do
       group_id: Faker.UUID.v4(),
       custom_values: build_list(5, :custom_value)
     }
+  end
+
+  def customized_value_factory do
+    %CustomizedValue{
+      name: Faker.UUID.v4(),
+      value: Faker.Pokemon.name()
+    }
+  end
+
+  def selected_check_factory(attrs) do
+    %Catalog.Check{id: id} = spec = Map.get(attrs, :spec, build(:check))
+
+    %SelectedCheck{
+      id: id,
+      spec: spec,
+      customized: Enum.random([false, true]),
+      customizations: build_list(5, :customized_value)
+    }
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes()
   end
 
   defp random_env_value do

--- a/test/wanda/catalog/selected_check_test.exs
+++ b/test/wanda/catalog/selected_check_test.exs
@@ -1,0 +1,26 @@
+defmodule Wanda.Catalog.SelectedCheckTest do
+  use ExUnit.Case
+
+  import Wanda.Factory
+
+  alias Wanda.Catalog.SelectedCheck
+
+  describe "selected check" do
+    test "should extract an empty list of specs from an empty list of selected checks" do
+      assert [] == SelectedCheck.extract_specs([])
+    end
+
+    test "should extract specs from a list of selected checks" do
+      [
+        %SelectedCheck{
+          spec: spec_1
+        },
+        %SelectedCheck{
+          spec: spec_2
+        }
+      ] = selected_checks = build_list(2, :selected_check)
+
+      assert [spec_1, spec_2] == SelectedCheck.extract_specs(selected_checks)
+    end
+  end
+end

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -435,38 +435,51 @@ defmodule Wanda.CatalogTest do
   end
 
   describe "checks execution selection" do
-    test "should return an empty current selection when check ids do not mathc" do
-      assert [] == Catalog.get_current_selection(["FOO", "BAR"], Faker.UUID.v4())
+    test "should return an empty list" do
+      assert [] == Catalog.to_selected_checks([], Faker.UUID.v4())
     end
 
     test "should return current selection with no customized checks" do
+      %Check{id: check_id_1} = check1 = build(:check)
+      %Check{id: check_id_2} = check2 = build(:check)
+
       assert [
                %SelectedCheck{
-                 id: "expect_check",
-                 spec: %Check{id: "expect_check"},
+                 id: ^check_id_1,
+                 spec: ^check1,
                  customized: false,
                  customizations: []
                },
                %SelectedCheck{
-                 id: "expect_same_check",
-                 spec: %Check{id: "expect_same_check"},
+                 id: ^check_id_2,
+                 spec: ^check2,
                  customized: false,
                  customizations: []
                }
-             ] =
-               Catalog.get_current_selection(
-                 ["expect_check", "expect_same_check"],
-                 Faker.UUID.v4()
-               )
+             ] = Catalog.to_selected_checks([check1, check2], Faker.UUID.v4())
     end
 
     test "should return current selection with some customized checks" do
       group_id = Faker.UUID.v4()
       custom_numeric_value = 420
 
+      %Check{id: check_id_1} = check1 = build(:check)
+      %Check{id: check_id_2} = check2 = build(:check)
+
+      %Check{id: check_id_3} =
+        check3 =
+        build(:check,
+          values: [
+            %{
+              name: "numeric_value",
+              value: 12
+            }
+          ]
+        )
+
       insert(:check_customization,
         group_id: group_id,
-        check_id: "mixed_values_customizability",
+        check_id: check_id_3,
         custom_values: [
           %{
             name: "numeric_value",
@@ -477,20 +490,20 @@ defmodule Wanda.CatalogTest do
 
       assert [
                %SelectedCheck{
-                 id: "expect_check",
-                 spec: %Check{id: "expect_check"},
+                 id: ^check_id_1,
+                 spec: ^check1,
                  customized: false,
                  customizations: []
                },
                %SelectedCheck{
-                 id: "expect_same_check",
-                 spec: %Check{id: "expect_same_check"},
+                 id: ^check_id_2,
+                 spec: ^check2,
                  customized: false,
                  customizations: []
                },
                %SelectedCheck{
-                 id: "mixed_values_customizability",
-                 spec: %Check{id: "mixed_values_customizability"},
+                 id: ^check_id_3,
+                 spec: ^check3,
                  customized: true,
                  customizations: [
                    %{
@@ -499,11 +512,7 @@ defmodule Wanda.CatalogTest do
                    }
                  ]
                }
-             ] =
-               Catalog.get_current_selection(
-                 ["expect_check", "expect_same_check", "mixed_values_customizability"],
-                 group_id
-               )
+             ] = Catalog.to_selected_checks([check1, check2, check3], group_id)
     end
   end
 end

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -40,9 +40,10 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+      %Catalog.Check{id: check_id} =
+        spec = build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: fact_value)
 
@@ -113,14 +114,16 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -196,14 +199,16 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -268,13 +273,15 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: fact_value)
 
@@ -345,14 +352,16 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -428,14 +437,16 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -486,14 +497,16 @@ defmodule Wanda.Executions.EvaluationTest do
       [%Catalog.Expectation{name: expectation_name}] =
         expectations = build_list(1, :catalog_expectation, type: :expect)
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id)
 
@@ -556,14 +569,16 @@ defmodule Wanda.Executions.EvaluationTest do
           expression: "facts.#{fact_name} == #{fact_value}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: fact_value)
 
@@ -614,14 +629,16 @@ defmodule Wanda.Executions.EvaluationTest do
 
       expectations = build_list(1, :catalog_expectation, type: :expect)
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :warning,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id)
 
@@ -654,14 +671,16 @@ defmodule Wanda.Executions.EvaluationTest do
 
       expectations = build_list(1, :catalog_expectation, type: :expect, expression: "1 == 1")
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :warning,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id)
 
@@ -776,9 +795,11 @@ defmodule Wanda.Executions.EvaluationTest do
           )
         ]
 
-        [%Catalog.Check{id: check_id}] =
-          checks =
-          build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+        %Catalog.Check{id: check_id} =
+          spec =
+          build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+        checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
         facts_agent_1 = [
           build(:fact, name: fact_1_name, check_id: check_id, value: agent_1_fact_1_value),
@@ -843,9 +864,11 @@ defmodule Wanda.Executions.EvaluationTest do
           failure_message: nil
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: "unknown")
 
@@ -947,9 +970,11 @@ defmodule Wanda.Executions.EvaluationTest do
             warning_message: warning_mesasge
           )
 
-        [%Catalog.Check{id: check_id}] =
-          checks =
-          build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+        %Catalog.Check{id: check_id} =
+          spec =
+          build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+        checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
         facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: fact_value)
 
@@ -1022,9 +1047,11 @@ defmodule Wanda.Executions.EvaluationTest do
         )
       ]
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: array)
 
@@ -1094,9 +1121,11 @@ defmodule Wanda.Executions.EvaluationTest do
         )
       ]
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check, facts: catalog_facts, values: [], expectations: expectations)
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check, facts: catalog_facts, values: [], expectations: expectations)
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       facts = build_list(1, :fact, name: fact_name, check_id: check_id, value: map)
 
@@ -1127,7 +1156,7 @@ defmodule Wanda.Executions.EvaluationTest do
 
   describe "environment based check evaluation" do
     setup do
-      check =
+      spec =
         build(:check,
           severity: :critical,
           facts: [
@@ -1162,7 +1191,7 @@ defmodule Wanda.Executions.EvaluationTest do
           ]
         )
 
-      %{checks: [check]}
+      %{checks: build_list(1, :selected_check, spec: spec, customized: false, customizations: [])}
     end
 
     test "should return a passing result based on the first matching environmental condition",
@@ -1186,6 +1215,7 @@ defmodule Wanda.Executions.EvaluationTest do
         group_id: group_id,
         check_results: [
           %CheckResult{
+            customized: false,
             agents_check_results: [
               %AgentCheckResult{
                 agent_id: "agent_1",
@@ -1204,7 +1234,11 @@ defmodule Wanda.Executions.EvaluationTest do
                   }
                 ],
                 values: [
-                  %Value{name: "some_value", value: "value_on_first_condition"}
+                  %Value{
+                    name: "some_value",
+                    value: "value_on_first_condition",
+                    customized: false
+                  }
                 ]
               },
               %AgentCheckResult{
@@ -1224,7 +1258,11 @@ defmodule Wanda.Executions.EvaluationTest do
                   }
                 ],
                 values: [
-                  %Value{name: "some_value", value: "value_on_first_condition"}
+                  %Value{
+                    name: "some_value",
+                    value: "value_on_first_condition",
+                    customized: false
+                  }
                 ]
               }
             ],
@@ -1370,6 +1408,7 @@ defmodule Wanda.Executions.EvaluationTest do
         group_id: group_id,
         check_results: [
           %CheckResult{
+            customized: false,
             agents_check_results: [
               %AgentCheckResult{
                 agent_id: "agent_1",
@@ -1388,7 +1427,7 @@ defmodule Wanda.Executions.EvaluationTest do
                   }
                 ],
                 values: [
-                  %Value{name: "some_value", value: "a_default_value"}
+                  %Value{name: "some_value", value: "a_default_value", customized: false}
                 ]
               },
               %AgentCheckResult{
@@ -1408,7 +1447,7 @@ defmodule Wanda.Executions.EvaluationTest do
                   }
                 ],
                 values: [
-                  %Value{name: "some_value", value: "a_default_value"}
+                  %Value{name: "some_value", value: "a_default_value", customized: false}
                 ]
               }
             ],
@@ -1575,14 +1614,16 @@ defmodule Wanda.Executions.EvaluationTest do
           failure_message: "failure checking ${facts.#{fact_name}}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -1666,14 +1707,16 @@ defmodule Wanda.Executions.EvaluationTest do
           failure_message: failure_message
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -1749,9 +1792,9 @@ defmodule Wanda.Executions.EvaluationTest do
 
       incorrect_fact_value = Faker.Cat.name()
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: [
             build(:catalog_fact, name: fact_name),
@@ -1773,6 +1816,8 @@ defmodule Wanda.Executions.EvaluationTest do
             )
           ]
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -1800,6 +1845,7 @@ defmodule Wanda.Executions.EvaluationTest do
                group_id: ^group_id,
                check_results: [
                  %CheckResult{
+                   customized: false,
                    check_id: ^check_id,
                    expectation_results: [
                      %ExpectationResult{
@@ -1840,14 +1886,16 @@ defmodule Wanda.Executions.EvaluationTest do
           failure_message: "failure checking ${facts.kekw}"
         )
 
-      [%Catalog.Check{id: check_id}] =
-        checks =
-        build_list(1, :check,
+      %Catalog.Check{id: check_id} =
+        spec =
+        build(:check,
           severity: :critical,
           facts: catalog_facts,
           values: [],
           expectations: expectations
         )
+
+      checks = build_list(1, :selected_check, spec: spec, customized: false, customizations: [])
 
       gathered_facts = %{
         check_id => %{
@@ -1907,6 +1955,258 @@ defmodule Wanda.Executions.EvaluationTest do
                ],
                result: :critical
              } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+    end
+  end
+
+  describe "evaluating with customizations" do
+    test "should evaluate result taking into account customizations", %{
+      engine: engine
+    } do
+      spec =
+        build(:check,
+          severity: :critical,
+          facts: [
+            build(:catalog_fact, name: "fact_1"),
+            build(:catalog_fact, name: "fact_2")
+          ],
+          values: [
+            build(:catalog_value,
+              name: "value_1",
+              default: "value_1_default",
+              conditions: [
+                build(:catalog_condition,
+                  value: "value_1_condition_1",
+                  expression: "env.env_1 == \"foo\" || env.env_1 == \"bar\""
+                ),
+                build(:catalog_condition,
+                  value: "value_1_condition_2",
+                  expression: "env.env_1 == \"baz\""
+                )
+              ]
+            ),
+            build(:catalog_value,
+              name: "value_2",
+              default: "value_2_default",
+              conditions: [
+                build(:catalog_condition,
+                  value: "value_2_condition_1",
+                  expression: "env.env_2 == \"foo\" || env.env_2 == \"bar\""
+                )
+              ]
+            )
+          ],
+          expectations: [
+            build(:catalog_expectation,
+              name: "expectation_1",
+              type: :expect,
+              expression: "facts.fact_1 == values.value_1",
+              failure_message:
+                "Failure message 1: values.value_1 is expected to be <- ${values.value_1} ->"
+            ),
+            build(:catalog_expectation,
+              name: "expectation_2",
+              type: :expect_same,
+              expression: "facts.fact_2 == values.value_2"
+            ),
+            build(:catalog_expectation,
+              name: "expectation_3",
+              type: :expect_enum,
+              failure_message:
+                "Failure message 3: values.value_1 is expected to be <- ${values.value_1} ->",
+              warning_message:
+                "Warning message 1: values.value_1 is expected to be <- ${values.value_1} ->",
+              expression: """
+              if facts.fact_1 == values.value_1 {
+                "passing"
+              } else {
+                "warning"
+              }
+              """
+            )
+          ]
+        )
+
+      [%{id: check_id}] =
+        checks =
+        build_list(1, :selected_check,
+          spec: spec,
+          customized: true,
+          customizations: [
+            build(:customized_value, name: "value_1", value: "expected_customized_value_1"),
+            build(:customized_value, name: "value_2", value: "expected_customized_value_2")
+          ]
+        )
+
+      gathered_facts = %{
+        check_id => %{
+          "agent_1" => [
+            build(:fact, check_id: check_id, name: "fact_1", value: "expected_customized_value_1"),
+            build(:fact, check_id: check_id, name: "fact_2", value: "expected_customized_value_2")
+          ],
+          "agent_2" => [
+            build(:fact, check_id: check_id, name: "fact_1", value: "not_what_expected"),
+            build(:fact, check_id: check_id, name: "fact_2", value: "expected_customized_value_2")
+          ]
+        }
+      }
+
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      matching_yet_not_affecting_envs = [
+        %{
+          "env_1" => "foo",
+          "env_2" => "bar"
+        },
+        %{
+          "env_1" => "bar",
+          "env_2" => "foo"
+        },
+        %{
+          "env_1" => "bar",
+          "env_2" => "baz"
+        }
+      ]
+
+      for env <- matching_yet_not_affecting_envs do
+        assert %Result{
+                 execution_id: execution_id,
+                 group_id: group_id,
+                 check_results: [
+                   %CheckResult{
+                     customized: true,
+                     agents_check_results: [
+                       %AgentCheckResult{
+                         agent_id: "agent_1",
+                         expectation_evaluations: [
+                           %ExpectationEvaluation{
+                             name: "expectation_1",
+                             return_value: true,
+                             type: :expect,
+                             failure_message: nil
+                           },
+                           %ExpectationEvaluation{
+                             name: "expectation_2",
+                             return_value: true,
+                             type: :expect_same,
+                             failure_message: nil
+                           },
+                           %ExpectationEvaluation{
+                             name: "expectation_3",
+                             return_value: :passing,
+                             type: :expect_enum,
+                             failure_message: nil
+                           }
+                         ],
+                         facts: [
+                           %Fact{
+                             check_id: check_id,
+                             name: "fact_1",
+                             value: "expected_customized_value_1"
+                           },
+                           %Fact{
+                             check_id: check_id,
+                             name: "fact_2",
+                             value: "expected_customized_value_2"
+                           }
+                         ],
+                         values: [
+                           %Value{
+                             name: "value_1",
+                             value: "expected_customized_value_1",
+                             customized: true
+                           },
+                           %Value{
+                             name: "value_2",
+                             value: "expected_customized_value_2",
+                             customized: true
+                           }
+                         ]
+                       },
+                       %AgentCheckResult{
+                         agent_id: "agent_2",
+                         expectation_evaluations: [
+                           %ExpectationEvaluation{
+                             name: "expectation_1",
+                             return_value: false,
+                             type: :expect,
+                             failure_message:
+                               "Failure message 1: values.value_1 is expected to be <- expected_customized_value_1 ->"
+                           },
+                           %ExpectationEvaluation{
+                             name: "expectation_2",
+                             return_value: true,
+                             type: :expect_same,
+                             failure_message: nil
+                           },
+                           %ExpectationEvaluation{
+                             name: "expectation_3",
+                             return_value: :warning,
+                             type: :expect_enum,
+                             failure_message:
+                               "Warning message 1: values.value_1 is expected to be <- expected_customized_value_1 ->"
+                           }
+                         ],
+                         facts: [
+                           %Fact{
+                             check_id: check_id,
+                             name: "fact_1",
+                             value: "not_what_expected"
+                           },
+                           %Fact{
+                             check_id: check_id,
+                             name: "fact_2",
+                             value: "expected_customized_value_2"
+                           }
+                         ],
+                         values: [
+                           %Value{
+                             name: "value_1",
+                             value: "expected_customized_value_1",
+                             customized: true
+                           },
+                           %Value{
+                             name: "value_2",
+                             value: "expected_customized_value_2",
+                             customized: true
+                           }
+                         ]
+                       }
+                     ],
+                     check_id: check_id,
+                     expectation_results: [
+                       %ExpectationResult{
+                         name: "expectation_1",
+                         result: false,
+                         type: :expect
+                       },
+                       %ExpectationResult{
+                         name: "expectation_2",
+                         result: true,
+                         type: :expect_same
+                       },
+                       %ExpectationResult{
+                         name: "expectation_3",
+                         result: :warning,
+                         type: :expect_enum,
+                         failure_message: nil
+                       }
+                     ],
+                     result: :critical
+                   }
+                 ],
+                 result: :critical,
+                 timeout: []
+               } ==
+                 Evaluation.execute(
+                   execution_id,
+                   group_id,
+                   checks,
+                   gathered_facts,
+                   env,
+                   engine
+                 )
+      end
     end
   end
 end

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -28,9 +28,10 @@ defmodule Wanda.Executions.ServerTest do
         expression: "#{fact_name}"
       )
 
-    check = build(:check, facts: catalog_facts, values: [], expectations: expectations)
+    spec = build(:check, facts: catalog_facts, values: [], expectations: expectations)
+    selected_check = build(:selected_check, spec: spec)
 
-    {:ok, check: check}
+    {:ok, check: selected_check}
   end
 
   describe "start_link/3" do
@@ -87,7 +88,7 @@ defmodule Wanda.Executions.ServerTest do
            execution_id: execution_id,
            group_id: group_id,
            targets: build_list(10, :target),
-           checks: build_list(10, :check),
+           checks: build_list(10, :selected_check),
            env: env
          ]}
       )
@@ -112,7 +113,7 @@ defmodule Wanda.Executions.ServerTest do
            execution_id: UUID.uuid4(),
            group_id: group_id,
            targets: targets,
-           checks: build_list(10, :check),
+           checks: build_list(10, :selected_check),
            env: %{}
          ]}
       )


### PR DESCRIPTION
# Description

This PR allows customized values to be used during checks executions. 
Additionally:
- each `CheckResult` is marked as customized when necessary
- each `Value` in `AgentCheckResult` is marked as customized when necessary

With regards to OpenApi spec: 
- `values` entry spec was missing in `AgentCheckResult` so it has been added
- in order to avoid another version bump at this time, new fields have beed added in a backward compatible manner (although java heap is complaining 🤦 )