### PR TITLE
Filter operations by status

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -88,7 +88,8 @@ config :rustler_precompiled, :force_build, rhai_rustler: true
 config :wanda,
   cors_enabled: true,
   jwt_authentication_enabled: true,
-  operations_enabled: true
+  operations_enabled: true,
+  date_service: Wanda.Support.DateService
 
 config :bodyguard,
   default_error: :forbidden

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -32,4 +32,11 @@ defmodule Wanda.Operations.Catalog.Operation do
       end
     end
   end
+
+  @spec total_timeout(__MODULE__.t()) :: non_neg_integer()
+  def total_timeout(%__MODULE__{steps: steps}) do
+    Enum.reduce(steps, 0, fn %Step{timeout: timeout}, acc ->
+      acc + timeout
+    end)
+  end
 end

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -14,7 +14,7 @@ defmodule Wanda.Operations.Operation do
 
   @type t :: %__MODULE__{}
 
-  @fields ~w(operation_id group_id result status agent_reports catalog_operation_id started_at updated_at completed_at)a
+  @fields ~w(operation_id group_id result status agent_reports catalog_operation_id started_at updated_at completed_at timeout_at)a
   @target_fields ~w(agent_id arguments)a
 
   @required_fields ~w(operation_id group_id result status)a
@@ -41,6 +41,7 @@ defmodule Wanda.Operations.Operation do
     field :catalog_operation, :map, virtual: true
 
     field :completed_at, :utc_datetime_usec
+    field :timeout_at, :utc_datetime_usec
     timestamps(type: :utc_datetime_usec, inserted_at: :started_at)
   end
 

--- a/lib/wanda/support/date.ex
+++ b/lib/wanda/support/date.ex
@@ -1,0 +1,10 @@
+defmodule Wanda.Support.DateService do
+  @moduledoc """
+  DateTime service
+  """
+
+  @callback utc_now() :: DateTime.t()
+  @callback utc_now(Calendar.calendar()) :: DateTime.t()
+
+  def utc_now(calendar \\ Calendar.ISO), do: DateTime.utc_now(calendar)
+end

--- a/priv/repo/migrations/20250623071928_add_timeout_at_to_operations.exs
+++ b/priv/repo/migrations/20250623071928_add_timeout_at_to_operations.exs
@@ -1,0 +1,9 @@
+defmodule Wanda.Repo.Migrations.AddTimeoutAtToOperations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:operations) do
+      add :timeout_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -248,6 +248,8 @@ defmodule Wanda.Factory do
         %Operation.Target{agent_id: id, arguments: args}
       end)
 
+    now = DateTime.utc_now()
+
     %Operation{
       operation_id: UUID.uuid4(),
       group_id: UUID.uuid4(),
@@ -256,7 +258,8 @@ defmodule Wanda.Factory do
       status: OpeartionStatus.running(),
       targets: targets,
       agent_reports: build_list(1, :step_report, step_number: 0),
-      started_at: DateTime.utc_now()
+      started_at: now,
+      timeout_at: DateTime.add(now, 30_000, :millisecond)
     }
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,6 +14,9 @@ Mox.defmock(GenRMQ.Processor.Mock, for: GenRMQ.Processor)
 Mox.defmock(Joken.CurrentTime.Mock, for: Joken.CurrentTime)
 Application.put_env(:joken, :current_time_adapter, Joken.CurrentTime.Mock)
 
+Mox.defmock(Wanda.Support.DateService.Mock, for: Wanda.Support.DateService)
+Application.put_env(:wanda, :date_service, Wanda.Support.DateService.Mock)
+
 ExUnit.start(capture_log: true)
 Faker.start()
 

--- a/test/wanda/operations/catalog/operation_test.exs
+++ b/test/wanda/operations/catalog/operation_test.exs
@@ -1,0 +1,23 @@
+defmodule Wanda.Operations.Catalog.OperationTest do
+  use ExUnit.Case
+
+  alias Wanda.Operations.Catalog.{Operation, Step}
+
+  test "should return operation total timeout" do
+    operation = %Operation{
+      steps: [
+        %Step{
+          timeout: 3_000
+        },
+        %Step{
+          timeout: 7_000
+        },
+        %Step{
+          timeout: 5 * 1_000
+        }
+      ]
+    }
+
+    assert 15_000 == Operation.total_timeout(operation)
+  end
+end


### PR DESCRIPTION
# Description

Filter operations by status in the `operations/executions` api call.
We need this to query the currently ongoing operations from wanda. Related: https://github.com/trento-project/web/pull/3591

Unfortunately, this is not as simple as just doing `where([status: ^status])`.
We need to take care of operations that were suddenly canceled without putting the `aborted` value in the `status` field.

I have update how we compute aborted operations, so it is done in the postgresql `sql` query, as we need for querying exact items per page. If we do later on, with other filter, we might get less values than given by the DB.

The logic is simple. Add the `timeout_at` value during operation creation.
With this, check if an operation is running and the timeout is already expired. In this case, the operation is set to `aborted`.

I have opted for this option as it looks the cleaner. We could've used the postgresql `values` utility to have "in memory" table joined to the current table with the timeouts, but it would make the code more volatile, as removing any entry from the registry would change the returned values.

Everything else is just testing parafernalia to have a mocked date.

## How was this tested?

UT
