### PR TITLE
Lock targets parallel execution during operation

### DIFF
--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -102,12 +102,24 @@ defmodule Wanda.Operations.Server do
   end
 
   @impl true
-  def init(%State{operation_id: operation_id} = state) do
+  def init(%State{operation_id: operation_id, targets: targets} = state) do
     Logger.debug("Starting operation: #{operation_id}", state: inspect(state))
 
     Process.flag(:trap_exit, true)
 
-    {:ok, state, {:continue, :start_operation}}
+    target_ids = Enum.map(targets, & &1.agent_id)
+
+    # lock targets usage in the init, so the process is self contained and all
+    # the locks are released once the operation itself is finished
+    case lock_targets(target_ids) do
+      :ok ->
+        {:ok, state, {:continue, :start_operation}}
+
+      {:error, :target_already_in_use} ->
+        Logger.error("Operation already in progress in some of the requested targets")
+
+        {:stop, :already_running}
+    end
   end
 
   @impl true
@@ -397,6 +409,42 @@ defmodule Wanda.Operations.Server do
 
       error ->
         error
+    end
+  end
+
+  # lock_targets tries to lock operation targets to avoid their usage in parallel.
+  # It uses the :global registry and it supports distributed erlang clusters deployment
+  defp lock_targets(target_ids) do
+    # List of all nodes in a distributed cluster
+    nodes = [node() | Node.list()]
+    # The requester_id is set to self as this is a new GenServer process.
+    # If this function was used outside of the short lived GenServer,
+    # self() might not be a good choice
+    requester_id = self()
+
+    locking_result =
+      target_ids
+      |> Enum.sort()
+      |> Enum.reduce_while([], fn target_id, locked_ids ->
+        # lock target in all nodes with 0 retries to simply try once
+        if :global.set_lock({{:target, target_id}, requester_id}, nodes, 0) do
+          {:cont, [target_id | locked_ids]}
+        else
+          {:halt, {:error, locked_ids}}
+        end
+      end)
+
+    case locking_result do
+      {:error, locked_ids} ->
+        # Some target is now in an operation process.
+        # Delete currently locked ids so they are free for other coming operations
+        # In any case, the locks are released once the parent process finishes
+        Enum.each(locked_ids, &:global.del_lock({{:target, &1}, requester_id}, nodes))
+
+        {:error, :target_already_in_use}
+
+      _locked_ids ->
+        :ok
     end
   end
 

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -147,6 +147,164 @@ defmodule Wanda.Operations.ServerTest do
       GenServer.stop(pid)
     end
 
