### PR TITLE
Add cluster start/stop operations to registry

### DIFF
--- a/lib/wanda/operations/catalog/crmclusterstart_v1.ex
+++ b/lib/wanda/operations/catalog/crmclusterstart_v1.ex
@@ -1,0 +1,22 @@
+defmodule Wanda.Operations.Catalog.CrmClusterStartV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "crmclusterstart@v1",
+      name: "Start HA cluster on the node",
+      description: """
+      This operation starts the High Availability (HA) cluster on a specified node.
+      It is typically used to bring a node back into the cluster after it has been down or
+      to initiate the cluster services on a new node.
+      """,
+      required_args: [],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Start HA cluster on the node",
+          operator: "crmclusterstart@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end

--- a/lib/wanda/operations/catalog/crmclusterstop_v1.ex
+++ b/lib/wanda/operations/catalog/crmclusterstop_v1.ex
@@ -1,0 +1,21 @@
+defmodule Wanda.Operations.Catalog.CrmClusterStopV1 do
+  @moduledoc false
+
+  use Wanda.Operations.Catalog.Operation,
+    operation: %Wanda.Operations.Catalog.Operation{
+      id: "crmclusterstop@v1",
+      name: "Stop HA cluster on the node",
+      description: """
+      This operation stops the High Availability (HA) cluster on a specified node.
+      It is typically used to bring a node down from the cluster or to stop the cluster services on a node.
+      """,
+      required_args: [],
+      steps: [
+        %Wanda.Operations.Catalog.Step{
+          name: "Stop HA cluster on the node",
+          operator: "crmclusterstop@v1",
+          predicate: "*"
+        }
+      ]
+    }
+end

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -7,6 +7,8 @@ defmodule Wanda.Operations.Catalog.Registry do
 
   alias Wanda.Operations.Catalog.{
     ClusterMaintenanceChangeV1,
+    CrmClusterStartV1,
+    CrmClusterStopV1,
     DatabaseStartV1,
     DatabaseStopV1,
     PacemakerDisableV1,
@@ -21,6 +23,8 @@ defmodule Wanda.Operations.Catalog.Registry do
 
   @registry %{
     "clustermaintenancechange@v1" => ClusterMaintenanceChangeV1.operation(),
+    "crmclusterstart@v1" => CrmClusterStartV1.operation(),
+    "crmclusterstop@v1" => CrmClusterStopV1.operation(),
     "databasestart@v1" => DatabaseStartV1.operation(),
     "databasestop@v1" => DatabaseStopV1.operation(),
     "pacemakerdisable@v1" => PacemakerDisableV1.operation(),


### PR DESCRIPTION
Expose `crmclusterstart` and `crmclusterstop`.

Depends on https://github.com/trento-project/workbench/pull/36
Depends on https://github.com/trento-project/workbench/pull/38
