### PR TITLE
[TRNT-4376] Align DB dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ env:
   MIX_ENV: test
   ELIXIR_BC: "1.15.7-otp-26"
   ERLANG_BC: "26.2.1"
+  NODEJS_BC: "22.15.1"
+  OPENAPI_DIFF_VERSION: "2.1.7" # https://github.com/OpenAPITools/openapi-diff/releases
 
 jobs:
   setup-matrix-env:
@@ -241,7 +243,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 22.15.1
+          node-version: ${{ env.NODEJS_BC }}
       - name: Install API linting tools
         run: |
           npm install -g @redocly/cli@latest
@@ -328,7 +330,7 @@ jobs:
         run: mv /tmp/specs .
       - name: Find difference between OpenAPI specifications
         run: |
-          docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
+          docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:${{ env.OPENAPI_DIFF_VERSION }} \
             /specs/target-spec.json \
             /specs/current-spec.json \
             --fail-on-incompatible \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Continous Integration
+name: Continuous Integration
 
 on:
   push:
@@ -20,6 +20,8 @@ env:
   ELIXIR_BC: "1.15.7-otp-26"
   ERLANG_BC: "26.2.1"
   NODEJS_BC: "22.15.1"
+  POSTGRES_VERSION: "14" # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml
+  RABBITMQ_VERSION: "3.12.6-management-alpine" # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/charts/rabbitmq/values.yaml
   OPENAPI_DIFF_VERSION: "2.1.7" # https://github.com/OpenAPITools/openapi-diff/releases
 
 jobs:
@@ -105,7 +107,7 @@ jobs:
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     services:
       postgres:
-        image: postgres
+        image: registry.suse.com/suse/postgres:${{ env.POSTGRES_VERSION }}
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: wanda_test
@@ -118,10 +120,15 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       rabbitmq:
-        image: rabbitmq
+        image: rabbitmq:${{ env.RABBITMQ_VERSION }}
         env:
           RABBITMQ_DEFAULT_USER: wanda
           RABBITMQ_DEFAULT_PASS: wanda
+        options: >-
+          --health-cmd "rabbitmq-diagnostics ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 5674:5672
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ env:
   ELIXIR_BC: "1.15.7-otp-26"
   ERLANG_BC: "26.2.1"
   NODEJS_BC: "22.15.1"
-  POSTGRES_VERSION: "14" # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml
+  POSTGRES_VERSION: "17.5" # https://registry.suse.com/repositories/suse-postgres17?tag=17.5
   RABBITMQ_VERSION: "3.12.6-management-alpine" # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/charts/rabbitmq/values.yaml
   OPENAPI_DIFF_VERSION: "2.1.7" # https://github.com/OpenAPITools/openapi-diff/releases
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
       RUST_DEV: ${{ env.RUST_VERSION }}
       ELIXIR_BC: ${{ env.ELIXIR_BC }}
       ERLANG_BC: ${{ env.ERLANG_BC }}
+      POSTGRES_VERSION: ${{ env.POSTGRES_VERSION }}
+      RABBITMQ_VERSION: ${{ env.RABBITMQ_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -45,6 +47,8 @@ jobs:
           echo "RUST_DEV=${{ env.RUST_VERSION }}" >> $GITHUB_OUTPUT
           echo "ELIXIR_BC=${{ env.ELIXIR_BC }}" >> $GITHUB_OUTPUT
           echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
+          echo "POSTGRES_VERSION=${{ env.POSTGRES_VERSION }}" >> $GITHUB_OUTPUT
+          echo "RABBITMQ_VERSION=${{ env.RABBITMQ_VERSION }}" >> $GITHUB_OUTPUT
 
   elixir-deps:
     name: Elixir dependencies
@@ -107,7 +111,7 @@ jobs:
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     services:
       postgres:
-        image: registry.suse.com/suse/postgres:${{ env.POSTGRES_VERSION }}
+        image: registry.suse.com/suse/postgres:${{ needs.setup-matrix-env.outputs.POSTGRES_VERSION }}
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: wanda_test
@@ -120,7 +124,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       rabbitmq:
-        image: rabbitmq:${{ env.RABBITMQ_VERSION }}
+        image: rabbitmq:${{ needs.setup-matrix-env.outputs.RABBITMQ_VERSION }}
         env:
           RABBITMQ_DEFAULT_USER: wanda
           RABBITMQ_DEFAULT_PASS: wanda

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     # Keep versions in sync with
       # .github/workflows/ci.yaml
       # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/charts/rabbitmq/values.yaml
-    image: rabbitmq:3.12.6-management-alpine
+    image: rabbitmq:3.12.6-management-alpine # https://hub.docker.com/_/rabbitmq/tags
     ports:
       - 5676:5671
       - 5674:5672
@@ -22,7 +22,8 @@ services:
     # Keep versions in sync with
       # .github/workflows/ci.yaml
       # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml
-    image: registry.suse.com/suse/postgres:14
+      # https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#id-install-postgresql
+    image: registry.suse.com/suse/postgres:17.5 # https://registry.suse.com/repositories/suse-postgres17?tag=17.5
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
       - ./container_fixtures/rabbitmq/certs/server_rabbit.trento.local_key.pem:/var/lib/rabbitmq/server_rabbit.trento.local_key.pem
       - ./container_fixtures/rabbitmq/certs/server_rabbit.trento.local_certificate.pem:/var/lib/rabbitmq/server_rabbit.trento.local_certificate.pem
       - ./container_fixtures/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+    # Keep versions in sync with
+      # .github/workflows/ci.yaml
+      # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/charts/rabbitmq/values.yaml
     image: rabbitmq:3.12.6-management-alpine
     ports:
       - 5676:5671
@@ -16,7 +19,10 @@ services:
       RABBITMQ_DEFAULT_USER: wanda
       RABBITMQ_DEFAULT_PASS: wanda
   postgres:
-    image: postgres:15
+    # Keep versions in sync with
+      # .github/workflows/ci.yaml
+      # https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml
+    image: registry.suse.com/suse/postgres:14
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
# Description

I noticed some tests are failing ([example](https://github.com/trento-project/wanda/actions/runs/24457669610/job/71463254264)); this PR is to try to discover and fix the issue causing it.

This PR is aligning the versions we use in development and in CI to the ones we use in the Helm Chart (manually for now, though). Using `latest` was causing some issues in out test cases.

Besides, it extracts some additional versions to env dependencies, for maintainability. 

Fixes # TRNT-4376

## How was this tested?

CI

Before the fix, it fails ([example](https://github.com/trento-project/wanda/actions/runs/25674566418/job/75368842001?pr=712)); after the fix, it works ([example](https://github.com/trento-project/wanda/actions/runs/25675187863/job/75371143719?pr=712)).