### PR TITLE
Receive operator execution reports

### DIFF
--- a/lib/wanda/operations/agent_report.ex
+++ b/lib/wanda/operations/agent_report.ex
@@ -8,11 +8,15 @@ defmodule Wanda.Operations.AgentReport do
   @derive Jason.Encoder
   defstruct [
     :agent_id,
-    :result
+    :result,
+    :diff,
+    :error_message
   ]
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          result: Result.t()
+          result: Result.t(),
+          diff: map(),
+          error_message: String.t()
         }
 end

--- a/lib/wanda/operations/enums/operator_phase.ex
+++ b/lib/wanda/operations/enums/operator_phase.ex
@@ -1,0 +1,8 @@
+defmodule Wanda.Operations.Enums.OperatorPhase do
+  @moduledoc """
+  Type that represents an operator phase.
+  """
+
+  use Wanda.Support.Enum,
+    values: [:plan, :commit, :verify, :rollback]
+end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -35,7 +35,7 @@ defmodule Wanda.Operations.Operation do
       field :arguments, :map
     end
 
-    field :agent_reports, {:array, :map}
+    field :agent_reports, Wanda.Support.Ecto.Json
 
     field :catalog_operation_id, :string
     field :catalog_operation, :map, virtual: true

--- a/lib/wanda/operations/operator_error.ex
+++ b/lib/wanda/operations/operator_error.ex
@@ -1,0 +1,18 @@
+defmodule Wanda.Operations.OperatorError do
+  @moduledoc """
+  Operator execution result with an error retrieved from an agent.
+  """
+
+  require Wanda.Operations.Enums.OperatorPhase, as: OperatorPhase
+
+  @derive Jason.Encoder
+  defstruct [
+    :phase,
+    :message
+  ]
+
+  @type t :: %__MODULE__{
+          phase: OperatorPhase.t(),
+          message: String.t()
+        }
+end

--- a/lib/wanda/operations/operator_result.ex
+++ b/lib/wanda/operations/operator_result.ex
@@ -1,0 +1,23 @@
+defmodule Wanda.Operations.OperatorResult do
+  @moduledoc """
+  Operator execution result retrieved from an agent.
+  """
+
+  require Wanda.Operations.Enums.OperatorPhase, as: OperatorPhase
+
+  @type diff :: %{
+          before: any(),
+          after: any()
+        }
+
+  @derive Jason.Encoder
+  defstruct [
+    :phase,
+    :diff
+  ]
+
+  @type t :: %__MODULE__{
+          phase: OperatorPhase.t(),
+          diff: diff()
+        }
+end

--- a/lib/wanda_web/controllers/v1/operation_json.ex
+++ b/lib/wanda_web/controllers/v1/operation_json.ex
@@ -48,7 +48,7 @@ defmodule WandaWeb.V1.OperationJSON do
   defp map_agent_reports(agent_reports, steps) do
     agent_reports
     |> Enum.with_index()
-    |> Enum.map(fn {%{"agents" => agents}, index} ->
+    |> Enum.map(fn {%{agents: agents}, index} ->
       %{name: name, timeout: timeout, operator: operator, predicate: predicate} =
         Enum.at(steps, index)
 

--- a/lib/wanda_web/schemas/v1/operation/agent_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/agent_report.ex
@@ -15,9 +15,25 @@ defmodule WandaWeb.Schemas.V1.Operation.AgentReport do
       additionalProperties: false,
       properties: %{
         agent_id: %Schema{type: :string, format: :uuid, description: "Agent ID"},
-        result: %Schema{type: :string, enum: Result.values()}
+        result: %Schema{type: :string, enum: Result.values()},
+        diff: %Schema{
+          type: :object,
+          additionalProperties: false,
+          nullable: true,
+          properties: %{
+            before: %Schema{description: "The state before applying the operation"},
+            after: %Schema{description: "The state after applying the operation"}
+          },
+          description: "The operation before/after difference",
+          required: [:before, :after]
+        },
+        error_message: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Error message in case of a failed operation"
+        }
       },
-      required: [:agent_id, :result]
+      required: [:agent_id, :result, :diff, :error_message]
     },
     struct?: false
   )

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -24,6 +24,8 @@ defmodule Wanda.Factory do
     AgentReport,
     Operation,
     OperationTarget,
