### PR TITLE
Check vendor deps on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -408,7 +408,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.66
+          toolchain: 1.81
       - name: Get mix deps
         run: mix local.hex --force && mix local.rebar --force && mix deps.clean --all && mix deps.get
       - name: cargo vendor
@@ -488,7 +488,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.66
+          toolchain: 1.81
       - name: Get mix deps
         run: mix local.hex --force && mix deps.clean --all && mix deps.get
       - name: Cargo vendor

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,44 @@ jobs:
           mix deps.compile --warnings-as-errors
           mix dialyzer --plt
 
+  check-vendor-deps:
+    name: Check vendored dependencies
+    runs-on: ubuntu-24.04
+    needs: [elixir-deps]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Elixir
+        id: setup-elixir
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict 
+      - name: Retrieve Elixir Cached Dependencies
+        uses: actions/cache@v4
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build/test
+            priv/plts
+          key: ${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81
+      - name: Get mix deps
+        run: mix local.hex --force && mix deps.clean --all && mix deps.get
+      - name: Cargo vendor
+        run: |
+          cd deps/rhai_rustler/native/rhai_rustler
+          cargo vendor
+
   static-code-analysis:
     name: Static Code Analysis
     needs: [elixir-deps, api-bc-check]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Cargo vendor
         run: |
           cd deps/rhai_rustler/native/rhai_rustler
-          cargo vendord
+          cargo vendor
 
   static-code-analysis:
     name: Static Code Analysis

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Cargo vendor
         run: |
           cd deps/rhai_rustler/native/rhai_rustler
-          cargo vendor
+          cargo vendord
 
   static-code-analysis:
     name: Static Code Analysis


### PR DESCRIPTION
# Description

To avoid future issues like in https://github.com/trento-project/wanda/pull/593, we can check the rust dependencies are correctly vendorized when adding a PR


Depends on #593 