### PR TITLE
Add test release step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mix coveralls.github --warnings-as-errors --color --trace
 
+  target-branch-deps:
+    name: Target branch dependencies
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/deps.yaml
+    with:
+      checkout_ref: ${{ github.event.pull_request.base.ref }}
+
   test-release:
     name: Test release build (Elixir ${{ matrix.elixir }})
     needs: [setup-matrix-env, elixir-deps]
@@ -216,14 +223,6 @@ jobs:
           export DATABASE_URL=ecto://wanda_user:wanda_password@postgres-host/wanda
           export AUTH_SERVER_URL=http://localhost:4000
           _build/prod/rel/wanda/bin/wanda eval "IO.puts(:ok)"
-
-  base-branch-deps:
-    name: Base branch dependencies
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/deps.yaml
-    with:
-      checkout_ref: ${{ github.event.pull_request.base.ref }}
-
   api-docs-check:
     name: API docs check (Elixir ${{ matrix.elixir }})
     needs: [setup-matrix-env, elixir-deps]
@@ -274,7 +273,7 @@ jobs:
 
   api-bc-check:
     name: API bc check (${{ matrix.version }}, Elixir ${{ matrix.elixir }})
-    needs: [setup-matrix-env, elixir-deps, base-branch-deps]
+    needs: [setup-matrix-env, elixir-deps, target-branch-deps]
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,49 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mix coveralls.github --warnings-as-errors --color --trace
 
+  test-release:
+    name: Test release build (Elixir ${{ matrix.elixir }})
+    needs: [setup-matrix-env, elixir-deps]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+    env:
+      MIX_ENV: prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Setup
+        id: setup-elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+      - name: Retrieve Elixir Cached Dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build/${{ env.MIX_ENV }}
+            priv/plts
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+      - name: Build release
+        run: mix release
+      - name: Start release
+        run: |
+          export CORS_ORIGIN=localhost
+          export SECRET_KEY_BASE=OxpmZytAd3dCb8heWykxY02zDQaNeDINbYK0ZCYxVn/xd+Vawc3JFiOLv5kwVBfARp3OT8mWqal0F45AiNP2QA==
+          export AMQP_URL=amqp://trento_user:trento_user_password@rabbitmq-host/vhost
+          export DATABASE_URL=ecto://wanda_user:wanda_password@postgres-host/wanda
+          export AUTH_SERVER_URL=http://localhost:4000
+          _build/prod/rel/wanda/bin/wanda eval "IO.puts(:ok)"
   main-branch-deps:
     name: main branch dependencies
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,9 +89,9 @@ jobs:
         with:
           path: |
             deps
-            _build/test
+            _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Check for Unused Dependencies
         run: mix deps.unlock --check-unused
       - name: Check Code Format
@@ -161,9 +161,9 @@ jobs:
         with:
           path: |
             deps
-            _build/test
+            _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Compile
         run: mix compile --warnings-as-errors
       - name: Create and migrate database
@@ -205,7 +205,7 @@ jobs:
             deps
             _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Build release
         run: mix release
       - name: Start release
@@ -216,54 +216,13 @@ jobs:
           export DATABASE_URL=ecto://wanda_user:wanda_password@postgres-host/wanda
           export AUTH_SERVER_URL=http://localhost:4000
           _build/prod/rel/wanda/bin/wanda eval "IO.puts(:ok)"
-  main-branch-deps:
-    name: main branch dependencies
+
+  base-branch-deps:
+    name: Base branch dependencies
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/deps.yaml
     with:
-      checkout_ref: main
-
-  target-branch-deps:
-    name: Rebuild target branch dependencies (Elixir ${{ matrix.elixir }})
-    needs: [setup-matrix-env]
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout target branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Set up Elixir
-        id: setup-elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
-      - name: Retrieve Elixir Cached Dependencies - target branch
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: mix-cache-target
-        with:
-          path: |
-            deps
-            _build/${{ env.MIX_ENV }}
-            priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
-      - name: Install missing dependencies
-        if: steps.mix-cache-target.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p priv/plts
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-          mix deps.compile --warnings-as-errors
-          mix dialyzer --plt
+      checkout_ref: ${{ github.event.pull_request.base.ref }}
 
   api-docs-check:
     name: API docs check (Elixir ${{ matrix.elixir }})
@@ -300,7 +259,7 @@ jobs:
             deps
             _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -315,7 +274,7 @@ jobs:
 
   api-bc-check:
     name: API bc check (${{ matrix.version }}, Elixir ${{ matrix.elixir }})