+    test "should not start operation if a target is already running in other operation" do
+      group_id = UUID.uuid4()
+      operation_id_1 = UUID.uuid4()
+      operation_id_2 = UUID.uuid4()
+      [first_target | _] = targets = build_list(2, :operation_target)
+
+      new_targest = [
+        build(:operation_target),
+        first_target
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 4, fn
+        _, "results", %OperationStarted{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "agents", %OperatorExecutionRequested{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "results", %OperationCompleted{operation_id: ^operation_id_1, result: :ABORTED}, _ ->
+          :ok
+
+        _,
+        "results",
+        %OperationCompleted{
+          operation_id: ^operation_id_2,
+          result: :REQUEST_FAILED,
+          details:
+            {:request_failed_details, %OperationRequestFailedDetails{error: :ALREADY_RUNNING}}
+        },
+        _ ->
+          :ok
+      end)
+
+      assert :ok =
+               Server.start_operation(
+                 operation_id_1,
+                 group_id,
+                 build(:catalog_operation, id: @existing_catalog_operation_id),
+                 targets,
+                 []
+               )
+
+      assert {:error, :already_running} =
+               Server.start_operation(
+                 operation_id_2,
+                 UUID.uuid4(),
+                 build(:catalog_operation),
+                 new_targest,
+                 []
+               )
+
+      pid = :global.whereis_name({Server, group_id})
+      GenServer.stop(pid)
+    end
+
+    test "should start 2 operations in parallel if group_id and targets are different" do
+      group_id_1 = UUID.uuid4()
+      group_id_2 = UUID.uuid4()
+      operation_id_1 = UUID.uuid4()
+      operation_id_2 = UUID.uuid4()
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 6, fn
+        _, "results", %OperationStarted{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "agents", %OperatorExecutionRequested{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "results", %OperationCompleted{operation_id: ^operation_id_1, result: :ABORTED}, _ ->
+          :ok
+
+        _, "results", %OperationStarted{operation_id: ^operation_id_2}, _ ->
+          :ok
+
+        _, "agents", %OperatorExecutionRequested{operation_id: ^operation_id_2}, _ ->
+          :ok
+
+        _, "results", %OperationCompleted{operation_id: ^operation_id_2, result: :ABORTED}, _ ->
+          :ok
+      end)
+
+      assert :ok =
+               Server.start_operation(
+                 operation_id_1,
+                 group_id_1,
+                 build(:catalog_operation, id: @existing_catalog_operation_id),
+                 build_list(2, :operation_target),
+                 []
+               )
+
+      assert :ok =
+               Server.start_operation(
+                 operation_id_2,
+                 group_id_2,
+                 build(:catalog_operation, id: @existing_catalog_operation_id),
+                 build_list(2, :operation_target),
+                 []
+               )
+
+      pid_1 = :global.whereis_name({Server, group_id_1})
+      pid_2 = :global.whereis_name({Server, group_id_2})
+
+      GenServer.stop(pid_1)
+      GenServer.stop(pid_2)
+    end
+
+    test "should start operation after unlocking targets after previous operation is done" do
+      group_id_1 = UUID.uuid4()
+      group_id_2 = UUID.uuid4()
+      operation_id_1 = UUID.uuid4()
+      operation_id_2 = UUID.uuid4()
+      targets = build_list(2, :operation_target)
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 6, fn
+        _, "results", %OperationStarted{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "agents", %OperatorExecutionRequested{operation_id: ^operation_id_1}, _ ->
+          :ok
+
+        _, "results", %OperationCompleted{operation_id: ^operation_id_1, result: :ABORTED}, _ ->
+          :ok
+
+        _, "results", %OperationStarted{operation_id: ^operation_id_2}, _ ->
+          :ok
+
+        _, "agents", %OperatorExecutionRequested{operation_id: ^operation_id_2}, _ ->
+          :ok
+
+        _, "results", %OperationCompleted{operation_id: ^operation_id_2, result: :ABORTED}, _ ->
+          :ok
+      end)
+
+      assert :ok =
+               Server.start_operation(
+                 operation_id_1,
+                 group_id_1,
+                 build(:catalog_operation, id: @existing_catalog_operation_id),
+                 targets,
+                 []
+               )
+
+      pid_1 = :global.whereis_name({Server, group_id_1})
+      GenServer.stop(pid_1)
+
+      assert :ok =
+               Server.start_operation(
+                 operation_id_2,
+                 group_id_2,
+                 build(:catalog_operation, id: @existing_catalog_operation_id),
+                 targets,
+                 []
+               )
+
+      pid_2 = :global.whereis_name({Server, group_id_2})
+      GenServer.stop(pid_2)
+    end
+
     test "should stop execution if last step failed" do
       operation_id = UUID.uuid4()
       group_id = UUID.uuid4()


### PR DESCRIPTION
# Description

Lock targets parallel execution during operation.

**Disclaimer:**
This implementation wouldn't cover all the scenarios right now, as it only works properly if all operations send all the targets composing one resource (example: all instances of a SAP system). 
This doesn't happen always. For example, for SAP operations, we only send one target, as it is enough to execute the operation.

I opened this PR just to show one option, but I have zero attachments, and seeing it doesn't cover everything, I'm open to discuss any other alternative.
____

Until now, parallel execution is only blocked by `group_id`.
For most of the cases this is enough, but we still need to have a additional protection against having parallel operations in the same target.

I have decided to continue using the `:global` registry and lock the target resources once the operations starts. When the operation is finished the locks are released again.
Using `:global` has the advantage of:
- It works in a distributed erlang cluster
- It avoids any race-condition as locking is a atomic operation

I have considered other options:
- `Registry`: I have discarded this as the `Registry` is a local node registry, so it wouldn't work in a distributed system
- Using the db to store the targets: we actually have the list of targets of currently running operations. But it would require a more complex usage, as first you need to read the currently running operations and get the targets, and after checking if all the targets in the new operation are not there, start a new one, saving the new targets there. Here we would have some race-condition if not managed properly
- Some external dependency like `Horde`: I didn't want to include this kind of "big" dependency for such a simple task


## How was this tested?

UT and manual testing

## Did you update the documentation?

No need
