### PR TITLE
Expose resolved original values

### DIFF
--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -170,17 +170,13 @@ defmodule Wanda.Catalog do
        ),
        do: Map.put(value, :default_value, default_value)
 
-  defp maybe_add_customization(%{customizable: customizable} = value, %ResolvedValue{
-         customized: customized
-       })
-       when not customized or not customizable,
-       do: value
-
   defp maybe_add_customization(
          %{customizable: true} = initial_value,
          %ResolvedValue{custom_value: custom_value, customized: true}
        ),
        do: Map.put(initial_value, :custom_value, custom_value)
+
+  defp maybe_add_customization(initial_value, _resolved_value), do: initial_value
 
   defp read_check(path, check_id) do
     case YamlElixir.read_from_file(path) do

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -157,18 +157,18 @@ defmodule Wanda.Catalog do
         name: value_name
       }
       |> add_value_customizability(value_spec, customization_globally_disabled?)
-      |> maybe_add_original_value(resolved_value)
+      |> maybe_add_default_value(resolved_value)
       |> maybe_add_customization(resolved_value)
     end)
   end
 
-  defp maybe_add_original_value(%{customizable: false} = value, _), do: value
+  defp maybe_add_default_value(%{customizable: false} = value, _), do: value
 
-  defp maybe_add_original_value(
+  defp maybe_add_default_value(
          %{customizable: true} = value,
-         %ResolvedValue{original_value: original_value}
+         %ResolvedValue{default_value: default_value}
        ),
-       do: Map.put(value, :original_value, original_value)
+       do: Map.put(value, :default_value, default_value)
 
   defp maybe_add_customization(%{customizable: customizable} = value, %ResolvedValue{
          customized: customized

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -3,16 +3,17 @@ defmodule Wanda.Catalog do
   Function to interact with the checks catalog.
   """
 
-  alias Wanda.Catalog.CustomizedValue
-  alias Wanda.Catalog.SelectedCheck
-
   alias Wanda.Catalog.{
     Check,
     CheckCustomization,
     Condition,
+    CustomizedValue,
+    Evaluation,
     Expectation,
     Fact,
+    ResolvedValue,
     SelectableCheck,
+    SelectedCheck,
     Value
   }
 
@@ -79,7 +80,7 @@ defmodule Wanda.Catalog do
 
     env
     |> get_catalog()
-    |> Enum.map(&map_to_selectable_check(&1, available_customizations))
+    |> Enum.map(&map_to_selectable_check(&1, available_customizations, env))
   end
 
   @spec to_selected_checks([Check.t()], String.t()) :: [SelectedCheck.t()]
@@ -98,12 +99,13 @@ defmodule Wanda.Catalog do
            values: values,
            customization_disabled: customization_globally_disabled?
          },
-         available_customizations
+         available_customizations,
+         env
        ) do
     mapped_values =
       id
       |> find_custom_values(available_customizations)
-      |> map_selectable_check_values(values, customization_globally_disabled?)
+      |> map_selectable_check_values(values, customization_globally_disabled?, env)
 
     customizable_check? =
       detect_check_customizability(mapped_values, not customization_globally_disabled?)
@@ -122,10 +124,7 @@ defmodule Wanda.Catalog do
   end
 
   defp map_to_selected_check(%Check{id: id} = check, available_customizations) do
-    customizations =
-      id
-      |> find_custom_values(available_customizations)
-      |> Enum.map(&CustomizedValue.from_custom_value/1)
+    customizations = find_custom_values(id, available_customizations)
 
     %SelectedCheck{
       id: id,
@@ -138,49 +137,50 @@ defmodule Wanda.Catalog do
   defp find_custom_values(check_id, available_customizations) do
     Enum.find_value(available_customizations, [], fn
       %CheckCustomization{check_id: ^check_id, custom_values: custom_values} ->
-        custom_values
+        Enum.map(custom_values, &CustomizedValue.from_custom_value/1)
 
       _ ->
         nil
     end)
   end
 
-  defp map_selectable_check_values(custom_values, check_values, customization_globally_disabled?) do
-    Enum.map(check_values, fn %Value{
-                                name: value_name,
-                                default: default_value
-                              } = value ->
+  defp map_selectable_check_values(
+         custom_values,
+         check_values,
+         customization_globally_disabled?,
+         env
+       ) do
+    check_values
+    |> Evaluation.resolve_values(custom_values, env)
+    |> Enum.map(fn %ResolvedValue{spec: value_spec, name: value_name} = resolved_value ->
       %{
         name: value_name
       }
-      |> add_value_customizability(value, customization_globally_disabled?)
-      |> maybe_add_current_value(default_value)
-      |> maybe_add_customization(custom_values)
+      |> add_value_customizability(value_spec, customization_globally_disabled?)
+      |> maybe_add_original_value(resolved_value)
+      |> maybe_add_customization(resolved_value)
     end)
   end
 
-  defp maybe_add_current_value(%{customizable: false} = value, _), do: value
+  defp maybe_add_original_value(%{customizable: false} = value, _), do: value
 
-  defp maybe_add_current_value(%{customizable: true} = value, default_value),
-    do: Map.put(value, :current_value, default_value)
+  defp maybe_add_original_value(
+         %{customizable: true} = value,
+         %ResolvedValue{original_value: original_value}
+       ),
+       do: Map.put(value, :original_value, original_value)
 
-  defp maybe_add_customization(%{customizable: false} = value, _), do: value
+  defp maybe_add_customization(%{customizable: customizable} = value, %ResolvedValue{
+         customized: customized
+       })
+       when not customized or not customizable,
+       do: value
 
   defp maybe_add_customization(
-         %{
-           name: value_name,
-           customizable: true
-         } = initial_value,
-         custom_values
-       ) do
-    Enum.find_value(custom_values, initial_value, fn
-      %{name: ^value_name, value: overriding_value} ->
-        Map.put(initial_value, :custom_value, overriding_value)
-
-      _ ->
-        false
-    end)
-  end
+         %{customizable: true} = initial_value,
+         %ResolvedValue{custom_value: custom_value, customized: true}
+       ),
+       do: Map.put(initial_value, :custom_value, custom_value)
 
   defp read_check(path, check_id) do
     case YamlElixir.read_from_file(path) do
@@ -340,17 +340,17 @@ defmodule Wanda.Catalog do
 
   defp add_value_customizability(
          mapped_value,
-         current_value,
+         value_spec,
          customization_globally_disabled?
        ) do
     Map.put(
       mapped_value,
       :customizable,
-      can_customize_value?(current_value, customization_globally_disabled?)
+      can_customize_value?(value_spec, customization_globally_disabled?)
     )
   end
 
-  defp can_customize_value?(_current_value, true = _customization_globally_disabled?), do: false
+  defp can_customize_value?(_value_spec, true = _customization_globally_disabled?), do: false
   defp can_customize_value?(%{customization_disabled: true}, _), do: false
 
   defp can_customize_value?(%{default: default_value}, _),

--- a/lib/wanda/catalog/evaluation.ex
+++ b/lib/wanda/catalog/evaluation.ex
@@ -20,12 +20,12 @@ defmodule Wanda.Catalog.Evaluation do
         spec: specified_value,
         customized: false
       }
-      |> add_original_value(specified_value, env, engine)
+      |> add_default_value(specified_value, env, engine)
       |> add_custom_value(Enum.find(customizations, &(&1.name == name)))
     end)
   end
 
-  defp add_original_value(
+  defp add_default_value(
          %ResolvedValue{} = resolved_value,
          %Value{} = spec,
          evaluation_scope,
@@ -33,7 +33,7 @@ defmodule Wanda.Catalog.Evaluation do
        ) do
     %ResolvedValue{
       resolved_value
-      | original_value: resolve_original_value(spec, evaluation_scope, engine)
+      | default_value: resolve_default_value(spec, evaluation_scope, engine)
     }
   end
 
@@ -47,7 +47,7 @@ defmodule Wanda.Catalog.Evaluation do
         customized: true
     }
 
-  defp resolve_original_value(
+  defp resolve_default_value(
          %Value{default: default, conditions: conditions},
          env,
          engine

--- a/lib/wanda/catalog/evaluation.ex
+++ b/lib/wanda/catalog/evaluation.ex
@@ -1,0 +1,65 @@
+defmodule Wanda.Catalog.Evaluation do
+  @moduledoc """
+  This module provides functions to evaluate check values based on their conditions.
+  """
+
+  alias Wanda.Catalog.{Condition, CustomizedValue, ResolvedValue, Value}
+
+  alias Wanda.EvaluationEngine
+
+  @spec resolve_values(
+          [Value.t()],
+          [CustomizedValue.t()],
+          map(),
+          Rhai.Engine.t()
+        ) :: [ResolvedValue.t()]
+  def resolve_values(spec_values, customizations, env, engine \\ EvaluationEngine.new()) do
+    Enum.map(spec_values, fn %Value{name: name} = specified_value ->
+      %ResolvedValue{
+        name: name,
+        spec: specified_value,
+        customized: false
+      }
+      |> add_original_value(specified_value, env, engine)
+      |> add_custom_value(Enum.find(customizations, &(&1.name == name)))
+    end)
+  end
+
+  defp add_original_value(
+         %ResolvedValue{} = resolved_value,
+         %Value{} = spec,
+         evaluation_scope,
+         engine
+       ) do
+    %ResolvedValue{
+      resolved_value
+      | original_value: resolve_original_value(spec, evaluation_scope, engine)
+    }
+  end
+
+  defp add_custom_value(%ResolvedValue{} = resolved_value, nil = _customized_value),
+    do: resolved_value
+
+  defp add_custom_value(%ResolvedValue{} = resolved_value, %CustomizedValue{value: custom_value}),
+    do: %ResolvedValue{
+      resolved_value
+      | custom_value: custom_value,
+        customized: true
+    }
+
+  defp resolve_original_value(
+         %Value{default: default, conditions: conditions},
+         env,
+         engine
+       ) do
+    Enum.find_value(conditions, default, fn %Condition{value: value, expression: expression} ->
+      case EvaluationEngine.eval(engine, expression, %{"env" => env}) do
+        {:ok, true} ->
+          value
+
+        _ ->
+          false
+      end
+    end)
+  end
+end

--- a/lib/wanda/catalog/resolved_value.ex
+++ b/lib/wanda/catalog/resolved_value.ex
@@ -1,0 +1,26 @@
+defmodule Wanda.Catalog.ResolvedValue do
+  @moduledoc """
+  Represents a resolved check value as defined check specification.
+  It is based on the contextual environment.
+  """
+  alias Wanda.Catalog.Value
+
+  @type value :: boolean() | number() | String.t()
+
+  @derive Jason.Encoder
+  defstruct [
+    :spec,
+    :name,
+    :original_value,
+    :custom_value,
+    :customized
+  ]
+
+  @type t :: %__MODULE__{
+          spec: Value.t(),
+          name: String.t(),
+          original_value: value(),
+          custom_value: value(),
+          customized: boolean()
+        }
+end

--- a/lib/wanda/catalog/resolved_value.ex
+++ b/lib/wanda/catalog/resolved_value.ex
@@ -11,7 +11,7 @@ defmodule Wanda.Catalog.ResolvedValue do
   defstruct [
     :spec,
     :name,
-    :original_value,
+    :default_value,
     :custom_value,
     :customized
   ]
@@ -19,7 +19,7 @@ defmodule Wanda.Catalog.ResolvedValue do
   @type t :: %__MODULE__{
           spec: Value.t(),
           name: String.t(),
-          original_value: value(),
+          default_value: value(),
           custom_value: value(),
           customized: boolean()
         }

--- a/lib/wanda/catalog/selectable_check.ex
+++ b/lib/wanda/catalog/selectable_check.ex
@@ -6,14 +6,14 @@ defmodule Wanda.Catalog.SelectableCheck do
   @type customized_value :: %{
           name: String.t(),
           customizable: true,
-          original_value: boolean() | number() | String.t(),
+          default_value: boolean() | number() | String.t(),
           custom_value: boolean() | number() | String.t()
         }
 
   @type non_customized_value :: %{
           name: String.t(),
           customizable: boolean(),
-          original_value: boolean() | number() | String.t()
+          default_value: boolean() | number() | String.t()
         }
 
   @derive Jason.Encoder

--- a/lib/wanda/catalog/selectable_check.ex
+++ b/lib/wanda/catalog/selectable_check.ex
@@ -6,14 +6,14 @@ defmodule Wanda.Catalog.SelectableCheck do
   @type customized_value :: %{
           name: String.t(),
           customizable: true,
-          current_value: boolean() | number() | String.t(),
+          original_value: boolean() | number() | String.t(),
           custom_value: boolean() | number() | String.t()
         }
 
   @type non_customized_value :: %{
           name: String.t(),
           customizable: boolean(),
-          current_value: boolean() | number() | String.t()
+          original_value: boolean() | number() | String.t()
         }
 
   @derive Jason.Encoder

--- a/lib/wanda/executions/value.ex
+++ b/lib/wanda/executions/value.ex
@@ -3,6 +3,7 @@ defmodule Wanda.Executions.Value do
   Represents a Value used in expectation evaluation.
   This value has been already determined given the conditions in check definition.
   """
+  alias Wanda.Catalog.ResolvedValue
 
   @derive Jason.Encoder
   defstruct [
@@ -16,4 +17,28 @@ defmodule Wanda.Executions.Value do
           value: boolean() | number() | String.t(),
           customized: boolean()
         }
+
+  def from_resolved_value(%ResolvedValue{
+        name: name,
+        original_value: value,
+        customized: false
+      }) do
+    %__MODULE__{
+      name: name,
+      value: value,
+      customized: false
+    }
+  end
+
+  def from_resolved_value(%ResolvedValue{
+        name: name,
+        custom_value: value,
+        customized: true
+      }) do
+    %__MODULE__{
+      name: name,
+      value: value,
+      customized: true
+    }
+  end
 end

--- a/lib/wanda/executions/value.ex
+++ b/lib/wanda/executions/value.ex
@@ -20,7 +20,7 @@ defmodule Wanda.Executions.Value do
 
   def from_resolved_value(%ResolvedValue{
         name: name,
-        original_value: value,
+        default_value: value,
         customized: false
       }) do
     %__MODULE__{

--- a/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
@@ -25,7 +25,7 @@ defmodule WandaWeb.Schemas.V1.ChecksSelection.CustomizedCheckValue do
           oneOf: @value_types,
           description: "Represents the custom value that overrides the current one."
         },
-        original_value: %Schema{
+        default_value: %Schema{
           oneOf: @value_types,
           description:
             "Original value as defined by specification. Resolved based on the environment."
@@ -35,7 +35,7 @@ defmodule WandaWeb.Schemas.V1.ChecksSelection.CustomizedCheckValue do
           description: "Whether the check is customizable or not"
         }
       },
-      required: [:name, :custom_value, :original_value, :customizable]
+      required: [:name, :custom_value, :default_value, :customizable]
     },
     struct?: false
   )

--- a/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
@@ -25,17 +25,17 @@ defmodule WandaWeb.Schemas.V1.ChecksSelection.CustomizedCheckValue do
           oneOf: @value_types,
           description: "Represents the custom value that overrides the current one."
         },
