### PR TITLE
Update build dependency requirements (again)

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -24,12 +24,15 @@ URL:            https://github.com/trento-project/wanda
 Source:         %{name}-%{version}.tar.gz
 Source1:        deps.tar.gz
 Group:          System/Monitoring
-BuildRequires:  elixir == 1.15
-BuildRequires:  erlang == 24
+BuildRequires:  elixir >= 1.15
 BuildRequires:  elixir-hex
 BuildRequires:  erlang-rebar3
 BuildRequires:  git-core
-BuildRequires:  rust+cargo >= 1.81, rust+cargo < 1.82
+BuildRequires:  rust1.81
+BuildRequires:  cargo1.81
+# avoid conflicting aliases in the rust dependency tree
+#!BuildIgnore: cargo
+#!BuildIgnore: rust
 Requires:       trento-checks
 
 %description


### PR DESCRIPTION
Third round of Trento vs RPM, following #596 and #557.

After having consulted with some SUSE folks in #discuss-rust, I became aware of the following things:

- The `rust+cargo` alias is deprecated, so we shall declare explicit requirements for both.
- The `==` version operator doesn't actually exist (but it happens to work, sometimes?), we shall use `=`...
  - ...but `=` can only be used if there is something like `Provides: $name = %{version}` in the dependency package. Which there was for  `rust+cargo`, but there isn't for just `rust` or just `cargo`. 🫠
- so for rust and cargo alone, we declare the name of the package including the version. I didn't want to do this because we follow a different convention for the other packages like elixir, but I guess rpm is a bitch so we'll leave it at that.
- also more issues arose due to conflicting aliases, hence the suggestion of using `#!BuildIgnore` for those problematic aliases.

Contextually, I also removed the explicit requirement of erlang 24 and started relying on whatever is declared in the elixir package, because that's what we do in the web package.