-    needs: [setup-matrix-env, elixir-deps, target-branch-deps]
+    needs: [setup-matrix-env, elixir-deps, base-branch-deps]
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:
@@ -367,7 +326,7 @@ jobs:
             deps
             _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Generate current openapi.json
         run: |
           mix openapi.spec.json --start-app=false --spec WandaWeb.Schemas.${{ matrix.version }}.ApiSpec /tmp/specs/current-spec.json
@@ -383,7 +342,7 @@ jobs:
             deps
             _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Generate target openapi.json
         run: |
           mix openapi.spec.json --start-app=false --spec WandaWeb.Schemas.${{ matrix.version }}.ApiSpec /tmp/specs/target-spec.json
@@ -461,9 +420,9 @@ jobs:
         with:
           path: |
             deps
-            _build/test
+            _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}-elixir-${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}-elixir-${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Build docs
         uses: lee-dohm/generate-elixir-docs@a745603eef443621976df401f45aaff4d849056b # v1
       - name: Generate openapi.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,7 +195,7 @@ jobs:
       MIX_ENV: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - name: Setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,6 +179,7 @@ jobs:
     uses: ./.github/workflows/deps.yaml
     with:
       checkout_ref: ${{ github.event.pull_request.base.ref }}
+      mix_envs: '["test"]'
 
   test-release:
     name: Test release build (Elixir ${{ matrix.elixir }})

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -46,12 +46,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mix_env: dev
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - mix_env: dev
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - mix_env: test
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -40,17 +40,32 @@ jobs:
           echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
 
   elixir-deps:
-    name: Elixir dependencies (Elixir ${{ matrix.elixir }})
+    name: Elixir ${{ matrix.mix_env }} dependencies (Elixir ${{ matrix.elixir }})
     runs-on: ubuntu-24.04
     needs: [setup-matrix-env]
     strategy:
       matrix:
         include:
-          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+          - mix_env: dev
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - mix_env: dev
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+          - mix_env: test
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - mix_env: test
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+          - mix_env: prod
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - mix_env: prod
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
+      MIX_ENV: ${{ matrix.mix_env }}
       RHAI_RUSTLER_FORCE_BUILD: "true"
     steps:
       - name: Cancel Previous Runs
@@ -82,9 +97,9 @@ jobs:
         with:
           path: |
             deps
-            _build/test
+            _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}
+          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Install Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |
@@ -93,4 +108,6 @@ jobs:
           mix local.hex --force
           mix deps.get
           mix deps.compile --warnings-as-errors
-          mix dialyzer --plt
+      - name: Build Dialyzer PLT
+        if: steps.mix-cache.outputs.cache-hit != 'true' && matrix.mix_env != 'prod'
+        run: mix dialyzer --plt

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ${{ github.ref }}
+      mix_envs:
+        required: false
+        type: string
+        default: '["test","prod"]'
 
 env:
   ELIXIR_BC: "1.15.7-otp-26"
@@ -40,23 +44,16 @@ jobs:
           echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
 
   elixir-deps:
-    name: Elixir ${{ matrix.mix_env }} dependencies (Elixir ${{ matrix.elixir }})
+    name: Elixir ${{ matrix.mix_env }} dependencies (Elixir ${{ matrix.versions.elixir }})
     runs-on: ubuntu-24.04
     needs: [setup-matrix-env]
     strategy:
       matrix:
-        include:
-          - mix_env: test
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+        mix_env: ${{ fromJSON(inputs.mix_envs) }}
+        versions:
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - mix_env: test
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
-          - mix_env: prod
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
-            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - mix_env: prod
-            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: ${{ matrix.mix_env }}
@@ -74,8 +71,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.versions.otp }}
+          elixir-version: ${{ matrix.versions.elixir }}
       - name: Read .tool-versions
         uses: endorama/asdf-parse-tool-versions@e60863920ff5af9bf1c794ffbaaef91384b07eed # v1.6.0
         id: tool-versions
@@ -93,7 +90,7 @@ jobs:
             deps
             _build/${{ env.MIX_ENV }}
             priv/plts
-          key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
+          key: erlang-${{ matrix.versions.otp }}-elixir-${{ matrix.versions.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Install Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
### Description

This PR brings to wanda the same step [we have in web](https://github.com/trento-project/web/blob/main/.github/workflows/ci.yaml#L457-L517).
It's a smoke test of the runtime initiation of the to-be-released artifact.

Additionally streamlines cache key usages.

### How was this tested?

✅ CI https://github.com/trento-project/wanda/actions/runs/28181935537