### PR TITLE
Add saptune change solution operation to the catalog

### DIFF
--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -5,10 +5,11 @@ defmodule Wanda.Operations.Catalog.Registry do
 
   alias Wanda.Operations.Catalog.Operation
 
-  alias Wanda.Operations.Catalog.SaptuneApplySolutionV1
+  alias Wanda.Operations.Catalog.{SaptuneApplySolutionV1, SaptuneChangeSolutionV1}
 
   @registry %{
-    "saptuneapplysolution@v1" => SaptuneApplySolutionV1.operation()
+    "saptuneapplysolution@v1" => SaptuneApplySolutionV1.operation(),
+    "saptunechangesolution@v1" => SaptuneChangeSolutionV1.operation()
   }
 
   @doc """

--- a/lib/wanda/operations/catalog/saptunechangesolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptunechangesolution_v1.ex
@@ -1,0 +1,20 @@
+defmodule Wanda.Operations.Catalog.SaptuneChangeSolutionV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "saptunechangesolution@v1",
+      name: "Change saptune solution",
+      description: """
+      This operation changes a saptune solution in the targets.
+      """,
+      required_args: ["solution"],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Change solution",
+          operator: "saptunechangesolution@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end


### PR DESCRIPTION
# Description

Adds the saptune change solution operation spec to the operations catalog

Current tests already cover necessary scenarios.

Related to https://github.com/trento-project/web/pull/3488