### PR TITLE
Bump rust toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -408,7 +408,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.66
+          toolchain: 1.81
       - name: Get mix deps
         run: mix local.hex --force && mix local.rebar --force && mix deps.clean --all && mix deps.get
       - name: cargo vendor
@@ -488,7 +488,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.66
+          toolchain: 1.81
       - name: Get mix deps
         run: mix local.hex --force && mix deps.clean --all && mix deps.get
       - name: Cargo vendor


### PR DESCRIPTION
# Description

This aligns rust toolchain in CI with what we have in the project.

Related to https://github.com/trento-project/wanda/pull/591

Should fix
- https://github.com/trento-project/wanda/actions/runs/13812815142/job/38638501834
- https://github.com/trento-project/wanda/actions/runs/13812815142/job/38638501833