### PR TITLE
Fix typo in rust package alias

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -29,7 +29,7 @@ BuildRequires:  erlang == 24
 BuildRequires:  elixir-hex
 BuildRequires:  erlang-rebar3
 BuildRequires:  git-core
-BuildRequires:  rust+cargo >= 1.81, rust-cargo < 1.82
+BuildRequires:  rust+cargo >= 1.81, rust+cargo < 1.82
 Requires:       trento-checks
 
 %description


### PR DESCRIPTION
somehow it escaped review in #557 and I guess it's only causing issues now because the downstream project changed.