### PR TITLE
handle exclude predicate

### DIFF
--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -256,6 +256,7 @@ defmodule Wanda.Catalog do
        remediation: remediation,
        metadata: Map.get(check, "metadata"),
        when: Map.get(check, "when"),
+       exclude: Map.get(check, "exclude"),
        severity: map_severity(check),
        facts: Enum.map(facts, &map_fact/1),
        values: mapped_values,

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -23,6 +23,7 @@ defmodule Wanda.Catalog.Check do
     :values,
     :expectations,
     :when,
+    :exclude,
     :customization_disabled
   ]
 
@@ -38,6 +39,7 @@ defmodule Wanda.Catalog.Check do
           facts: [Fact.t()],
           values: [Value.t()],
           expectations: [Expectation.t()],
-          when: String.t()
+          when: String.t(),
+          exclude: String.t() | nil
         }
 end

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -16,13 +16,19 @@ defmodule Wanda.Executions.AgentCheckResult do
   @derive Jason.Encoder
   defstruct [
     :agent_id,
+    :status,
+    :exclude_expression,
     values: [],
     facts: [],
     expectation_evaluations: []
   ]
 
+  @type status :: :excluded_by_policy | nil
+
   @type t :: %__MODULE__{
           agent_id: String.t(),
+          status: status(),
+          exclude_expression: String.t() | nil,
           facts: [Fact.t()],
           values: [Value.t()],
           expectation_evaluations: [ExpectationEvaluation.t() | ExpectationEvaluationError.t()]

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -435,6 +435,10 @@ defmodule Wanda.Executions.Evaluation do
         _ -> false
       end)
 
+  defp aggregate_execution_result(%Result{check_results: []} = execution) do
+    %Result{execution | result: ResultEnum.passing()}
+  end
+
   defp aggregate_execution_result(%Result{check_results: check_results} = execution) do
     result =
       check_results

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -1,0 +1,15 @@
+defmodule Wanda.Executions.ExcludedCheckResult do
+  @moduledoc """
+  Represents a (check, agent) pair excluded by the check's `exclude` predicate.
+  """
+
+  @derive Jason.Encoder
+  defstruct [:check_id, :agent_id, :status, :exclude_expression]
+
+  @type t :: %__MODULE__{
+          check_id: String.t(),
+          agent_id: String.t(),
+          status: :excluded_by_policy,
+          exclude_expression: String.t() | nil
+        }
+end

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -6,7 +6,7 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
-  alias Wanda.Executions.CheckResult
+  alias Wanda.Executions.{CheckResult, ExcludedCheckResult}
 
   require Wanda.Executions.Enums.Result, as: ResultEnum
 
@@ -16,6 +16,7 @@ defmodule Wanda.Executions.Result do
     :group_id,
     :result,
     check_results: [],
+    excluded_checks: [],
     timeout: []
   ]
 
@@ -23,6 +24,7 @@ defmodule Wanda.Executions.Result do
           execution_id: String.t(),
           group_id: String.t(),
           check_results: [CheckResult.t()],
+          excluded_checks: [ExcludedCheckResult.t()],
           timeout: [String.t()],
           result: ResultEnum.t()
         }

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -11,10 +11,13 @@ defmodule Wanda.Executions.Server do
 
   use GenServer, restart: :transient
 
-  alias Wanda.Catalog.SelectedCheck
+  alias Wanda.Catalog.{Check, SelectedCheck}
 
   alias Wanda.Executions.{
+    AgentCheckResult,
+    CheckResult,
     Evaluation,
+    ExcludedCheckResult,
     Gathering,
     Result,
     State,
@@ -33,6 +36,7 @@ defmodule Wanda.Executions.Server do
   alias Wanda.Executions.Messaging.Publisher
 
   require Logger
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_target_type "cluster"
   @default_timeout 5 * 60 * 1_000
@@ -101,26 +105,71 @@ defmodule Wanda.Executions.Server do
           group_id: group_id,
           targets: targets,
           checks: checks,
+          env: env,
           timeout: timeout
         } = state
       ) do
     engine = EvaluationEngine.new()
 
+    {active_targets, excluded_checks} = evaluate_exclusions(targets, checks, engine)
+
     specs = SelectedCheck.extract_specs(checks)
 
-    facts_gathering_requested =
-      Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, targets, specs)
-
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
-
     Executions.create_execution!(execution_id, group_id, targets)
-
     :ok = Messaging.publish(Publisher, "results", execution_started)
-    :ok = Messaging.publish(Publisher, "agents", facts_gathering_requested)
 