+    OperatorError,
+    OperatorResult,
     StepReport
   }
 
@@ -37,6 +39,7 @@ defmodule Wanda.Factory do
   require Wanda.Executions.Enums.Status, as: ExecutionStatus
   require Wanda.Operations.Enums.Result, as: OpeartionResult
   require Wanda.Operations.Enums.Status, as: OpeartionStatus
+  require Wanda.Operations.Enums.OperatorPhase, as: OperatorPhase
 
   def check_factory do
     %Catalog.Check{
@@ -252,7 +255,7 @@ defmodule Wanda.Factory do
       result: OpeartionResult.not_executed(),
       status: OpeartionStatus.running(),
       targets: targets,
-      agent_reports: [],
+      agent_reports: build_list(1, :step_report, step_number: 0),
       started_at: DateTime.utc_now()
     }
   end
@@ -274,7 +277,29 @@ defmodule Wanda.Factory do
   def agent_report_factory do
     %AgentReport{
       agent_id: UUID.uuid4(),
-      result: OpeartionResult.updated()
+      result: OpeartionResult.updated(),
+      diff: %{
+        before: Faker.Lorem.sentence(),
+        after: Faker.Lorem.sentence()
+      },
+      error_message: nil
+    }
+  end
+
+  def operator_result_factory do
+    %OperatorResult{
+      phase: Enum.random(OperatorPhase.values()),
+      diff: %{
+        before: Faker.Lorem.sentence(),
+        after: Faker.Lorem.sentence()
+      }
+    }
+  end
+
+  def operator_error_factory do
+    %OperatorError{
+      phase: Enum.random(OperatorPhase.values()),
+      message: Faker.Lorem.sentence()
     }
   end
 

--- a/test/wanda_web/controllers/v1/operation_json_test.exs
+++ b/test/wanda_web/controllers/v1/operation_json_test.exs
@@ -13,7 +13,10 @@ defmodule WandaWeb.V1.OperationJSONTest do
       [%{operation_id: id_1}, %{operation_id: id_2}, %{operation_id: id_3}] =
         operations =
         3
-        |> build_list(:operation, catalog_operation_id: catalog_operation_id)
+        |> build_list(:operation,
+          agent_reports: build_list(2, :step_report),
+          catalog_operation_id: catalog_operation_id
+        )
         |> Enum.map(fn operation -> %{operation | catalog_operation: catalog_operation} end)
 
       assert %{
@@ -50,10 +53,7 @@ defmodule WandaWeb.V1.OperationJSONTest do
         ]
       } = catalog_operation = build(:catalog_operation)
 
-      agent_reports = build_list(2, :step_report)
-
-      [%{"agents" => agents_1}, %{"agents" => agents_2}] =
-        string_agents = agent_reports |> Jason.encode!() |> Jason.decode!()
+      [%{agents: agents_1}, %{agents: agents_2}] = agent_reports = build_list(2, :step_report)
 
       %{
         operation_id: operation_id,
@@ -68,7 +68,7 @@ defmodule WandaWeb.V1.OperationJSONTest do
         operation =
         build(:operation,
           catalog_operation_id: catalog_operation_id,
-          agent_reports: string_agents
+          agent_reports: agent_reports
         )
 
       operation = %{operation | catalog_operation: catalog_operation}


### PR DESCRIPTION
# Description

Receive and handler `OperatorExecutionCompleted` messages sent by the agent and process the result.

Now the `diff` or `error_message` sent in the report are stored as well in the database and exposed in the operation API.

I have changed the `agent_reports` field to be of `JSON` type, so we use `atom` entries everywhere as all the used keys are well known atoms.

## How was this tested?

UT and manual testing