### PR TITLE
Add ipv6 bug fix

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -36,13 +36,22 @@ if config_env() in [:prod, :demo] do
 
   port = String.to_integer(System.get_env("PORT") || "4000")
 
+  # Returns an IP address to bind the HTTP server, based on IPv6 support.
+  # This prevents startup failures on systems without IPv6 where the app would crash
+  # Falls back to IPv4 `{0, 0, 0, 0}` if IPv6 is not available.
+  ip =
+    case :inet.getaddr(~c"localhost", :inet6) do
+      {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
+      {:error, _} -> {0, 0, 0, 0}
+    end
+
   config :wanda, WandaWeb.Endpoint,
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
       # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: ip,
       port: port
     ],
     secret_key_base: secret_key_base


### PR DESCRIPTION
# Description

This pr provides a fix for wanda, currently when wanda is started and the machine does not have ipv6 the app fails to start.
This happens because the [Cowboy webserver Plug](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html) requires either an ipv4 or ipv6 address. For this we can use the erlang inet getaddr function

Same fix as in [web ](https://github.com/trento-project/web/pull/3490)
