### PR TITLE
[WIP] Demo operations

### DIFF
--- a/config/demo.exs
+++ b/config/demo.exs
@@ -1,6 +1,8 @@
 import Config
 
-config :wanda, Wanda.Policy, execution_server_impl: Wanda.Executions.FakeServer
+config :wanda, Wanda.Policy,
+  execution_server_impl: Wanda.Executions.FakeServer,
+  operation_server_impl: Wanda.Operations.FakeServer
 
 config :wanda, WandaWeb.Endpoint,
   check_origin: :conn,
@@ -10,3 +12,6 @@ config :wanda, WandaWeb.Endpoint,
 config :logger, level: :debug
 
 config :wanda, Wanda.Executions.FakeGatheredFacts, demo_facts_config: "priv/demo/fake_facts.yaml"
+
+config :wanda, Wanda.Operations.FakeReports,
+  demo_operations_config: "priv/demo/fake_operations_reports.yaml"

--- a/demo/fake_operations_reports.ex
+++ b/demo/fake_operations_reports.ex
@@ -1,0 +1,11 @@
+defmodule Wanda.Operations.FakeReports do
+  @moduledoc """
+  Module responsible to generate the fake operation reports from targets
+  """
+
+  require Logger
+
+  def get_demo_operation_report(_ \\ {}) do
+    # read from the demo file
+  end
+end

--- a/demo/fake_operations_server.ex
+++ b/demo/fake_operations_server.ex
@@ -1,0 +1,128 @@
+defmodule Wanda.Operations.FakeServer do
+  @moduledoc """
+  Operations server implementation that does not actually execute anything and just
+  returns (fake) random results.
+  """
+
+  # alias Wanda.Operations.Catalog.Operation
+
+  @behaviour Wanda.Operations.ServerBehaviour
+
+  # use GenServer, restart: :temporary
+
+  # alias Wanda.Operations
+
+  alias Wanda.Operations
+
+  alias Wanda.Operations.Reporting
+  # alias Wanda.Operations.{
+  # AgentReport,
+  # OperationTarget,
+  # OperatorError,
+  # OperatorResult,
+  # Reporting
+  # State
+  # StepReport
+  # }
+
+  alias Wanda.Operations.Catalog.{Operation, Step}
+
+  alias Wanda.Messaging
+
+  alias Wanda.EvaluationEngine
+
+  alias Wanda.Operations.FakeReports
+
+  alias Wanda.Operations.Messaging.Publisher
+
+  require Logger
+
+  @impl true
+  def start_operation(operation_id, group_id, operation, targets, config \\ [])
+
+  def start_operation(_, _, _, [], _), do: {:error, :targets_missing}
+
+  def start_operation(
+        operation_id,
+        group_id,
+        %Operation{
+          required_args: required_args
+        } = operation,
+        targets,
+        config
+      ) do
+    targets
+    |> Enum.all?(&(required_args -- Map.keys(&1.arguments) == []))
+    |> then(fn
+      true -> do_start_operation(operation_id, group_id, operation, targets, config)
+      false -> {:error, :arguments_missing}
+    end)
+  end
+
+  defp do_start_operation(operation_id, group_id, operation, targets, config) do
+    %Operation{
+      id: catalog_operation_id,
+      steps: steps
+    } = operation
+
+    engine = EvaluationEngine.new()
+    # new_state = initialize_report_results(state)
+
+    Operations.create_operation!(operation_id, group_id, catalog_operation_id, targets)
+
+    operation_started =
+      Messaging.Mapper.to_operation_started(operation_id, group_id, catalog_operation_id, targets)
+
+    :ok = Messaging.publish(Publisher, "results", operation_started)
+
+    steps
+    |> Enum.with_index()
+    # Enum.reduce(...) # reduce instead of each
+    |> Enum.each(fn {%Step{
+                       name: _name,
+                       operator: _operator,
+                       predicate: predicate,
+                       timeout: _timeout
+                     } = _step, index} ->
+      agent_reports = FakeReports.get_demo_operation_report()
+
+      Reporting.handle_step(
+        engine,
+        predicate,
+        targets,
+        index,
+        agent_reports
+      )
+
+      Process.sleep(Keyword.get(config, :sleep, 2_000))
+      nil
+    end)
+
+    # reduced from previous step
+    agent_reports = []
+
+    result = Reporting.evaluate_agent_reports_result(agent_reports)
+    Operations.update_agent_reports!(operation_id, agent_reports)
+    Operations.complete_operation!(operation_id, result)
+
+    operation_completed =
+      Messaging.Mapper.to_operation_completed(
+        operation_id,
+        group_id,
+        catalog_operation_id,
+        result
+      )
+
+    :ok = Messaging.publish(Publisher, "results", operation_completed)
+  end
+
+  @impl true
+  def receive_operation_reports(
+        _operation_id,
+        _group_id,
+        _step_id,
+        _agent_id,
+        _operation_result
+      ),
+      do: :ok
+end

