### PR TITLE
use latest version of get latest tag action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
@@ -104,7 +104,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v4
@@ -154,7 +154,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Retrieve Cached Dependencies - current branch
         uses: actions/cache@v4
@@ -249,7 +249,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v4

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -30,7 +30,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Setup rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/obs.yaml
+++ b/.github/workflows/obs.yaml
@@ -49,7 +49,7 @@ jobs:
           VERSION=$(/scripts/get_version_from_git.sh)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Setup rust
         uses: actions-rs/toolchain@v1
@@ -124,7 +124,7 @@ jobs:
           VERSION=$(/scripts/get_version_from_git.sh)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Read .tool-versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.3.4
         id: tool-versions
       - name: Setup rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Use latest version of endorama/asdf-parse-tool-versions to avoid using deprecated set-output command in gh actions.

Fixes # (issue)
https://jira.suse.com/browse/TRNT-3819

## Did you add the right label?

Remember to add the right labels to this PR.

- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.

- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Wanda guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.

- [ ] **DONE**
