### PR TITLE
Add SAP system start/stop operations

### DIFF
--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -11,6 +11,8 @@ defmodule Wanda.Operations.Catalog.Registry do
     PacemakerEnableV1,
     SapInstanceStartV1,
     SapInstanceStopV1,
+    SapSystemStartV1,
+    SapSystemStopV1,
     SaptuneApplySolutionV1,
     SaptuneChangeSolutionV1
   }
@@ -21,6 +23,8 @@ defmodule Wanda.Operations.Catalog.Registry do
     "pacemakerenable@v1" => PacemakerEnableV1.operation(),
     "sapinstancestart@v1" => SapInstanceStartV1.operation(),
     "sapinstancestop@v1" => SapInstanceStopV1.operation(),
+    "sapsystemstart@v1" => SapSystemStartV1.operation(),
+    "sapsystemstop@v1" => SapSystemStopV1.operation(),
     "saptuneapplysolution@v1" => SaptuneApplySolutionV1.operation(),
     "saptunechangesolution@v1" => SaptuneChangeSolutionV1.operation()
   }

--- a/lib/wanda/operations/catalog/sapsystemstart_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstart_v1.ex
@@ -1,0 +1,25 @@
+defmodule Wanda.Operations.Catalog.SapSystemStartV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "sapsystemstart@v1",
+      name: "Start SAP system",
+      description: """
+      This operation starts a complete SAP system.
+
+      Arguments:
+        instance_number (string): Instance number to start the system
+        instance_type (string): Instance type to start. Available values: all|abap|j2ee|scs|enqrep. Default value: all
+        timeout (number): Timeout in seconds to wait until the system is started
+      """,
+      required_args: ["instance_number"],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Start SAP system",
+          operator: "sapsystemstart@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end

--- a/lib/wanda/operations/catalog/sapsystemstart_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstart_v1.ex
@@ -18,7 +18,8 @@ defmodule Wanda.Operations.Catalog.SapSystemStartV1 do
         %Wanda.Operations.Catalog.Step{
           name: "Start SAP system",
           operator: "sapsystemstart@v1",
-          predicate: "*"
+          predicate: "*",
+          timeout: 60 * 60 * 1_000
         }
       ]
     }

--- a/lib/wanda/operations/catalog/sapsystemstop_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstop_v1.ex
@@ -1,0 +1,25 @@
+defmodule Wanda.Operations.Catalog.SapSystemStopV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "sapsystemstop@v1",
+      name: "Stop SAP system",
+      description: """
+      This operation stops a complete SAP system.
+
+      Arguments:
+        instance_number (string): Instance number to stop the system
+        instance_type (string): Instance type to stop. Available values: all|abap|j2ee|scs|enqrep. Default value: all
+        timeout (number): Timeout in seconds to wait until the system is stopped
+      """,
+      required_args: ["instance_number"],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Stop SAP system",
+          operator: "sapsystemstop@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end

--- a/lib/wanda/operations/catalog/sapsystemstop_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstop_v1.ex
@@ -18,7 +18,8 @@ defmodule Wanda.Operations.Catalog.SapSystemStopV1 do
         %Wanda.Operations.Catalog.Step{
           name: "Stop SAP system",
           operator: "sapsystemstop@v1",
-          predicate: "*"
+          predicate: "*",
+          timeout: 60 * 60 * 1_000
         }
       ]
     }


### PR DESCRIPTION
# Description

Add SAP system start/stop operations

I'm leaving the PR open until @abravosuse is back. I want to discuss with him if we need to have some more specific timeouts for the steps. Maybe the default 5 minute is not enough, as these operations might take more time than this one.