-        current_value: %Schema{
+        original_value: %Schema{
           oneOf: @value_types,
           description:
-            "Value that is currently being used for the check based on the environment."
+            "Original value as defined by specification. Resolved based on the environment."
         },
         customizable: %Schema{
           type: :boolean,
           description: "Whether the check is customizable or not"
         }
       },
-      required: [:name, :custom_value, :current_value, :customizable]
+      required: [:name, :custom_value, :original_value, :customizable]
     },
     struct?: false
   )

--- a/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
@@ -17,14 +17,14 @@ defmodule WandaWeb.Schemas.V1.ChecksSelection.NotCustomizedCheckValue do
       additionalProperties: false,
       properties: %{
         name: %Schema{type: :string, description: "Value name"},
-        current_value: %Schema{
+        original_value: %Schema{
           oneOf: [
             %Schema{type: :string},
             %Schema{anyOf: [%Schema{type: :integer}, %Schema{type: :number}]},
             %Schema{type: :boolean}
           ],
           description:
-            "Value that is currently being used for the check based on the environment. Absent if value is not customizable."
+            "Original value as defined by specification. Resolved based on the environment. Absent if value is not customizable."
         },
         customizable: %Schema{
           type: :boolean,

--- a/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
@@ -17,7 +17,7 @@ defmodule WandaWeb.Schemas.V1.ChecksSelection.NotCustomizedCheckValue do
       additionalProperties: false,
       properties: %{
         name: %Schema{type: :string, description: "Value name"},
-        original_value: %Schema{
+        default_value: %Schema{
           oneOf: [
             %Schema{type: :string},
             %Schema{anyOf: [%Schema{type: :integer}, %Schema{type: :number}]},

--- a/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
+++ b/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
@@ -31,7 +31,7 @@ values:
     # customization_disabled: false #inferred
     conditions:
       - value: baz_qux
-        when: some_third_expression
+        when: env.some_key == "some_value"
   - name: non_customizable_string_value
     default: kaboom
     customization_disabled: true

--- a/test/wanda/catalog/evaluation_test.exs
+++ b/test/wanda/catalog/evaluation_test.exs
@@ -60,21 +60,21 @@ defmodule Wanda.Catalog.EvaluationTest do
         %ResolvedValue{
           name: value_name_1,
           spec: spec1,
-          original_value: default_value_1,
+          default_value: default_value_1,
           custom_value: nil,
           customized: false
         },
         %ResolvedValue{
           name: value_name_2,
           spec: spec2,
-          original_value: contextual_value_1,
+          default_value: contextual_value_1,
           custom_value: nil,
           customized: false
         },
         %ResolvedValue{
           name: value_name_3,
           spec: spec3,
-          original_value: default_value_3,
+          default_value: default_value_3,
           custom_value: nil,
           customized: false
         }
@@ -138,21 +138,21 @@ defmodule Wanda.Catalog.EvaluationTest do
         %ResolvedValue{
           name: value_name_1,
           spec: spec1,
-          original_value: default_value_1,
+          default_value: default_value_1,
           custom_value: nil,
           customized: false
         },
         %ResolvedValue{
           name: value_name_2,
           spec: spec2,
-          original_value: contextual_value_2,
+          default_value: contextual_value_2,
           custom_value: custom_value_2,
           customized: true
         },
         %ResolvedValue{
           name: value_name_3,
           spec: spec3,
-          original_value: default_value_3,
+          default_value: default_value_3,
           custom_value: custom_value_3,
           customized: true
         }

--- a/test/wanda/catalog/evaluation_test.exs
+++ b/test/wanda/catalog/evaluation_test.exs
@@ -1,0 +1,175 @@
+defmodule Wanda.Catalog.EvaluationTest do
+  use ExUnit.Case
+
+  import Wanda.Factory
+
+  alias Wanda.Catalog.{Evaluation, ResolvedValue}
+
+  alias Wanda.EvaluationEngine
+
+  describe "value resolution" do
+    test "should return empty result" do
+      customizations = build_list(5, :customized_value)
+
+      assert [] == Evaluation.resolve_values([], [], %{}, EvaluationEngine.new())
+      assert [] == Evaluation.resolve_values([], [], %{})
+      assert [] == Evaluation.resolve_values([], customizations, %{}, EvaluationEngine.new())
+      assert [] == Evaluation.resolve_values([], customizations, %{})
+    end
+
+    test "should resolve non customized values" do
+      value_name_1 = Faker.Lorem.word()
+      default_value_1 = Faker.Lorem.word()
+
+      value_name_2 = Faker.StarWars.character()
+      default_value_2 = Enum.random(1..10)
+      contextual_value_1 = Enum.random(11..100)
+
+      value_name_3 = Faker.Pokemon.name()
+      default_value_3 = Enum.random(1..10)
+
+      [spec1, spec2, spec3] =
+        specified_values = [
+          build(:catalog_value,
+            name: value_name_1,
+            default: default_value_1,
+            conditions: []
+          ),
+          build(:catalog_value,
+            name: value_name_2,
+            default: default_value_2,
+            conditions: [
+              build(:catalog_condition,
+                value: contextual_value_1,
+                expression: "env.some_entry > 10"
+              )
+            ]
+          ),
+          build(:catalog_value,
+            name: value_name_3,
+            default: default_value_3,
+            conditions: [
+              build(:catalog_condition,
+                expression: "env.some_entry == 10"
+              )
+            ]
+          )
+        ]
+
+      expected_resolution = [
+        %ResolvedValue{
+          name: value_name_1,
+          spec: spec1,
+          original_value: default_value_1,
+          custom_value: nil,
+          customized: false
+        },
+        %ResolvedValue{
+          name: value_name_2,
+          spec: spec2,
+          original_value: contextual_value_1,
+          custom_value: nil,
+          customized: false
+        },
+        %ResolvedValue{
+          name: value_name_3,
+          spec: spec3,
+          original_value: default_value_3,
+          custom_value: nil,
+          customized: false
+        }
+      ]
+
+      scope = %{"some_entry" => 11}
+
+      assert expected_resolution ==
+               Evaluation.resolve_values(specified_values, [], scope, EvaluationEngine.new())
+
+      assert expected_resolution == Evaluation.resolve_values(specified_values, [], scope)
+    end
+
+    test "should resolve customized values" do
+      value_name_1 = Faker.Lorem.word()
+      default_value_1 = Faker.Lorem.word()
+
+      value_name_2 = Faker.StarWars.character()
+      default_value_2 = Enum.random(1..10)
+      contextual_value_2 = Enum.random(11..100)
+      custom_value_2 = Enum.random(101..200)
+
+      value_name_3 = Faker.Pokemon.name()
+      default_value_3 = Enum.random(1..10)
+      custom_value_3 = Enum.random(11..20)
+
+      [spec1, spec2, spec3] =
+        specified_values = [
+          build(:catalog_value,
+            name: value_name_1,
+            default: default_value_1,
+            conditions: []
+          ),
+          build(:catalog_value,
+            name: value_name_2,
+            default: default_value_2,
+            conditions: [
+              build(:catalog_condition,
+                value: contextual_value_2,
+                expression: "env.some_entry > 10"
+              )
+            ]
+          ),
+          build(:catalog_value,
+            name: value_name_3,
+            default: default_value_3,
+            conditions: [
+              build(:catalog_condition,
+                expression: "env.some_entry == 10"
+              )
+            ]
+          )
+        ]
+
+      customizations = [
+        build(:customized_value, name: value_name_2, value: custom_value_2),
+        build(:customized_value, name: value_name_3, value: custom_value_3)
+      ]
+
+      expected_resolution = [
+        %ResolvedValue{
+          name: value_name_1,
+          spec: spec1,
+          original_value: default_value_1,
+          custom_value: nil,
+          customized: false
+        },
+        %ResolvedValue{
+          name: value_name_2,
+          spec: spec2,
+          original_value: contextual_value_2,
+          custom_value: custom_value_2,
+          customized: true
+        },
+        %ResolvedValue{
+          name: value_name_3,
+          spec: spec3,
+          original_value: default_value_3,
+          custom_value: custom_value_3,
+          customized: true
+        }
+      ]
+
+      scope = %{"some_entry" => 11}
+
+      assert expected_resolution ==
+               Evaluation.resolve_values(
+                 specified_values,
+                 customizations,
+                 scope,
+                 EvaluationEngine.new()
+               )
+
+      assert expected_resolution ==
+               Evaluation.resolve_values(specified_values, customizations, scope)
+    end
+  end
+end

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -287,13 +287,15 @@ defmodule Wanda.CatalogTest do
           %{
             name: "numeric_value",
             customizable: true,
-            current_value: 5,
+            original_value: 5,
             custom_value: expected_customization
           },
           %{
             name: "customizable_string_value",
             customizable: true,
-            current_value: "foo_bar",
+            # original_value: "foo_bar", <- "foo_bar" is the default original_value
+            # "baz_qux" is the env based resolved original_value
+            original_value: "baz_qux",
             custom_value: "new value"
           },
           %{
@@ -303,7 +305,7 @@ defmodule Wanda.CatalogTest do
           %{
             name: "bool_value",
             customizable: true,
-            current_value: true
+            original_value: true
           },
           %{
             name: "list_value",
@@ -317,7 +319,8 @@ defmodule Wanda.CatalogTest do
 
         selectable_checks =
           Catalog.get_catalog_for_group(group_id, %{
-            "id" => "mixed_values_customizability"
+            "id" => "mixed_values_customizability",
+            "some_key" => "some_value"
           })
 
         assert length(selectable_checks) == 10
@@ -429,7 +432,7 @@ defmodule Wanda.CatalogTest do
       refute Map.has_key?(value, :custom_value)
 
       if not customizable do
-        refute Map.has_key?(value, :current_value)
+        refute Map.has_key?(value, :original_value)
       end
     end
   end

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -287,15 +287,15 @@ defmodule Wanda.CatalogTest do
           %{
             name: "numeric_value",
             customizable: true,
-            original_value: 5,
+            default_value: 5,
             custom_value: expected_customization
           },
           %{
             name: "customizable_string_value",
             customizable: true,
-            # original_value: "foo_bar", <- "foo_bar" is the default original_value
-            # "baz_qux" is the env based resolved original_value
-            original_value: "baz_qux",
+            # default_value: "foo_bar", <- "foo_bar" is the default default_value
+            # "baz_qux" is the env based resolved default_value
+            default_value: "baz_qux",
             custom_value: "new value"
           },
           %{
@@ -305,7 +305,7 @@ defmodule Wanda.CatalogTest do
           %{
             name: "bool_value",
             customizable: true,
-            original_value: true
+            default_value: true
           },
           %{
             name: "list_value",
@@ -432,7 +432,7 @@ defmodule Wanda.CatalogTest do
       refute Map.has_key?(value, :custom_value)
 
       if not customizable do
-        refute Map.has_key?(value, :original_value)
+        refute Map.has_key?(value, :default_value)
       end
     end
   end

--- a/test/wanda_web/controllers/v1/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v1/catalog_controller_test.exs
@@ -142,7 +142,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
                  %{
                    name: "expected_value",
                    customizable: true,
-                   original_value: 5,
+                   default_value: 5,
                    custom_value: ^expected_customization
                  },
                  %{

--- a/test/wanda_web/controllers/v1/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v1/catalog_controller_test.exs
@@ -142,7 +142,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
                  %{
                    name: "expected_value",
                    customizable: true,
-                   current_value: 5,
+                   original_value: 5,
                    custom_value: ^expected_customization
                  },
                  %{


### PR DESCRIPTION
# Description

This PR allows to expose the resolved original values based on current context.
This is handy during checks customization to tell users what they're going to customize.

Additionally `current_value` has been renamed to `original_value` as the former sounds confusing because a _current value_ could be either the original one as defined in the check spec or a custom value.

Alternatives to `original_value` could be `initial_value`, `builtin_value`, `specified_value`, etc... open for suggestions.

Notes:
- clearly the ci complains about a breaking change in the api
- a tiny update in the ui is required https://github.com/trento-project/web/pull/3380