### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # This file contains the configuration for Credo and you are probably reading
 # this after creating it with `mix credo.gen.config`.
 #

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 /_build/
 /deps/
 /doc/

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Used by "mix format"
 [
   import_deps: [:ecto, :phoenix, :open_api_spex],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,8 @@ jobs:
           key: erlang-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
       - name: Compile
         run: mix compile --warnings-as-errors
+      - name: Create and migrate database
+        run: mix ecto.create && mix ecto.migrate
       - name: Run test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,8 @@ jobs:
         run: mix credo --strict
       - name: Run Dialyzer
         run: mix dialyzer
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        name: Check license headers
 
   test:
     name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Continous Integration
 
 on:

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build dependencies
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-wanda
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.eslintrc"
+    - "**/*.example"
+    - "**/*.json"
+    - "**/*.md"
+    - "**/*.pem"
+    - "**/*.service"
+    - "**/*.svg"
+    - "**/*.txt"
+    - ".github/CODEOWNERS"
+    - ".github/dependabot.yaml"
+    - ".tool-versions"
+    - "LICENSE"
+    - "VERSION"
+    - "mix.lock"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,14 +12,12 @@ header:
       SPDX-License-Identifier: Apache-2.0
   paths-ignore:
     - "**/*.adoc"
-    - "**/*.eslintrc"
     - "**/*.example"
     - "**/*.json"
     - "**/*.md"
     - "**/*.pem"
     - "**/*.service"
     - "**/*.svg"
-    - "**/*.txt"
     - ".github/CODEOWNERS"
     - ".github/dependabot.yaml"
     - ".tool-versions"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ARG OS_VER=15.7
 FROM registry.suse.com/bci/rust:1.92 AS elixir-build
 ARG OS_VER

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 config :wanda, Wanda.Messaging.Publisher, adapter: Wanda.Messaging.Adapters.AMQP

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 config :wanda, Wanda.Policy, execution_server_impl: Wanda.Executions.FakeServer

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 # Configure your database

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 # For production, don't forget to configure the url host

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 # config/runtime.exs is executed for all environments, including

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import Config
 
 # Configure your database

--- a/container_fixtures/rabbitmq/rabbitmq.conf
+++ b/container_fixtures/rabbitmq/rabbitmq.conf
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
 ssl_options.cacertfile           = /etc/ssl/certs/ca_certificate.pem
 ssl_options.certfile             = /var/lib/rabbitmq/server_rabbit.trento.local_certificate.pem
 ssl_options.keyfile              = /var/lib/rabbitmq/server_rabbit.trento.local_key.pem

--- a/demo/fake_gathered_facts.ex
+++ b/demo/fake_gathered_facts.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.FakeGatheredFacts do
   @moduledoc """
   Module responsible to generate the fake gathered facts from targets

--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.FakeServer do
   @moduledoc """
   Execution server implementation that does not actually execute anything and just

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 version: "3.7"
 
 services:

--- a/hack/api_docs_check.sh
+++ b/hack/api_docs_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # ------------------------------------------------------------------------------

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 set -o pipefail
 

--- a/hack/gh_release_to_obs_changeset.py
+++ b/hack/gh_release_to_obs_changeset.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 import argparse
 import json
 import os

--- a/lib/wanda.ex
+++ b/lib/wanda.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda do
   @moduledoc false
 end

--- a/lib/wanda/application.ex
+++ b/lib/wanda/application.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Application do
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog do
   @moduledoc """
   Function to interact with the checks catalog.

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Check do
   @moduledoc """
   Represents a check.

--- a/lib/wanda/catalog/check_customization.ex
+++ b/lib/wanda/catalog/check_customization.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.CheckCustomization do
   @moduledoc """
   Schema representing Customizations applied for a Check in a specific execution group.

--- a/lib/wanda/catalog/condition.ex
+++ b/lib/wanda/catalog/condition.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Condition do
   @moduledoc """
   Represents a condition.

--- a/lib/wanda/catalog/customization_policy.ex
+++ b/lib/wanda/catalog/customization_policy.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.CustomizationPolicy do
   @moduledoc """
   Policy for checks customizations.

--- a/lib/wanda/catalog/customized_value.ex
+++ b/lib/wanda/catalog/customized_value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.CustomizedValue do
   @moduledoc """
   Represents a check's customized value.

--- a/lib/wanda/catalog/enums/expect_type.ex
+++ b/lib/wanda/catalog/enums/expect_type.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Enums.ExpectType do
   @moduledoc """
   Type that represents a check expectation type.

--- a/lib/wanda/catalog/enums/severity.ex
+++ b/lib/wanda/catalog/enums/severity.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Enums.Severity do
   @moduledoc """
   Type that represents a check severity.

--- a/lib/wanda/catalog/evaluation.ex
+++ b/lib/wanda/catalog/evaluation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Evaluation do
   @moduledoc """
   This module provides functions to evaluate check values based on their conditions.

--- a/lib/wanda/catalog/expectation.ex
+++ b/lib/wanda/catalog/expectation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Expectation do
   @moduledoc """
   Represents an expectation.

--- a/lib/wanda/catalog/fact.ex
+++ b/lib/wanda/catalog/fact.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Fact do
   @moduledoc """
   Represents a fact.

--- a/lib/wanda/catalog/messaging/publisher.ex
+++ b/lib/wanda/catalog/messaging/publisher.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Messaging.Publisher do
   @moduledoc """
   Catalog messaging publisher module

--- a/lib/wanda/catalog/resolved_value.ex
+++ b/lib/wanda/catalog/resolved_value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.ResolvedValue do
   @moduledoc """
   Represents a resolved check value as defined check specification.

--- a/lib/wanda/catalog/selectable_check.ex
+++ b/lib/wanda/catalog/selectable_check.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.SelectableCheck do
   @moduledoc """
   Represents a check that is selectable for a given execution group given the context.

--- a/lib/wanda/catalog/selected_check.ex
+++ b/lib/wanda/catalog/selected_check.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.SelectedCheck do
   @moduledoc """
   Represents a selected check used during a check execution.

--- a/lib/wanda/catalog/value.ex
+++ b/lib/wanda/catalog/value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.Value do
   @moduledoc """
   Represents a value.

--- a/lib/wanda/checks_customizations.ex
+++ b/lib/wanda/checks_customizations.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.ChecksCustomizations do
   @moduledoc """
   Customization features.

--- a/lib/wanda/evaluation_engine.ex
+++ b/lib/wanda/evaluation_engine.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.EvaluationEngine do
   @moduledoc """
   This module wraps the Rhai engine and provides a simple interface for

--- a/lib/wanda/executions.ex
+++ b/lib/wanda/executions.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions do
   @moduledoc """
   This module exposes functionalities to interact with the historycal log of executions.

--- a/lib/wanda/executions/agent_check_error.ex
+++ b/lib/wanda/executions/agent_check_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.AgentCheckError do
   @moduledoc """
   Represents the result of a check on a specific agent.

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.AgentCheckResult do
   @moduledoc """
   Represents the result of a check on a specific agent.

--- a/lib/wanda/executions/check_result.ex
+++ b/lib/wanda/executions/check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.CheckResult do
   @moduledoc """
   Represents the result of a check.

--- a/lib/wanda/executions/enums/result.ex
+++ b/lib/wanda/executions/enums/result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Enums.Result do
   @moduledoc """
   Type that represents a check execution result.

--- a/lib/wanda/executions/enums/status.ex
+++ b/lib/wanda/executions/enums/status.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Enums.Status do
   @moduledoc """
   Type that represents a check execution status.

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Evaluation do
   @moduledoc """
   Evaluation functional core.

--- a/lib/wanda/executions/execution.ex
+++ b/lib/wanda/executions/execution.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Execution do
   @moduledoc """
   Schema of a persisted execution.

--- a/lib/wanda/executions/expectation_evaluation.ex
+++ b/lib/wanda/executions/expectation_evaluation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ExpectationEvaluation do
   @moduledoc """
   Represents the evaluation of an expectation.

--- a/lib/wanda/executions/expectation_evaluation_error.ex
+++ b/lib/wanda/executions/expectation_evaluation_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ExpectationEvaluationError do
   @moduledoc """
   Represents an error occurred during the evaluation of an expectation.

--- a/lib/wanda/executions/expectation_result.ex
+++ b/lib/wanda/executions/expectation_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ExpectationResult do
   @moduledoc """
   Represents the result of an expectation.

--- a/lib/wanda/executions/fact.ex
+++ b/lib/wanda/executions/fact.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Fact do
   @moduledoc """
   A fact is a piece of information that was gathered from a target.

--- a/lib/wanda/executions/fact_error.ex
+++ b/lib/wanda/executions/fact_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.FactError do
   @moduledoc """
   Fact with an error.

--- a/lib/wanda/executions/gathering.ex
+++ b/lib/wanda/executions/gathering.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Gathering do
   @moduledoc """
   Facts gathering functional core.

--- a/lib/wanda/executions/messaging/consumer.ex
+++ b/lib/wanda/executions/messaging/consumer.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Messaging.Consumer do
   @moduledoc """
   Executions messagging consumer module

--- a/lib/wanda/executions/messaging/publisher.ex
+++ b/lib/wanda/executions/messaging/publisher.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Messaging.Publisher do
   @moduledoc """
   Executions messagging publisher module

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Result do
   @moduledoc """
   Represents the result of an execution.

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Server do
   @moduledoc """
   Represents the execution of the CheckSelection(s) on the target nodes/agents of a cluster

--- a/lib/wanda/executions/server_behaviour.ex
+++ b/lib/wanda/executions/server_behaviour.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ServerBehaviour do
   @moduledoc """
   Execution server API behaviour.

--- a/lib/wanda/executions/state.ex
+++ b/lib/wanda/executions/state.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.State do
   @moduledoc """
   State of an execution.

--- a/lib/wanda/executions/target.ex
+++ b/lib/wanda/executions/target.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Target do
   @moduledoc """
   Execution targets.

--- a/lib/wanda/executions/value.ex
+++ b/lib/wanda/executions/value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.Value do
   @moduledoc """
   Represents a Value used in expectation evaluation.

--- a/lib/wanda/messaging.ex
+++ b/lib/wanda/messaging.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging do
   @moduledoc """
   Publishes messages to the message bus

--- a/lib/wanda/messaging/adapters/amqp.ex
+++ b/lib/wanda/messaging/adapters/amqp.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.AMQP do
   @moduledoc """
   AMQP adapter

--- a/lib/wanda/messaging/adapters/amqp/consumer.ex
+++ b/lib/wanda/messaging/adapters/amqp/consumer.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.AMQP.Consumer do
   @moduledoc """
   AMQP consumer.

--- a/lib/wanda/messaging/adapters/amqp/processor.ex
+++ b/lib/wanda/messaging/adapters/amqp/processor.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.AMQP.Processor do
   @moduledoc """
   AMQP processor.

--- a/lib/wanda/messaging/adapters/amqp/publisher.ex
+++ b/lib/wanda/messaging/adapters/amqp/publisher.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.AMQP.Publisher do
   @moduledoc """
   AMQP publisher.

--- a/lib/wanda/messaging/adapters/behaviour.ex
+++ b/lib/wanda/messaging/adapters/behaviour.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.Behaviour do
   @moduledoc false
 

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Mapper do
   @moduledoc """
   Maps domain structures to integration events.

--- a/lib/wanda/operations.ex
+++ b/lib/wanda/operations.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations do
   @moduledoc """
   Operations are combined actions dispatched to different agents in order to apply

--- a/lib/wanda/operations/agent_report.ex
+++ b/lib/wanda/operations/agent_report.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.AgentReport do
   @moduledoc """
   Report of an executed operation from an individual agent

--- a/lib/wanda/operations/catalog/clustermaintenancechange_v1.ex
+++ b/lib/wanda/operations/catalog/clustermaintenancechange_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.ClusterMaintenanceChangeV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/clusterresourcerefresh_v1.ex
+++ b/lib/wanda/operations/catalog/clusterresourcerefresh_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.ClusterResourceRefreshV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/crmclusterstart_v1.ex
+++ b/lib/wanda/operations/catalog/crmclusterstart_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.CrmClusterStartV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/crmclusterstop_v1.ex
+++ b/lib/wanda/operations/catalog/crmclusterstop_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.CrmClusterStopV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/databasestart_v1.ex
+++ b/lib/wanda/operations/catalog/databasestart_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.DatabaseStartV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/databasestop_v1.ex
+++ b/lib/wanda/operations/catalog/databasestop_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.DatabaseStopV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/hostreboot_v1.ex
+++ b/lib/wanda/operations/catalog/hostreboot_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.HostRebootV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/operation.ex
+++ b/lib/wanda/operations/catalog/operation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.Operation do
   @moduledoc """
   An operation is a set of actions executed step by step in agents to apply

--- a/lib/wanda/operations/catalog/pacemakerdisable_v1.ex
+++ b/lib/wanda/operations/catalog/pacemakerdisable_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.PacemakerDisableV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/pacemakerenable_v1.ex
+++ b/lib/wanda/operations/catalog/pacemakerenable_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.PacemakerEnableV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/registry.ex
+++ b/lib/wanda/operations/catalog/registry.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.Registry do
   @moduledoc """
   Operations registry where are available operations are listed

--- a/lib/wanda/operations/catalog/sapinstancestart_v1.ex
+++ b/lib/wanda/operations/catalog/sapinstancestart_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SapInstanceStartV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/sapinstancestop_v1.ex
+++ b/lib/wanda/operations/catalog/sapinstancestop_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SapInstanceStopV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/sapsystemstart_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstart_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SapSystemStartV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/sapsystemstop_v1.ex
+++ b/lib/wanda/operations/catalog/sapsystemstop_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SapSystemStopV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptuneapplysolution_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SaptuneApplySolutionV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/saptunechangesolution_v1.ex
+++ b/lib/wanda/operations/catalog/saptunechangesolution_v1.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.SaptuneChangeSolutionV1 do
   @moduledoc false
 

--- a/lib/wanda/operations/catalog/step.ex
+++ b/lib/wanda/operations/catalog/step.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.Step do
   @moduledoc """
   A individual operation step running a single operator.

--- a/lib/wanda/operations/enums/operator_phase.ex
+++ b/lib/wanda/operations/enums/operator_phase.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Enums.OperatorPhase do
   @moduledoc """
   Type that represents an operator phase.

--- a/lib/wanda/operations/enums/result.ex
+++ b/lib/wanda/operations/enums/result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Enums.Result do
   @moduledoc """
   Type that represents an operation result.

--- a/lib/wanda/operations/enums/status.ex
+++ b/lib/wanda/operations/enums/status.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Enums.Status do
   @moduledoc """
   Type that represents an operation execution status.

--- a/lib/wanda/operations/messaging/consumer.ex
+++ b/lib/wanda/operations/messaging/consumer.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Messaging.Consumer do
   @moduledoc """
   Operations messagging consumer module

--- a/lib/wanda/operations/messaging/publisher.ex
+++ b/lib/wanda/operations/messaging/publisher.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Messaging.Publisher do
   @moduledoc """
   Operations messagging publisher module

--- a/lib/wanda/operations/operation.ex
+++ b/lib/wanda/operations/operation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Operation do
   @moduledoc """
   Schema of a persisted operation.

--- a/lib/wanda/operations/operation_target.ex
+++ b/lib/wanda/operations/operation_target.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.OperationTarget do
   @moduledoc """
   An operation target defines an agent where the operation is executed

--- a/lib/wanda/operations/operator_error.ex
+++ b/lib/wanda/operations/operator_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.OperatorError do
   @moduledoc """
   Operator execution result with an error retrieved from an agent.

--- a/lib/wanda/operations/operator_result.ex
+++ b/lib/wanda/operations/operator_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.OperatorResult do
   @moduledoc """
   Operator execution result retrieved from an agent.

--- a/lib/wanda/operations/server.ex
+++ b/lib/wanda/operations/server.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Server do
   @moduledoc """
   Represents the execution of operations in target agents

--- a/lib/wanda/operations/server_behaviour.ex
+++ b/lib/wanda/operations/server_behaviour.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.ServerBehaviour do
   @moduledoc """
   Operation server API behaviour.

--- a/lib/wanda/operations/state.ex
+++ b/lib/wanda/operations/state.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.State do
   @moduledoc """
   State of an operation.

--- a/lib/wanda/operations/step_report.ex
+++ b/lib/wanda/operations/step_report.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.StepReport do
   @moduledoc """
   Report of all agent execution of an operation step

--- a/lib/wanda/policy.ex
+++ b/lib/wanda/policy.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Policy do
   @moduledoc """
   Handles integration events.

--- a/lib/wanda/release.ex
+++ b/lib/wanda/release.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Release do
   @moduledoc """
   Used for executing DB release tasks when run in production without Mix

--- a/lib/wanda/repo.ex
+++ b/lib/wanda/repo.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo do
   use Ecto.Repo,
     otp_app: :wanda,

--- a/lib/wanda/support/abilities_helper.ex
+++ b/lib/wanda/support/abilities_helper.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.AbilitiesHelper do
   @moduledoc """
   Helper functions for bodyguard policies

--- a/lib/wanda/support/date.ex
+++ b/lib/wanda/support/date.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.DateService do
   @moduledoc """
   DateTime service

--- a/lib/wanda/support/ecto/json.ex
+++ b/lib/wanda/support/ecto/json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.Ecto.Json do
   @moduledoc """
   Ecto Type that represents JSON data.

--- a/lib/wanda/support/enum.ex
+++ b/lib/wanda/support/enum.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.Enum do
   @moduledoc """
   Enum  module with added macros to define a type,

--- a/lib/wanda/users/user.ex
+++ b/lib/wanda/users/user.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Users.User do
   @moduledoc """
   Represents the user performing actions in the system.

--- a/lib/wanda_web.ex
+++ b/lib/wanda_web.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb do
   @moduledoc """
   The entrypoint for defining your web interface, such

--- a/lib/wanda_web/auth/auth_plug.ex
+++ b/lib/wanda_web/auth/auth_plug.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.AuthPlug do
   @moduledoc """
     Plug responsible for reading the Token from the authorization header and

--- a/lib/wanda_web/auth/client/auth_client.ex
+++ b/lib/wanda_web/auth/client/auth_client.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.Client.AuthClient do
   @moduledoc """
   Client for interacting with the authentication server.

--- a/lib/wanda_web/auth/client/auth_client_http.ex
+++ b/lib/wanda_web/auth/client/auth_client_http.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.Client.HttpClient do
   @moduledoc """
   Http AuthClient implementation.

--- a/lib/wanda_web/auth/user_detector.ex
+++ b/lib/wanda_web/auth/user_detector.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.UserDetector do
   @moduledoc """
   This module allows extracting a very simple representation of a user from a connection.

--- a/lib/wanda_web/controllers/error_helpers.ex
+++ b/lib/wanda_web/controllers/error_helpers.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.ErrorHelpers do
   @moduledoc """
   Conveniences for translating and building error messages.

--- a/lib/wanda_web/controllers/error_json.ex
+++ b/lib/wanda_web/controllers/error_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.ErrorJSON do
   def render("422.json", %{reason: reason}) do
     %{

--- a/lib/wanda_web/controllers/fallback_controller.ex
+++ b/lib/wanda_web/controllers/fallback_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.FallbackController do
   use Phoenix.Controller
 

--- a/lib/wanda_web/controllers/health_controller.ex
+++ b/lib/wanda_web/controllers/health_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.HealthController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/health_json.ex
+++ b/lib/wanda_web/controllers/health_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.HealthJSON do
   def health(%{health: health}), do: health
 end

--- a/lib/wanda_web/controllers/info_controller.ex
+++ b/lib/wanda_web/controllers/info_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.InfoController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v1/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v1/catalog_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.CatalogController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v1/catalog_json.ex
+++ b/lib/wanda_web/controllers/v1/catalog_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.CatalogJSON do
   alias Wanda.Catalog.{Check, SelectableCheck}
 

--- a/lib/wanda_web/controllers/v1/checks_customizations_controller.ex
+++ b/lib/wanda_web/controllers/v1/checks_customizations_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ChecksCustomizationsController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v1/checks_customizations_json.ex
+++ b/lib/wanda_web/controllers/v1/checks_customizations_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ChecksCustomizationsJSON do
   alias Wanda.Catalog.CheckCustomization
 

--- a/lib/wanda_web/controllers/v1/execution_controller.ex
+++ b/lib/wanda_web/controllers/v1/execution_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ExecutionController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v1/execution_json.ex
+++ b/lib/wanda_web/controllers/v1/execution_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ExecutionJSON do
   alias Wanda.Executions.Execution
   alias WandaWeb.V2

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.OperationController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v1/operation_json.ex
+++ b/lib/wanda_web/controllers/v1/operation_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.OperationJSON do
   alias Wanda.Operations.Operation
 

--- a/lib/wanda_web/controllers/v2/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v2/catalog_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.CatalogController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v2/catalog_json.ex
+++ b/lib/wanda_web/controllers/v2/catalog_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.CatalogJSON do
   alias WandaWeb.V1.CatalogJSON
 

--- a/lib/wanda_web/controllers/v2/execution_controller.ex
+++ b/lib/wanda_web/controllers/v2/execution_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.ExecutionController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v2/execution_json.ex
+++ b/lib/wanda_web/controllers/v2/execution_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.ExecutionJSON do
   alias Wanda.Executions.Execution
 

--- a/lib/wanda_web/controllers/v3/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v3/catalog_controller.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V3.CatalogController do
   use WandaWeb, :controller
   use OpenApiSpex.ControllerSpecs

--- a/lib/wanda_web/controllers/v3/catalog_json.ex
+++ b/lib/wanda_web/controllers/v3/catalog_json.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V3.CatalogJSON do
   alias Wanda.Catalog.Check
 

--- a/lib/wanda_web/endpoint.ex
+++ b/lib/wanda_web/endpoint.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :wanda
 

--- a/lib/wanda_web/plugs/api_redirector.ex
+++ b/lib/wanda_web/plugs/api_redirector.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Plugs.ApiRedirector do
   @moduledoc """
     This Plug is responsible for redirecting api requests without a specific version

--- a/lib/wanda_web/plugs/swaggerui_runtime.ex
+++ b/lib/wanda_web/plugs/swaggerui_runtime.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Plugs.SwaggerUIRuntime do
   @moduledoc """
     This Plug updates the original SwaggerUI configuration, by adding the

--- a/lib/wanda_web/router.ex
+++ b/lib/wanda_web/router.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Router do
   use WandaWeb, :router
 

--- a/lib/wanda_web/schemas/all/api_spec.ex
+++ b/lib/wanda_web/schemas/all/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.All.ApiSpec do
   @moduledoc """
   OpenApi all specification

--- a/lib/wanda_web/schemas/api_spec.ex
+++ b/lib/wanda_web/schemas/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.ApiSpec do
   @moduledoc """
   OpenApi specification entry point

--- a/lib/wanda_web/schemas/unversioned/api_spec.ex
+++ b/lib/wanda_web/schemas/unversioned/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.Unversioned.ApiSpec do
   @moduledoc """
   OpenApi specification entry point for unversioned endpoints

--- a/lib/wanda_web/schemas/v1/accepted_execution_response.ex
+++ b/lib/wanda_web/schemas/v1/accepted_execution_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.AcceptedExecutionResponse do
   @moduledoc """
   Minimal information about an Execution accepted by the system,

--- a/lib/wanda_web/schemas/v1/api_spec.ex
+++ b/lib/wanda_web/schemas/v1/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ApiSpec do
   @moduledoc """
   OpenApi specification for entrypoint V1

--- a/lib/wanda_web/schemas/v1/bad_request.ex
+++ b/lib/wanda_web/schemas/v1/bad_request.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.BadRequest do
   @moduledoc """
   Bad Request.

--- a/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v1/catalog/catalog_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Catalog.CatalogResponse do
   @moduledoc """
   Checks catalog response API spec

--- a/lib/wanda_web/schemas/v1/catalog/check.ex
+++ b/lib/wanda_web/schemas/v1/catalog/check.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Catalog.Check do
   @moduledoc """
   Individual check of the catalog response API spec

--- a/lib/wanda_web/schemas/v1/checks_customizations/custom_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_customizations/custom_value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksCustomizations.CustomValue do
   @moduledoc """
   Custom value to be applied or already applied to a check

--- a/lib/wanda_web/schemas/v1/checks_customizations/customization_request.ex
+++ b/lib/wanda_web/schemas/v1/checks_customizations/customization_request.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksCustomizations.CustomizationRequest do
   @moduledoc """
   Request to customize a check

--- a/lib/wanda_web/schemas/v1/checks_customizations/customization_response.ex
+++ b/lib/wanda_web/schemas/v1/checks_customizations/customization_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksCustomizations.CustomizationResponse do
   @moduledoc """
   Response for a customization operation

--- a/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/customized_check_value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksSelection.CustomizedCheckValue do
   @moduledoc """
   A Customized Check Value

--- a/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/not_customized_check_value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksSelection.NotCustomizedCheckValue do
   @moduledoc """
   A Check Value that has not been customized.

--- a/lib/wanda_web/schemas/v1/checks_selection/selectable_checks_response.ex
+++ b/lib/wanda_web/schemas/v1/checks_selection/selectable_checks_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.ChecksSelection.SelectableChecksResponse do
   @moduledoc """
   Response representing the list of selectable checks for a given execution group and environment.

--- a/lib/wanda_web/schemas/v1/env.ex
+++ b/lib/wanda_web/schemas/v1/env.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Env do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.AgentCheckError do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.CheckResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/execution_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.ExecutionResponse do
   @moduledoc """
   Execution item response API spec

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluation do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_evaluation_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.ExpectationEvaluationError do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/expectation_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.ExpectationResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/fact.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.Fact do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/fact_error.ex
+++ b/lib/wanda_web/schemas/v1/execution/fact_error.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.FactError do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v1/execution/list_executions_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.ListExecutionsResponse do
   @moduledoc """
   Execution list response API spec

--- a/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v1/execution/start_execution_request.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.StartExecutionRequest do
   @moduledoc """
   The request to be sent to start an execution.

--- a/lib/wanda_web/schemas/v1/execution/target.ex
+++ b/lib/wanda_web/schemas/v1/execution/target.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.Target do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/execution/value.ex
+++ b/lib/wanda_web/schemas/v1/execution/value.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Execution.Value do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/forbidden.ex
+++ b/lib/wanda_web/schemas/v1/forbidden.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Forbidden do
   @moduledoc """
   403 - Forbidden.

--- a/lib/wanda_web/schemas/v1/health.ex
+++ b/lib/wanda_web/schemas/v1/health.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Health do
   @moduledoc """
   Healthcheck

--- a/lib/wanda_web/schemas/v1/info.ex
+++ b/lib/wanda_web/schemas/v1/info.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Info do
   @moduledoc """
   Info response schema.

--- a/lib/wanda_web/schemas/v1/not_found.ex
+++ b/lib/wanda_web/schemas/v1/not_found.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.NotFound do
   @moduledoc """
   404 - Not Found.

--- a/lib/wanda_web/schemas/v1/operation/agent_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/agent_report.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Operation.AgentReport do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/operation/list_operations_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/list_operations_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Operation.ListOperationsResponse do
   @moduledoc """
   Operation list response API spec

--- a/lib/wanda_web/schemas/v1/operation/operation_response.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Operation.OperationResponse do
   @moduledoc """
   Operation item response API spec

--- a/lib/wanda_web/schemas/v1/operation/operation_target.ex
+++ b/lib/wanda_web/schemas/v1/operation/operation_target.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Operation.OperationTarget do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/operation/step_report.ex
+++ b/lib/wanda_web/schemas/v1/operation/step_report.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Operation.StepReport do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v1/ready.ex
+++ b/lib/wanda_web/schemas/v1/ready.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.Ready do
   @moduledoc """
   Ready.

--- a/lib/wanda_web/schemas/v1/unprocessable_entity.ex
+++ b/lib/wanda_web/schemas/v1/unprocessable_entity.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V1.UnprocessableEntity do
   @moduledoc """
   422 - Unprocessable Entity.

--- a/lib/wanda_web/schemas/v2/api_spec.ex
+++ b/lib/wanda_web/schemas/v2/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.ApiSpec do
   @moduledoc """
   OpenApi specification for entrypoint V2

--- a/lib/wanda_web/schemas/v2/env.ex
+++ b/lib/wanda_web/schemas/v2/env.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Env do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v2/execution/check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/check_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.CheckResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v2/execution/execution_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/execution_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.ExecutionResponse do
   @moduledoc """
   Execution item response API spec

--- a/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_evaluation.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.ExpectationEvaluation do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v2/execution/expectation_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/expectation_result.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.ExpectationResult do
   @moduledoc false
 

--- a/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
+++ b/lib/wanda_web/schemas/v2/execution/list_executions_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.ListExecutionsResponse do
   @moduledoc """
   Execution list response API spec

--- a/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
+++ b/lib/wanda_web/schemas/v2/execution/start_execution_request.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V2.Execution.StartExecutionRequest do
   @moduledoc """
   The request to be sent to start an execution.

--- a/lib/wanda_web/schemas/v3/api_spec.ex
+++ b/lib/wanda_web/schemas/v3/api_spec.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V3.ApiSpec do
   @moduledoc """
   OpenApi specification for entrypoint V3

--- a/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
+++ b/lib/wanda_web/schemas/v3/catalog/catalog_response.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V3.Catalog.CatalogResponse do
   @moduledoc """
   Checks catalog response API spec

--- a/lib/wanda_web/schemas/v3/catalog/check.ex
+++ b/lib/wanda_web/schemas/v3/catalog/check.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.V3.Catalog.Check do
   @moduledoc """
   Individual check of the catalog response API spec

--- a/lib/wanda_web/telemetry.ex
+++ b/lib/wanda_web/telemetry.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Telemetry do
   @moduledoc false
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.MixProject do
   use Mix.Project
 

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 #!BuildTag: trento/trento-wanda:latest
 #!BuildTag: trento/trento-wanda:%%VERSION%%

--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -1,7 +1,8 @@
 #
 # spec file for package trento-wanda
 #
-# Copyright (c) 2024 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -66,17 +67,17 @@ cp -a _build/prod/rel/wanda %{buildroot}/usr/lib
 install -D -m 0644 packaging/suse/rpm/systemd/trento-wanda.service %{buildroot}%{_unitdir}/trento-wanda.service
 install -D -m 0600 packaging/suse/rpm/systemd/trento-wanda.example %{buildroot}/etc/trento/trento-wanda.example
 
-%pre  
-%service_add_pre trento-wanda.service  
+%pre
+%service_add_pre trento-wanda.service
 
-%post  
-%service_add_post trento-wanda.service  
+%post
+%service_add_post trento-wanda.service
 
-%preun  
-%service_del_preun trento-wanda.service  
+%preun
+%service_del_preun trento-wanda.service
 
-%postun  
-%service_del_postun trento-wanda.service  
+%postun
+%service_del_postun trento-wanda.service
 
 %files
 /usr/lib/wanda

--- a/priv/demo/fake_facts.yaml
+++ b/priv/demo/fake_facts.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 targets:
   target1: 0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4
   target2: 13e8c25c-3180-5a9a-95c8-51ec38e50cfc

--- a/priv/repo/migrations/.formatter.exs
+++ b/priv/repo/migrations/.formatter.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 [
   import_deps: [:ecto_sql],
   inputs: ["*.exs"]

--- a/priv/repo/migrations/20220928131105_add_execution_result.exs
+++ b/priv/repo/migrations/20220928131105_add_execution_result.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.AddExecution do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20250109154813_add_operation.exs
+++ b/priv/repo/migrations/20250109154813_add_operation.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.AddOperation do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
+++ b/priv/repo/migrations/20250116095113_add_operation_jsonb_indexes.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.AddOperationJsonbIndexes do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20250123102550_create_check_customizations.exs
+++ b/priv/repo/migrations/20250123102550_create_check_customizations.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.CreateCheckCustomizations do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20250123143407_add_catalog_operation_id_to_operation.exs
+++ b/priv/repo/migrations/20250123143407_add_catalog_operation_id_to_operation.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.AddCatalogOperationIdToOperation do
   use Ecto.Migration
 

--- a/priv/repo/migrations/20250623071928_add_timeout_at_to_operations.exs
+++ b/priv/repo/migrations/20250623071928_add_timeout_at_to_operations.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Repo.Migrations.AddTimeoutAtToOperations do
   use Ecto.Migration
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Script for populating the database. You can run it as:
 #
 #     mix run priv/repo/seeds.exs

--- a/test/demo/fake_gathered_facts_test.exs
+++ b/test/demo/fake_gathered_facts_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.FakeGatheredFactsTest do
   @moduledoc false
 

--- a/test/demo/fake_server_test.exs
+++ b/test/demo/fake_server_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.FakeServerTest do
   use Wanda.DataCase
 

--- a/test/fixtures/catalog/check_without_values.yaml
+++ b/test/fixtures/catalog/check_without_values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: check_without_values
 name: Warning check
 group: Test

--- a/test/fixtures/catalog/customizable_check.yaml
+++ b/test/fixtures/catalog/customizable_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: customizable_check
 name: Test check
 group: Test

--- a/test/fixtures/catalog/expect_check.yaml
+++ b/test/fixtures/catalog/expect_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: expect_check
 name: Test check
 group: Test

--- a/test/fixtures/catalog/expect_enum_check.yaml
+++ b/test/fixtures/catalog/expect_enum_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: expect_enum_check
 name: Test check
 group: Test

--- a/test/fixtures/catalog/expect_same_check.yaml
+++ b/test/fixtures/catalog/expect_same_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: expect_same_check
 name: Test check
 group: Test

--- a/test/fixtures/catalog/malformed_check.yaml
+++ b/test/fixtures/catalog/malformed_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: malformed_check
 name: Malformed check
 group: Test

--- a/test/fixtures/catalog/malformed_file.yaml
+++ b/test/fixtures/catalog/malformed_file.yaml
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 some random string: kekw: aa

--- a/test/fixtures/catalog/non_customizable_check.yaml
+++ b/test/fixtures/catalog/non_customizable_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: non_customizable_check
 name: Test check
 group: Test

--- a/test/fixtures/catalog/non_customizable_check_values.yaml
+++ b/test/fixtures/catalog/non_customizable_check_values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: non_customizable_check_values
 name: Test check
 group: Test

--- a/test/fixtures/catalog/warning_severity_check.yaml
+++ b/test/fixtures/catalog/warning_severity_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: warning_severity_check
 name: Warning check
 group: Test

--- a/test/fixtures/catalog/when_condition_check.yaml
+++ b/test/fixtures/catalog/when_condition_check.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: when_condition_check
 name: When condition check
 group: Test

--- a/test/fixtures/catalog/with_metadata.yaml
+++ b/test/fixtures/catalog/with_metadata.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: with_metadata
 name: Metadata powered check
 group: Test

--- a/test/fixtures/demo/fake_facts_test.yaml
+++ b/test/fixtures/demo/fake_facts_test.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 targets:
   target1: 0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4
   target2: 13e8c25c-3180-5a9a-95c8-51ec38e50cfc

--- a/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
+++ b/test/fixtures/non_scalar_values_catalog/mixed_values_customizability.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 id: mixed_values_customizability
 name: Test check
 group: Test

--- a/test/support/catalog_case.ex
+++ b/test/support/catalog_case.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.CatalogCase do
   @moduledoc """
   Base case for testing the checks catalog only against fixtures in the `test/fixtures/catalog` directory.

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.ConnCase do
   @moduledoc """
   This module defines the test case to be used by

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.DataCase do
   @moduledoc """
   This module defines the setup for tests requiring

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Factory do
   @moduledoc false
 

--- a/test/support/messaging/adapters/stub.ex
+++ b/test/support/messaging/adapters/stub.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.Messaging.Adapters.Stub do
   @moduledoc false
 

--- a/test/support/messaging/dummy_event.ex
+++ b/test/support/messaging/dummy_event.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.Messaging.DummyEvent do
   @moduledoc false
 

--- a/test/support/messaging_case.ex
+++ b/test/support/messaging_case.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.MessagingCase do
   @moduledoc false
 

--- a/test/support/operations/test_registry.ex
+++ b/test/support/operations/test_registry.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.TestRegistry do
   @moduledoc false
 

--- a/test/support/user_aware_conn_case.ex
+++ b/test/support/user_aware_conn_case.ex
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.UserAwareConnCase do
   @moduledoc """
   Test case to deal with users and their abilities.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 Mox.defmock(Wanda.Messaging.Adapters.Mock, for: Wanda.Messaging.Adapters.Behaviour)
 Application.put_env(:wanda, :messaging, adapter: Wanda.Messaging.Adapters.Mock)
 

--- a/test/wanda/catalog/customization_policy_test.exs
+++ b/test/wanda/catalog/customization_policy_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.CustomizationPolicyTest do
   use ExUnit.Case
 

--- a/test/wanda/catalog/evaluation_test.exs
+++ b/test/wanda/catalog/evaluation_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.EvaluationTest do
   use ExUnit.Case
 

--- a/test/wanda/catalog/selected_check_test.exs
+++ b/test/wanda/catalog/selected_check_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Catalog.SelectedCheckTest do
   use ExUnit.Case
 

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.CatalogTest do
   use Wanda.DataCase, async: true
 

--- a/test/wanda/checks_customizations_test.exs
+++ b/test/wanda/checks_customizations_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.ChecksCustomizationsTest do
   use Wanda.DataCase, async: true
   use Wanda.Support.MessagingCase, async: true

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.EvaluationTest do
   use ExUnit.Case
 

--- a/test/wanda/executions/gathering_test.exs
+++ b/test/wanda/executions/gathering_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.GatheringTest do
   use ExUnit.Case
 

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ServerTest do
   use Wanda.Support.MessagingCase, async: false
   use Wanda.DataCase

--- a/test/wanda/executions/target_test.exs
+++ b/test/wanda/executions/target_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.TargetTest do
   use ExUnit.Case
 

--- a/test/wanda/executions_test.exs
+++ b/test/wanda/executions_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.ExecutionsTest do
   use ExUnit.Case
   use Wanda.DataCase

--- a/test/wanda/messaging/adapters/amqp/consumer_test.exs
+++ b/test/wanda/messaging/adapters/amqp/consumer_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapters.AMQP.ConsumerTest do
   use ExUnit.Case
 

--- a/test/wanda/messaging/adapters/amqp/processor_test.exs
+++ b/test/wanda/messaging/adapters/amqp/processor_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.Adapter.AMQP.ProcessorTest do
   use ExUnit.Case
 

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Messaging.MapperTest do
   @moduledoc false
 

--- a/test/wanda/operations/catalog/operation_test.exs
+++ b/test/wanda/operations/catalog/operation_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.OperationTest do
   use ExUnit.Case
 

--- a/test/wanda/operations/catalog/registry_test.exs
+++ b/test/wanda/operations/catalog/registry_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.Catalog.RegistryTest do
   use ExUnit.Case
 

--- a/test/wanda/operations/server_test.exs
+++ b/test/wanda/operations/server_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Operations.ServerTest do
   use Wanda.DataCase
 

--- a/test/wanda/operations_test.exs
+++ b/test/wanda/operations_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.OperationsTest do
   use ExUnit.Case
   use Wanda.DataCase

--- a/test/wanda/policy_test.exs
+++ b/test/wanda/policy_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.PolicyTest do
   use ExUnit.Case
 

--- a/test/wanda/support/abilities_helper_test.exs
+++ b/test/wanda/support/abilities_helper_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Support.AbilitiesHelperTest do
   use ExUnit.Case
 

--- a/test/wanda_web/auth/auth_plug_test.exs
+++ b/test/wanda_web/auth/auth_plug_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.AuthPlugTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/auth/client/auth_client_http_test.exs
+++ b/test/wanda_web/auth/client/auth_client_http_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.Client.HTTPClientTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney

--- a/test/wanda_web/auth/user_detector_test.exs
+++ b/test/wanda_web/auth/user_detector_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Auth.UserDetectorTest do
   use WandaWeb.ConnCase
 

--- a/test/wanda_web/controllers/error_json_test.exs
+++ b/test/wanda_web/controllers/error_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.ErrorJSONTest do
   use WandaWeb.ConnCase, async: true
   alias WandaWeb.ErrorJSON

--- a/test/wanda_web/controllers/fallback_controller_test.exs
+++ b/test/wanda_web/controllers/fallback_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.FallbackControllerTest do
   use WandaWeb.ConnCase
 

--- a/test/wanda_web/controllers/health_controller_test.exs
+++ b/test/wanda_web/controllers/health_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.HealthControllerTest do
   @moduledoc false
 

--- a/test/wanda_web/controllers/health_json_test.exs
+++ b/test/wanda_web/controllers/health_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.HealthJSONTest do
   use ExUnit.Case
 

--- a/test/wanda_web/controllers/info_controller_test.exs
+++ b/test/wanda_web/controllers/info_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.InfoControllerTest do
   @moduledoc false
 

--- a/test/wanda_web/controllers/v1/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v1/catalog_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.CatalogControllerTest do
   use WandaWeb.ConnCase, async: false
   use Wanda.Support.CatalogCase

--- a/test/wanda_web/controllers/v1/catalog_json_test.exs
+++ b/test/wanda_web/controllers/v1/catalog_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.CatalogJSONTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v1/checks_customization_controller_test.exs
+++ b/test/wanda_web/controllers/v1/checks_customization_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ChecksCustomizationsControllerTest do
   use WandaWeb.ConnCase, async: true
   use Wanda.Support.MessagingCase, async: true

--- a/test/wanda_web/controllers/v1/execution_controller_test.exs
+++ b/test/wanda_web/controllers/v1/execution_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ExecutionControllerTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v1/execution_json_test.exs
+++ b/test/wanda_web/controllers/v1/execution_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.ExecutionJSONTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v1/operation_controller_test.exs
+++ b/test/wanda_web/controllers/v1/operation_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.OperationControllerTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v1/operation_json_test.exs
+++ b/test/wanda_web/controllers/v1/operation_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V1.OperationJSONTest do
   use ExUnit.Case, async: true
 

--- a/test/wanda_web/controllers/v2/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v2/catalog_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.CatalogControllerTest do
   use WandaWeb.ConnCase, async: false
   use Wanda.Support.CatalogCase

--- a/test/wanda_web/controllers/v2/catalog_json_test.exs
+++ b/test/wanda_web/controllers/v2/catalog_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.CatalogJSONTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v2/execution_controller_test.exs
+++ b/test/wanda_web/controllers/v2/execution_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.ExecutionControllerTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v2/execution_json_test.exs
+++ b/test/wanda_web/controllers/v2/execution_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V2.ExecutionJSONTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/controllers/v3/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v3/catalog_controller_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V3.CatalogControllerTest do
   use WandaWeb.ConnCase, async: false
   use Wanda.Support.CatalogCase

--- a/test/wanda_web/controllers/v3/catalog_json_test.exs
+++ b/test/wanda_web/controllers/v3/catalog_json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.V3.CatalogJSONTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/plugs/api_redirector_test.exs
+++ b/test/wanda_web/plugs/api_redirector_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Plugs.ApiRedirectorTest do
   use WandaWeb.ConnCase, async: true
 

--- a/test/wanda_web/plugs/swaggerui_runtime_test.exs
+++ b/test/wanda_web/plugs/swaggerui_runtime_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Plugs.SwaggerUIRuntimeTest do
   use WandaWeb.ConnCase, async: false
 

--- a/test/wanda_web/schemas/api_spec_test.exs
+++ b/test/wanda_web/schemas/api_spec_test.exs
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule WandaWeb.Schemas.ApiSpecTest do
   use ExUnit.Case, async: false
 


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter, see #4236 