-    Process.send_after(self(), :timeout, timeout)
+    if active_targets == [] do
+      # Even with no active targets, we still need to surface the excluded
+      # hosts in each check's `agents_check_results` so the UI can list them.
+      checks_with_excluded =
+        excluded_checks
+        |> Enum.group_by(& &1.check_id)
+        |> Map.new(fn {check_id, entries} ->
+          {check_id,
+           Enum.map(entries, fn %ExcludedCheckResult{agent_id: agent_id} = e ->
+             %AgentCheckResult{
+               agent_id: agent_id,
+               status: :excluded_by_policy,
+               exclude_expression: e.exclude_expression
+             }
+           end)}
+        end)
 
-    {:noreply, %State{state | engine: engine}}
+      check_results =
+        checks
+        |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}} = sc ->
+          %CheckResult{
+            check_id: id,
+            customized: sc.customized,
+            agents_check_results: Map.get(checks_with_excluded, id, []),
+            expectation_results: [],
+            result: ResultEnum.passing()
+          }
+        end)
+
+      result = %Result{
+        execution_id: execution_id,
+        group_id: group_id,
+        check_results: check_results,
+        excluded_checks: [],
+        timeout: [],
+        result: ResultEnum.passing()
+      }
+
+      store_and_publish_execution_result(result, env)
+      {:stop, :normal, state}
+    else
+      facts_gathering_requested =
+        Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, active_targets, specs)
+
+      :ok = Messaging.publish(Publisher, "agents", facts_gathering_requested)
+
+      Process.send_after(self(), :timeout, timeout)
+
+      {:noreply,
+       %State{state | engine: engine, targets: active_targets, excluded_checks: excluded_checks}}
+    end
   end
 
   @impl true
@@ -161,7 +210,8 @@ defmodule Wanda.Executions.Server do
           targets: targets,
           checks: checks,
           env: env,
-          agents_gathered: agents_gathered
+          agents_gathered: agents_gathered,
+          excluded_checks: excluded_checks
         } = state
       ) do
     targets =
@@ -174,15 +224,10 @@ defmodule Wanda.Executions.Server do
     gathered_facts = Gathering.put_gathering_timeouts(gathered_facts, targets)
 
     result =
-      Evaluation.execute(
-        execution_id,
-        group_id,
-        checks,
-        gathered_facts,
-        env,
-        timedout_agents,
-        engine
-      )
+      execution_id
+      |> Evaluation.execute(group_id, checks, gathered_facts, env, timedout_agents, engine)
+      |> inject_excluded_checks(excluded_checks)
+      |> Map.put(:excluded_checks, [])
 
     store_and_publish_execution_result(result, env)
 
@@ -198,7 +243,8 @@ defmodule Wanda.Executions.Server do
            targets: targets,
            checks: checks,
            env: env,
-           agents_gathered: agents_gathered
+           agents_gathered: agents_gathered,
+           excluded_checks: excluded_checks
          } = state,
          agent_id,
          facts
@@ -209,7 +255,11 @@ defmodule Wanda.Executions.Server do
     state = %State{state | gathered_facts: gathered_facts, agents_gathered: agents_gathered}
 
     if Gathering.all_agents_sent_facts?(agents_gathered, targets) do
-      result = Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, engine)
+      result =
+        execution_id
+        |> Evaluation.execute(group_id, checks, gathered_facts, env, engine)
+        |> inject_excluded_checks(excluded_checks)
+        |> Map.put(:excluded_checks, [])
 
       store_and_publish_execution_result(result, env)
 
@@ -228,8 +278,133 @@ defmodule Wanda.Executions.Server do
     :ok = Messaging.publish(Publisher, "results", execution_completed)
   end
 