--- a/lib/wanda/operations/reporting.ex
+++ b/lib/wanda/operations/reporting.ex
@@ -1,0 +1,138 @@
+defmodule Wanda.Operations.Reporting do
+  @moduledoc """
+  Reporting module for Wanda operations.
+  """
+  alias Wanda.Operations.{
+    AgentReport,
+    OperationTarget,
+    OperatorError,
+    OperatorResult,
+    StepReport
+  }
+
+  alias Wanda.EvaluationEngine
+
+  require Wanda.Operations.Enums.OperatorPhase, as: OperatorPhase
+  require Wanda.Operations.Enums.Result, as: Result
+
+  def initialize_report_results(targets, steps) do
+    not_executed_agent_reports =
+      Enum.map(targets, fn %OperationTarget{agent_id: agent_id} ->
+        %AgentReport{agent_id: agent_id, result: Result.not_executed()}
+      end)
+
+    agent_reports =
+      steps
+      |> Enum.with_index()
+      |> Enum.map(fn {_, index} ->
+        %StepReport{step_number: index, agents: not_executed_agent_reports}
+      end)
+
+    agent_reports
+  end
+
+  def evaluate_agent_reports_result(agent_reports) do
+    agent_reports
+    |> Enum.flat_map(fn %{agents: agents} -> agents end)
+    |> Enum.map(& &1.result)
+    |> Enum.map(&{&1, result_weight(&1)})
+    |> Enum.max_by(fn {_, weight} -> weight end)
+    |> elem(0)
+  end
+
+  # update_report_results updates the agent report status for the given
+  # agent, step_number and result
+  def update_report_results(
+        current_agent_reports,
+        step_number,
+        agent_id,
+        result,
+        diff,
+        message
+      ) do
+    %StepReport{agents: current_agents} =
+      step_to_update = Enum.at(current_agent_reports, step_number)
+
+    updated_agents =
+      Enum.map(current_agents, fn
+        %AgentReport{agent_id: ^agent_id} = agent_report ->
+          %AgentReport{agent_report | result: result, diff: diff, error_message: message}
+
+        agent_report ->
+          agent_report
+      end)
+
+    List.replace_at(current_agent_reports, step_number, %{
+      step_to_update
+      | agents: updated_agents
+    })
+  end
+
+  def handle_step(engine, predicate, targets, current_step, current_agent_reports) do
+    engine
+    |> predicate_targets_execution(predicate, targets)
+    |> track_skipped_targets(targets, current_step, current_agent_reports)
+  end
+
+  defp predicate_targets_execution(
+         engine,
+         predicate,
+         targets
+       ) do
+    Enum.reduce(targets, [], fn %OperationTarget{agent_id: agent_id, arguments: arguments}, acc ->
+      if predicate_is_met(engine, predicate, arguments) do
+        [agent_id | acc]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp predicate_is_met(_, "*", _), do: true
+  defp predicate_is_met(_, "", _), do: true
+
+  defp predicate_is_met(engine, predicate, arguments) do
+    case EvaluationEngine.eval(engine, predicate, arguments) do
+      {:ok, true} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp track_skipped_targets(
+         pending_targets,
+         targets,
+         step_number,
+         current_agent_reports
+       ) do
+    updated_reports =
+      targets
+      |> Enum.filter(&(&1.agent_id not in pending_targets))
+      |> Enum.reduce(current_agent_reports, fn %OperationTarget{agent_id: agent_id}, acc ->
+        update_report_results(acc, step_number, agent_id, Result.skipped(), nil, nil)
+      end)
+
+    {pending_targets, updated_reports}
+  end
+
+  defp result_weight(Result.failed()), do: 6
+  defp result_weight(Result.rolled_back()), do: 5
+  defp result_weight(Result.timeout()), do: 4
+  defp result_weight(Result.updated()), do: 3
+  defp result_weight(Result.not_updated()), do: 2
+  defp result_weight(Result.skipped()), do: 1
+  defp result_weight(Result.not_executed()), do: 0
+
+  def evaluate_operator_result(%OperatorResult{diff: %{before: value, after: value} = diff}),
+    do: {Result.not_updated(), diff, nil}
+
+  def evaluate_operator_result(%OperatorResult{diff: diff}), do: {Result.updated(), diff, nil}
+
+  def evaluate_operator_result(%OperatorError{phase: OperatorPhase.commit(), message: message}),
+    do: {Result.rolled_back(), nil, message}
+
+  def evaluate_operator_result(%OperatorError{message: message}),
+    do: {Result.failed(), nil, message}
+end

--- a/priv/demo/fake_operations_reports.yaml
+++ b/priv/demo/fake_operations_reports.yaml
@@ -1,0 +1,19 @@
+targets:
+  target1: c1f161e0-56b8-57cb-a28c-e5e581057b24
+
+
+reports:
+  "saptuneapplysolution@v1":
+    0:
+      target1: 
+        before: 
+          solution: ""
+        after: 
+          solution: "HANA"
+  "saptunechangesolution@v1":
+    0:
+      target1: 
+        before: 
+          solution: "HANA"
+        after: 
+          solution: "S4HANA-DBSERVER"


### PR DESCRIPTION
# Description

This PR aims to add the ability to have faked operations, similarly to what we have for checks executions.

The underlying idea is the same: we have a configuration file that specifies what to assume agents return - operation reports in this case.

Alternatives to this approach could be:
- fully faked agents (well, we don't have it)
- a more sophisticated mechanism where we spawn different processes (ie genservers) that behave like an agent:
  - listen to the same `OperatorExecutionRequested` message as an agent would do
  - determine which mocked report to emit
  - emit the mocked report via a `OperatorExecutionCompleted` message as an agent would do