### PR TITLE
[TRNT-3845] Tag endpoints for MCP

### DIFF
--- a/lib/wanda_web/controllers/v1/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v1/catalog_controller.ex
@@ -19,7 +19,7 @@ defmodule WandaWeb.V1.CatalogController do
     summary: "List checks catalog.",
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       env: [
         in: :query,
@@ -47,7 +47,7 @@ defmodule WandaWeb.V1.CatalogController do
     summary: "List selectable checks for a given execution group and environment.",
     description:
       "Provides a list of selectable checks for a specified group and environment, enabling targeted execution.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       group_id: [
         in: :path,

--- a/lib/wanda_web/controllers/v1/execution_controller.ex
+++ b/lib/wanda_web/controllers/v1/execution_controller.ex
@@ -27,7 +27,7 @@ defmodule WandaWeb.V1.ExecutionController do
     summary: "List executions.",
     description:
       "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       group_id: [
         in: :query,
@@ -68,7 +68,7 @@ defmodule WandaWeb.V1.ExecutionController do
   operation :show,
     summary: "Get an execution by ID.",
     description: "Provides detailed information about a specific execution identified by its ID.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       id: [
         in: :path,
@@ -97,7 +97,7 @@ defmodule WandaWeb.V1.ExecutionController do
   operation :last,
     summary: "Get the last execution of a group.",
     description: "Provides details about the most recent execution for a specified group.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       id: [
         in: :path,
@@ -128,7 +128,7 @@ defmodule WandaWeb.V1.ExecutionController do
     summary: "Start a Checks Execution.",
     description:
       "Initiates a new checks execution on the target infrastructure, enabling automated validation.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     request_body:
       {"The context required to start a new execution, including necessary parameters.",
        "application/json", StartExecutionRequest},

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -22,7 +22,7 @@ defmodule WandaWeb.V1.OperationController do
     summary: "List operations.",
     description:
       "Provides a paginated list of operations performed in the system, allowing for easy tracking and management.",
-    tags: ["Operations Engine"],
+    tags: ["Operations Engine", "MCP"],
     parameters: [
       group_id: [
         in: :query,
@@ -74,7 +74,7 @@ defmodule WandaWeb.V1.OperationController do
     summary: "Get an operation by ID.",
     description:
       "Provides detailed information about a specific operation identified by its UUID.",
-    tags: ["Operations Engine"],
+    tags: ["Operations Engine", "MCP"],
     parameters: [
       id: [
         in: :path,

--- a/lib/wanda_web/controllers/v2/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v2/catalog_controller.ex
@@ -14,7 +14,7 @@ defmodule WandaWeb.V2.CatalogController do
     summary: "List checks catalog.",
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       env: [
         in: :query,

--- a/lib/wanda_web/controllers/v2/execution_controller.ex
+++ b/lib/wanda_web/controllers/v2/execution_controller.ex
@@ -27,7 +27,7 @@ defmodule WandaWeb.V2.ExecutionController do
     summary: "List executions.",
     description:
       "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       group_id: [
         in: :query,
@@ -68,7 +68,7 @@ defmodule WandaWeb.V2.ExecutionController do
   operation :show,
     summary: "Get an execution by ID.",
     description: "Provides detailed information about a specific execution identified by its ID.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       id: [
         in: :path,
@@ -97,7 +97,7 @@ defmodule WandaWeb.V2.ExecutionController do
   operation :last,
     summary: "Get the last execution of a group.",
     description: "Provides details about the most recent execution for a specified group.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       id: [
         in: :path,
@@ -128,7 +128,7 @@ defmodule WandaWeb.V2.ExecutionController do
     summary: "Start a Checks Execution.",
     description:
       "Initiates a new checks execution on the target infrastructure, enabling automated validation.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     request_body:
       {"The context required to start a new execution, including necessary parameters.",
        "application/json", StartExecutionRequest},

--- a/lib/wanda_web/controllers/v3/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v3/catalog_controller.ex
@@ -14,7 +14,7 @@ defmodule WandaWeb.V3.CatalogController do
     summary: "List checks catalog.",
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
-    tags: ["Checks Engine"],
+    tags: ["Checks Engine", "MCP"],
     parameters: [
       env: [
         in: :query,

--- a/lib/wanda_web/schemas/api_spec.ex
+++ b/lib/wanda_web/schemas/api_spec.ex
@@ -76,6 +76,11 @@ defmodule WandaWeb.Schemas.ApiSpec do
               description: "Endpoints for accessing checks/operations platform features."
             },
             %Tag{
+              name: "MCP",
+              description:
+                "Exposes endpoints as tools for Model Context Protocol (MCP) integration, enabling those endpoints to be consumed by any LLM."
+            },
+            %Tag{
               name: "Operations Engine",
               description:
                 "Endpoints for managing and executing operations and related information."


### PR DESCRIPTION
# Description

This PR adds the `MCP` tag in the API docs; besides, it tags some endpoints with it. The idea is to flag those endpoints that are ok to be exposed via LLM.

For now, this is just a proposal; we need to check with more stakeholders before merging.

## How was this tested?

CI