+  defp evaluate_exclusions(targets, checks, engine) do
+    {active_targets_rev, excluded} =
+      Enum.reduce(targets, {[], []}, fn target, {active_acc, excluded_acc} ->
+        {active_check_ids_rev, excluded_for_target} =
+          Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
+            case Enum.find(checks, &(&1.id == check_id)) do
+              nil ->
+                {[check_id | keep], excl}
+
+              selected_check ->
+                case evaluate_exclude_predicate(selected_check, target, engine) do
+                  :excluded -> {keep, [check_id | excl]}
+                  :keep -> {[check_id | keep], excl}
+                end
+            end
+          end)
+
+        newly_excluded =
+          Enum.map(excluded_for_target, fn check_id ->
+            exclude_expr = find_exclude_expression(checks, check_id)
+
+            %ExcludedCheckResult{
+              check_id: check_id,
+              agent_id: target.agent_id,
+              status: :excluded_by_policy,
+              exclude_expression: exclude_expr
+            }
+          end)
+
+        active_target = %Target{target | checks: Enum.reverse(active_check_ids_rev)}
+        {[active_target | active_acc], newly_excluded ++ excluded_acc}
+      end)
+
+    filtered_targets =
+      active_targets_rev
+      |> Enum.reverse()
+      |> Enum.filter(fn %Target{checks: checks} -> checks != [] end)
+
+    {filtered_targets, excluded}
+  end
+
+  defp find_exclude_expression(checks, check_id) do
+    case Enum.find(checks, &(&1.id == check_id)) do
+      %SelectedCheck{spec: %Check{exclude: expr}} -> expr
+      _ -> nil
+    end
+  end
+
+  defp evaluate_exclude_predicate(
+         %SelectedCheck{spec: %Check{exclude: nil}},
+         _target,
+         _engine
+       ),
+       do: :keep
+
+  defp evaluate_exclude_predicate(
+         %SelectedCheck{spec: %Check{id: check_id, exclude: exclude_expr}},
+         %Target{agent_id: agent_id, host_data: host_data},
+         engine
+       ) do
+    case EvaluationEngine.eval(engine, exclude_expr, %{"host" => host_data}) do
+      {:ok, true} ->
+        :excluded
+
+      {:ok, false} ->
+        :keep
+
+      {:ok, other} ->
+        Logger.warning(
+          "Check #{check_id} exclude predicate for agent #{agent_id} returned non-boolean " <>
+            "#{inspect(other)}, keeping pair"
+        )
+
+        :keep
+
+      {:error, reason} ->
+        Logger.warning(
+          "Check #{check_id} exclude predicate for agent #{agent_id} raised error " <>
+            "#{inspect(reason)}, keeping pair"
+        )
+
+        :keep
+    end
+  end
+
   defp via_tuple(group_id),
     do: {:via, :global, {__MODULE__, group_id}}
+
+  # Injects the excluded (check, agent) pairs into the corresponding check's
+  # `agents_check_results` list, so the excluded host appears inline with the
+  # other agent results rather than being silently dropped.
+  defp inject_excluded_checks(%Result{check_results: _check_results} = result, []),
+    do: result
+
+  defp inject_excluded_checks(%Result{check_results: check_results} = result, excluded) do
+    excluded_by_check =
+      excluded
+      |> Enum.group_by(& &1.check_id)
+
+    new_check_results =
+      Enum.map(check_results, fn %CheckResult{check_id: check_id} = check_result ->
+        case Map.get(excluded_by_check, check_id) do
+          nil ->
+            check_result
+
+          entries ->
+            excluded_agents =
+              Enum.map(entries, fn %ExcludedCheckResult{
+                                         agent_id: agent_id,
+                                         exclude_expression: exclude_expression
+                                       } ->
+                %AgentCheckResult{
+                  agent_id: agent_id,
+                  status: :excluded_by_policy,
+                  exclude_expression: exclude_expression
+                }
+              end)
+
+            %CheckResult{
+              check_result
+              | agents_check_results: check_result.agents_check_results ++ excluded_agents
+            }
+        end
+      end)
+
+    %Result{result | check_results: new_check_results}
+  end
 
   defp maybe_start_execution(_, _, _, [], _, _), do: {:error, :no_checks_selected}
 

