### PR TITLE
Exclude our common workflows from cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+      exclude: "trento-project/.github*"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
-      exclude: "trento-project/.github*"
+      exclude: 
+        - "trento-project/.github*"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:


### PR DESCRIPTION
I suggest we exclude our own common re-usable workflows from the cooldown period, so we can rapidly update our CI.

Warning: I haven't tested this change. I'm not entirely sure if this is the correct "package name" for what we want to exclude.

PS. Excuse this sloppy PR description, I'm making it from my phone. :)