### PR TITLE
Add support to updating checks customizations

### DIFF
--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -128,7 +128,11 @@ defmodule Wanda.ChecksCustomizations do
         group_id: group_id,
         custom_values: custom_values
       })
-      |> Repo.insert(on_conflict: :nothing)
+      |> Repo.insert(
+        on_conflict: {:replace, [:custom_values]},
+        conflict_target: [:check_id, :group_id],
+        returning: true
+      )
 
     case result do
       {:ok, _} = success ->


### PR DESCRIPTION
# Description

This PR enhances check customization endpoint by adding support to updating previously applied customization.

For simplicity:
- there is not a different endpoint for updating customizations
- new custom values replace all previously applied, so in order to retain a previously applied customization it has to be sent again to the endpoint.
