### PR TITLE
Add x-ai-tool information to MCP tagged operations

### DIFF
--- a/lib/wanda_web/controllers/info_controller.ex
+++ b/lib/wanda_web/controllers/info_controller.ex
@@ -11,7 +11,7 @@ defmodule WandaWeb.InfoController do
     summary: "Wanda service information.",
     tags: ["Checks/Operations Platform"],
     description:
-      "This endpoint returns information about this Wanda instance for service discovery purposes, including name and version",
+      "This endpoint returns information about this Wanda instance for service discovery purposes, including name and version.",
     security: [],
     responses: [
       ok:

--- a/lib/wanda_web/controllers/v1/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v1/catalog_controller.ex
@@ -25,7 +25,7 @@ defmodule WandaWeb.V1.CatalogController do
     deprecated: true,
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
-    tags: ["Checks Engine", "MCP"],
+    tags: ["Checks Engine"],
     parameters: [
       env: [
         in: :query,
@@ -54,6 +54,10 @@ defmodule WandaWeb.V1.CatalogController do
     description:
       "Provides a list of selectable checks for a specified group and environment, enabling targeted execution.",
     tags: ["Checks Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "selectable_checks",
+      display_text: "Selectable Checks"
+    },
     parameters: [
       group_id: [
         in: :path,

--- a/lib/wanda_web/controllers/v1/execution_controller.ex
+++ b/lib/wanda_web/controllers/v1/execution_controller.ex
@@ -31,7 +31,7 @@ defmodule WandaWeb.V1.ExecutionController do
     deprecated: true,
     description:
       "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
-    tags: ["Checks Engine", "MCP"],
+    tags: ["Checks Engine"],
     parameters: [
       group_id: [
         in: :query,
@@ -73,7 +73,7 @@ defmodule WandaWeb.V1.ExecutionController do
     summary: "Get an execution by ID.",
     deprecated: true,
     description: "Provides detailed information about a specific execution identified by its ID.",
-    tags: ["Checks Engine", "MCP"],
+    tags: ["Checks Engine"],
     parameters: [
       id: [
         in: :path,
@@ -103,7 +103,7 @@ defmodule WandaWeb.V1.ExecutionController do
     summary: "Get the last execution of a group.",
     deprecated: true,
     description: "Provides details about the most recent execution for a specified group.",
-    tags: ["Checks Engine", "MCP"],
+    tags: ["Checks Engine"],
     parameters: [
       id: [
         in: :path,

--- a/lib/wanda_web/controllers/v1/operation_controller.ex
+++ b/lib/wanda_web/controllers/v1/operation_controller.ex
@@ -26,6 +26,10 @@ defmodule WandaWeb.V1.OperationController do
     description:
       "Provides a paginated list of operations performed in the system, allowing for easy tracking and management.",
     tags: ["Operations Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "operations_list",
+      display_text: "Operations List"
+    },
     parameters: [
       group_id: [
         in: :query,
@@ -78,6 +82,10 @@ defmodule WandaWeb.V1.OperationController do
     description:
       "Provides detailed information about a specific operation identified by its UUID.",
     tags: ["Operations Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "operations_details",
+      display_text: "Operation Details"
+    },
     parameters: [
       id: [
         in: :path,

--- a/lib/wanda_web/controllers/v2/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v2/catalog_controller.ex
@@ -18,7 +18,7 @@ defmodule WandaWeb.V2.CatalogController do
     deprecated: true,
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
-    tags: ["Checks Engine", "MCP"],
+    tags: ["Checks Engine"],
     parameters: [
       env: [
         in: :query,

--- a/lib/wanda_web/controllers/v2/execution_controller.ex
+++ b/lib/wanda_web/controllers/v2/execution_controller.ex
@@ -31,6 +31,10 @@ defmodule WandaWeb.V2.ExecutionController do
     description:
       "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
     tags: ["Checks Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "checks_executions_list",
+      display_text: "List Checks Executions"
+    },
     parameters: [
       group_id: [
         in: :query,
@@ -72,6 +76,10 @@ defmodule WandaWeb.V2.ExecutionController do
     summary: "Get an execution by ID.",
     description: "Provides detailed information about a specific execution identified by its ID.",
     tags: ["Checks Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "check_execution_details",
+      display_text: "Check Execution Details"
+    },
     parameters: [
       id: [
         in: :path,
@@ -101,6 +109,10 @@ defmodule WandaWeb.V2.ExecutionController do
     summary: "Get the last execution of a group.",
     description: "Provides details about the most recent execution for a specified group.",
     tags: ["Checks Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "last_check_execution",
+      display_text: "Last Check Execution"
+    },
     parameters: [
       id: [
         in: :path,

--- a/lib/wanda_web/controllers/v3/catalog_controller.ex
+++ b/lib/wanda_web/controllers/v3/catalog_controller.ex
@@ -18,6 +18,10 @@ defmodule WandaWeb.V3.CatalogController do
     description:
       "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
     tags: ["Checks Engine", "MCP"],
+    "x-ai-tool": %{
+      name: "catalog_list",
+      display_text: "Checks Catalog"
+    },
     parameters: [
       env: [
         in: :query,


### PR DESCRIPTION
# Description

This PR introduces an `x-ai-tool` [extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions) entry to relevant AI related operations (MCP tagged).

The idea is to be able to drive `tool name` and `display text` - and possibly more in the future - as we do in https://github.com/trento-project/web/pull/4330 so that we can better control AI integration.

As an extra I also untagged deprecated endpoints from being MCP. I couldn't find solid reasons to keep deprecated endpoint at use of AI agents.

AI feature-set is quite new and access to latest operations should be enough. Additionally it might mitigate the risk of hallucinations of LLMs as there would not be ambiguity.

Let me know what you think.

## How was this tested?

No specific tests needed here.