--- a/lib/wanda/executions/state.ex
+++ b/lib/wanda/executions/state.ex
@@ -7,7 +7,7 @@ defmodule Wanda.Executions.State do
   """
 
   alias Wanda.Catalog.SelectedCheck
-  alias Wanda.Executions.Target
+  alias Wanda.Executions.{ExcludedCheckResult, Target}
 
   defstruct [
     :engine,
@@ -18,7 +18,8 @@ defmodule Wanda.Executions.State do
     checks: [],
     env: %{},
     gathered_facts: %{},
-    agents_gathered: []
+    agents_gathered: [],
+    excluded_checks: []
   ]
 
   @type t :: %__MODULE__{
@@ -30,6 +31,7 @@ defmodule Wanda.Executions.State do
           checks: [SelectedCheck.t()],
           env: %{String.t() => boolean() | number() | String.t()},
           gathered_facts: map(),
-          agents_gathered: [String.t()]
+          agents_gathered: [String.t()],
+          excluded_checks: [ExcludedCheckResult.t()]
         }
 end

--- a/lib/wanda/executions/target.ex
+++ b/lib/wanda/executions/target.ex
@@ -8,12 +8,14 @@ defmodule Wanda.Executions.Target do
 
   defstruct [
     :agent_id,
-    checks: []
+    checks: [],
+    host_data: %{}
   ]
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          checks: [String.t()]
+          checks: [String.t()],
+          host_data: %{String.t() => term()}
         }
 
   @spec get_checks_from_targets([t()]) :: [String.t()]
@@ -26,8 +28,12 @@ defmodule Wanda.Executions.Target do
   def map_targets(map_list) do
     map_list
     |> Enum.uniq_by(& &1.agent_id)
-    |> Enum.map(fn %{agent_id: agent_id, checks: checks} ->
-      %__MODULE__{agent_id: agent_id, checks: checks}
+    |> Enum.map(fn %{agent_id: agent_id, checks: checks} = item ->
+      %__MODULE__{
+        agent_id: agent_id,
+        checks: checks,
+        host_data: Map.get(item, :host_data, %{})
+      }
     end)
   end
 end

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -97,10 +97,20 @@ defmodule Wanda.Messaging.Mapper do
         target_type: target_type,
         env: env
       }) do
+    plain_targets =
+      Enum.map(targets, fn %{agent_id: agent_id, checks: checks} = item ->
+        host_data =
+          item
+          |> Map.get(:host_data, %{})
+          |> Map.new(fn {k, v} -> {k, unwrap_proto_value(v)} end)
+
+        %{agent_id: agent_id, checks: checks, host_data: host_data}
+      end)
+
     %{
       execution_id: execution_id,
       group_id: group_id,
-      targets: Target.map_targets(targets),
+      targets: Target.map_targets(plain_targets),
       target_type: target_type,
       env: from_value(env)
     }
@@ -416,4 +426,20 @@ defmodule Wanda.Messaging.Mapper do
   defp from_value(map) when is_map(map) do
     Enum.into(map, %{}, fn {key, value} -> {key, from_value(value)} end)
   end
+
+  defp unwrap_proto_value(%{kind: {:string_value, s}}), do: s
+
+  defp unwrap_proto_value(%{kind: {:bool_value, b}}), do: b
+
+  defp unwrap_proto_value(%{kind: {:number_value, n}}), do: n
+
+  defp unwrap_proto_value(%{kind: {:null_value, _}}), do: nil
+
+  defp unwrap_proto_value(%{kind: {:list_value, %{values: vals}}}),
+    do: Enum.map(vals, &unwrap_proto_value/1)
+
+  defp unwrap_proto_value(%{kind: {:struct_value, %{fields: fields}}}),
+    do: Map.new(fields, fn {k, v} -> {k, unwrap_proto_value(v)} end)
+
+  defp unwrap_proto_value(_), do: ""
 end

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -50,6 +50,19 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
           },
           description:
             "Result of the single expectation evaluation, indicating whether the expectation was met for the agent's check."
+        },
+        status: %Schema{
+          type: :string,
+          nullable: true,
+          enum: [nil, "excluded_by_policy"],
+          description:
+            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+        },
+        exclude_expression: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
         }
       },
       required: [:agent_id, :facts, :expectation_evaluations],

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -52,6 +52,19 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
           },
           description:
             "An array containing the results of each expectation evaluation performed for the agent during the check execution."
+        },
+        status: %Schema{
+          type: :string,
+          nullable: true,
+          enum: [nil, "excluded_by_policy"],
+          description:
+            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+        },
+        exclude_expression: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
         }
       },
       required: [:agent_id, :facts, :expectation_evaluations],

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Wanda.MixProject do
       {:trento_contracts,
        github: "trento-project/contracts",
        sparse: "elixir",
-       ref: "69a5241e3065ebf91af02acd7d3c9c00d01407c7"},
+       ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"},
       {:unplug, "~> 1.1.0"},
       # test deps
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -66,7 +66,7 @@
   "telemetry_poller": {:hex, :telemetry_poller, "1.3.0", "d5c46420126b5ac2d72bc6580fb4f537d35e851cc0f8dbd571acf6d6e10f5ec7", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "51f18bed7128544a50f75897db9974436ea9bfba560420b646af27a9a9b35211"},
   "thoas": {:hex, :thoas, "1.2.1", "19a25f31177a17e74004d4840f66d791d4298c5738790fa2cc73731eb911f195", [:rebar3], [], "hexpm", "e38697edffd6e91bd12cea41b155115282630075c2a727e7a6b2947f5408b86a"},
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "69a5241e3065ebf91af02acd7d3c9c00d01407c7", [sparse: "elixir", ref: "69a5241e3065ebf91af02acd7d3c9c00d01407c7"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "2d0c53202ad364964ea4965445e10ebeeaa70da0", [sparse: "elixir", ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"]},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
   "unplug": {:hex, :unplug, "1.1.0", "acd8c40dfda63a831b01534307c8cc44726389429294a5ed44d7f89fb01ccd02", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "a3b302125ed60b658a9a7c0dff6941050bfc56dc77a0bca72facdb743159898f"},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},

--- a/test/fixtures/catalog/exclude_check.yaml
+++ b/test/fixtures/catalog/exclude_check.yaml
@@ -1,0 +1,16 @@
+id: exclude_check
+name: Exclude test check
+group: Test
+description: |
+  A check with an exclude predicate
+remediation: |
+  ## Remediation
+  Remediation text
+exclude: host["provider"] == "aws"
+facts:
+  - name: jedi
+    gatherer: wandalorian
+    argument: -o
+expectations:
+  - name: some_expectation
+    expect: facts.jedi == true

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule Wanda.Factory do
     AgentCheckResult,
     CheckResult,
     Execution,
+    ExcludedCheckResult,
     ExpectationEvaluation,
     ExpectationEvaluationError,
     ExpectationResult,
@@ -62,6 +63,7 @@ defmodule Wanda.Factory do
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
       when: Faker.Lorem.sentence(),
+      exclude: nil,
       customization_disabled: Enum.random([false, true])
     }
   end
@@ -103,7 +105,8 @@ defmodule Wanda.Factory do
   def target_factory do
     %Target{
       agent_id: UUID.uuid4(),
-      checks: random_checks()
+      checks: random_checks(),
+      host_data: %{}
     }
   end
 

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -317,4 +317,317 @@ defmodule Wanda.Executions.ServerTest do
       assert actual_targets == expected_targets
     end
   end
+
+  describe "exclusion predicates" do
+    test "check without exclude field keeps all targets" do
+      group_id = UUID.uuid4()
+
+      targets = [
+        build(:target, checks: ["expect_check"], host_data: %{"provider" => "aws"}),
+        build(:target, checks: ["expect_check"], host_data: %{"provider" => "azure"})
+      ]
+
+      assert :ok =
+               Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
+
+      pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(pid)
+
+      assert length(active_targets) == 2
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    test "check with exclude returning true removes target from gathering" do
+      pid = self()
+      group_id = UUID.uuid4()
+      execution_id = UUID.uuid4()
+
+      # exclude_check has `exclude: host["provider"] == "aws"`
+      aws_agent = UUID.uuid4()
+      azure_agent = UUID.uuid4()
+
+      targets = [
+        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "aws"}),
+        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "azure"})
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn
+        Publisher, "agents", %FactsGatheringRequested{targets: gathering_targets}, _ ->
+          send(pid, {:gathering_targets, gathering_targets})
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      assert :ok = Server.start_execution(execution_id, group_id, targets, "cluster", %{})
+
+      assert_receive {:gathering_targets, gathering_targets}
+
+      # Only azure agent should receive gathering request
+      assert [%{agent_id: ^azure_agent}] = gathering_targets
+
+      stop_supervised(Server)
+    end
+
+    test "excluded pairs are recorded with excluded_by_policy status" do
+      pid = self()
+      group_id = UUID.uuid4()
+
+      aws_agent = UUID.uuid4()
+      azure_agent = UUID.uuid4()
+
+      targets = [
+        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "aws"}),
+        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "azure"})
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      assert :ok = Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
+
+      # Wait for handle_continue to run
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      assert [
+               %Wanda.Executions.ExcludedCheckResult{
+                 check_id: "exclude_check",
+                 agent_id: ^aws_agent,
+                 status: :excluded_by_policy
+               }
+             ] = excluded
+
+      stop_supervised(Server)
+    end
+
+    test "all targets excluded completes execution immediately with excluded_by_policy entries" do
+      pid = self()
+      group_id = UUID.uuid4()
+      execution_id = UUID.uuid4()
+
+      targets = [
+        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"}),
+        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"})
+      ]
+
+      # Expect execution_started + execution_completed (no agents gathering)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "results", %ExecutionCompleted{}, _ ->
+          send(pid, :completed)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      assert :ok = Server.start_execution(execution_id, group_id, targets, "cluster", %{})
+      assert_receive :completed, 500
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               status: :completed,
+               result: %{
+                 "check_results" => [
+                   %{
+                     "check_id" => "exclude_check",
+                     "agents_check_results" => [
+                       %{"agent_id" => _, "status" => "excluded_by_policy"},
+                       %{"agent_id" => _, "status" => "excluded_by_policy"}
+                     ]
+                   }
+                 ]
+               }
+             } = Repo.one!(Execution)
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate returning non-boolean keeps the pair and logs warning" do
+      group_id = UUID.uuid4()
+
+      # Build a check with an exclude expression that returns a non-boolean
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "42"
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      targets = [build(:target, checks: [spec.id], host_data: %{"provider" => "aws"})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      # Pair is kept when predicate returns non-boolean
+      assert length(active_targets) == 1
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate with syntax error keeps the pair and logs warning" do
+      group_id = UUID.uuid4()
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "this is not valid rhai !!!"
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      targets = [build(:target, checks: [spec.id], host_data: %{})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      assert length(active_targets) == 1
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate on empty host_data keeps the pair (backwards compatibility)" do
+      group_id = UUID.uuid4()
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "host[\"provider\"] == \"aws\""
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      # empty host_data simulates old web version with no host_data
+      targets = [build(:target, checks: [spec.id], host_data: %{})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets} = :sys.get_state(server_pid)
+
+      assert length(active_targets) == 1
+
+      stop_supervised(Server)
+    end
+
+    test "regression: execution without exclude fields behaves identically to current behaviour",
+         context do
+      pid = self()
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      env = build(:env)
+
+      targets = build_list(3, :target, %{checks: [context[:check].id]})
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 3, fn
+        Publisher, "results", _, _ ->
+          send(pid, :executed)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      {:ok, server_pid} =
+        start_supervised(
+          {Server,
+           [
+             execution_id: execution_id,
+             group_id: group_id,
+             targets: targets,
+             checks: [context[:check]],
+             env: env
+           ]}
+        )
+
+      ref = Process.monitor(server_pid)
+
+      Enum.each(targets, fn target ->
+        Server.receive_facts(
+          execution_id,
+          group_id,
+          target.agent_id,
+          build_list(1, :fact, check_id: context[:check].id)
+        )
+      end)
+
+      assert_receive :executed
+      assert_receive {:DOWN, ^ref, _, ^server_pid, :normal}
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               status: :completed,
+               result: %{"excluded_checks" => []}
+             } = Repo.one!(Execution)
+    end
+  end
 end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -693,4 +693,142 @@ defmodule Wanda.Messaging.MapperTest do
              } = Mapper.to_check_customization_reset(check_id, group_id, target_type)
     end
   end
+
+  describe "host_data unwrapping in from_execution_requested" do
+    test "unwraps string proto value to plain string" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{"provider" => %{kind: {:string_value, "aws"}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   agent_id: "agent_1",
+                   host_data: %{"provider" => "aws"}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps list proto value to list of plain strings" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{
+              "roles" => %{
+                kind:
+                  {:list_value,
+                   %{
+                     values: [
+                       %{kind: {:string_value, "primary"}},
+                       %{kind: {:string_value, "secondary"}}
+                     ]
+                   }}
+              }
+            }
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{"roles" => ["primary", "secondary"]}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps unknown proto value kind to empty string" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{"unknown" => %{kind: {:null_value, :NULL_VALUE}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{"unknown" => ""}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "maps empty host_data to empty map (backwards compatibility)" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"]
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{host_data: %{}}
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps multiple host_data fields in a single target" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{
+              "provider" => %{kind: {:string_value, "azure"}},
+              "os_family" => %{kind: {:string_value, "suse"}},
+              "arch" => %{kind: {:string_value, "x86_64"}},
+              "roles" => %{
+                kind: {:list_value, %{values: [%{kind: {:string_value, "primary"}}]}}
+              }
+            }
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{
+                     "provider" => "azure",
+                     "os_family" => "suse",
+                     "arch" => "x86_64",
+                     "roles" => ["primary"]
+                   }
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+  end
 end


### PR DESCRIPTION
Implement the RFC https://github.com/trento-project/docs/pull/188

Introduce an exclude predicate field in the check specification, a Rhai expression evaluated at execution start against each target's host data (host.is_majority_maker, etc.). If the predicate evaluates to true, that (check, agent) pair is excluded from execution.

Excluded hosts are reported in the check result

Depends on https://github.com/trento-project/contracts/pull/152