### PR TITLE
Fix CI obs image tarball creation

### DIFF
--- a/.github/workflows/obs.yaml
+++ b/.github/workflows/obs.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Update sources
         run: |
           cp -r $SOURCE_DIR/* $CHECKOUT_DIR
-          tar --transform 's,^./,/wanda/,' -zcvf $DEST_FOLDER/wanda.tar.gz --exclude=./.git ./*
+          tar --transform 's,^./,/wanda/,' -zcvf $CHECKOUT_DIR/wanda.tar.gz --exclude=./.git ./*
       - name: Commit to OBS
         run: |
           pushd $CHECKOUT_DIR


### PR DESCRIPTION
# Description
Fix CI to create in the correct folder the wanda tarball for the OBS docker image.