### PR TITLE
Enable operations in produdction

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -45,7 +45,7 @@ config :wanda, Wanda.Messaging.Adapters.AMQP,
   ]
 
 config :wanda,
-  operations_enabled: false
+  operations_enabled: true
 
 # ## SSL Support
 #


### PR DESCRIPTION
# Description
Enable operation in production.
Keeping the flag as it is so we still have the chance to disable.
