### PR TITLE
Add catalog non-emptiness as part of health check

### DIFF
--- a/lib/wanda_web/schemas/health.ex
+++ b/lib/wanda_web/schemas/health.ex
@@ -7,19 +7,27 @@ defmodule WandaWeb.Schemas.Health do
 
   require OpenApiSpex
 
+  @status_enum ["pass", "fail"]
+
   OpenApiSpex.schema(
     %Schema{
       title: "Health",
       type: :object,
       additionalProperties: false,
       example: %{
-        database: "pass"
+        database: "pass",
+        catalog: "pass"
       },
       properties: %{
         database: %Schema{
           description: "The status of the database connection",
           type: :string,
-          enum: ["pass", "fail"]
+          enum: @status_enum
+        },
+        catalog: %Schema{
+          description: "The status of the checks catalog",
+          type: :string,
+          enum: @status_enum
         }
       }
     },

--- a/test/wanda_web/controllers/health_json_test.exs
+++ b/test/wanda_web/controllers/health_json_test.exs
@@ -4,10 +4,12 @@ defmodule WandaWeb.HealthJSONTest do
   alias WandaWeb.HealthJSON
 
   test "should render data indicating that the database is in a healthy state" do
-    assert %{database: "pass"} == HealthJSON.health(%{health: %{database: "pass"}})
+    health = %{database: "pass", catalog: "pass"}
+    assert health == HealthJSON.health(%{health: health})
   end
 
   test "should render data indicating that the database is in an unhealthy state" do
-    assert %{database: "fail"} == HealthJSON.health(%{health: %{database: "fail"}})
+    health = %{database: "fail", catalog: "pass"}
+    assert health == HealthJSON.health(%{health: health})
   end
 end


### PR DESCRIPTION
# Description

Adding catalog non emptiness as a health check for wanda.
It might become useful for instance when testing the ansible playbook to determine the catalog has been properly deployed.