### PR TITLE
Add HANA secondary unregistration operation spec

### DIFF
--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -10,7 +10,8 @@ defmodule Wanda.Operations.Catalog.Registry do
     SapInstanceStartV1,
     SapInstanceStopV1,
     SaptuneApplySolutionV1,
-    SaptuneChangeSolutionV1
+    SaptuneChangeSolutionV1,
+    UnregisterHANASecondaryV1
   }
 
   @registry %{
@@ -18,7 +19,8 @@ defmodule Wanda.Operations.Catalog.Registry do
     "sapinstancestart@v1" => SapInstanceStartV1.operation(),
     "sapinstancestop@v1" => SapInstanceStopV1.operation(),
     "saptuneapplysolution@v1" => SaptuneApplySolutionV1.operation(),
-    "saptunechangesolution@v1" => SaptuneChangeSolutionV1.operation()
+    "saptunechangesolution@v1" => SaptuneChangeSolutionV1.operation(),
+    "unregisterhanasecondary@v1" => UnregisterHANASecondaryV1.operation()
   }
 
   @doc """

--- a/lib/wanda/operations/catalog/unregister_hana_secondary_v1.ex
+++ b/lib/wanda/operations/catalog/unregister_hana_secondary_v1.ex
@@ -1,0 +1,28 @@
+defmodule Wanda.Operations.Catalog.UnregisterHANASecondaryV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "unregisterhanasecondary@v1",
+      name: "Unregister HANA Secondary",
+      description: """
+      This operation unregisters a HANA secondary from system replication setup.
+
+      In order to unregister a HANA secondary, it must be stopped first and then to finalize unregistration it needs to be started again.
+
+      The operation is meant to run on only one of the HANA secondary nodes so when requesting the operation,
+      make sure to sennd only one target.
+
+      Arguments:
+        sid (string): The System ID of the HANA secondary to unregister
+      """,
+      required_args: ["sid"],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Unregister HANA Secondary",
+          operator: "unregisterhanasecondary@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end


### PR DESCRIPTION
# Description

Add specification for the _Unregister HANA Secondary_ operation.

We discovered that a full unregistration is achieved via the following steps:
- stop hana secondary
- unregister hana secondary
- start hana secondary

And decided that will be 3 different operations issued by the user.

This specific `unregisterhanasecondary@v1` will be available for execution only if hana secondary is detected as stopped