### PR TITLE
Handle check exclude predicate 

### DIFF
--- a/demo/fake_server.ex
+++ b/demo/fake_server.ex
@@ -57,6 +57,7 @@ defmodule Wanda.Executions.FakeServer do
         selected_checks,
         gathered_facts,
         env,
+        [],
         EvaluationEngine.new()
       )
 

--- a/lib/wanda/catalog.ex
+++ b/lib/wanda/catalog.ex
@@ -256,6 +256,7 @@ defmodule Wanda.Catalog do
        remediation: remediation,
        metadata: Map.get(check, "metadata"),
        when: Map.get(check, "when"),
+       exclude: Map.get(check, "exclude"),
        severity: map_severity(check),
        facts: Enum.map(facts, &map_fact/1),
        values: mapped_values,

--- a/lib/wanda/catalog/check.ex
+++ b/lib/wanda/catalog/check.ex
@@ -23,6 +23,7 @@ defmodule Wanda.Catalog.Check do
     :values,
     :expectations,
     :when,
+    :exclude,
     :customization_disabled
   ]
 
@@ -38,6 +39,7 @@ defmodule Wanda.Catalog.Check do
           facts: [Fact.t()],
           values: [Value.t()],
           expectations: [Expectation.t()],
-          when: String.t()
+          when: String.t(),
+          exclude: String.t() | nil
         }
 end

--- a/lib/wanda/evaluation_engine.ex
+++ b/lib/wanda/evaluation_engine.ex
@@ -14,7 +14,6 @@ defmodule Wanda.EvaluationEngine do
     engine = Engine.new()
 
     Engine.set_fail_on_invalid_map_property(engine, true)
-    # TODO: set map size, array size, string size limits
   end
 
   def eval(%Engine{} = engine, expression, %{} = scope) do

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -16,13 +16,19 @@ defmodule Wanda.Executions.AgentCheckResult do
   @derive Jason.Encoder
   defstruct [
     :agent_id,
+    :status,
+    :exclude_expression,
     values: [],
     facts: [],
     expectation_evaluations: []
   ]
 
+  @type status :: :excluded_by_policy | nil
+
   @type t :: %__MODULE__{
           agent_id: String.t(),
+          status: status(),
+          exclude_expression: String.t() | nil,
           facts: [Fact.t()],
           values: [Value.t()],
           expectation_evaluations: [ExpectationEvaluation.t() | ExpectationEvaluationError.t()]

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -16,14 +16,14 @@ defmodule Wanda.Executions.AgentCheckResult do
   @derive Jason.Encoder
   defstruct [
     :agent_id,
-    :status,
     :exclude_expression,
+    status: :executed,
     values: [],
     facts: [],
     expectation_evaluations: []
   ]
 
-  @type status :: :excluded_by_policy | nil
+  @type status :: :executed | :excluded
 
   @type t :: %__MODULE__{
           agent_id: String.t(),

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -19,7 +19,7 @@ defmodule Wanda.Executions.AgentCheckResult do
   defstruct [
     :agent_id,
     :exclude_expression,
-    status: :executed,
+    status: AgentCheckStatus.excluded(),
     values: [],
     facts: [],
     expectation_evaluations: []

--- a/lib/wanda/executions/agent_check_result.ex
+++ b/lib/wanda/executions/agent_check_result.ex
@@ -13,6 +13,8 @@ defmodule Wanda.Executions.AgentCheckResult do
     Value
   }
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
+
   @derive Jason.Encoder
   defstruct [
     :agent_id,
@@ -23,11 +25,9 @@ defmodule Wanda.Executions.AgentCheckResult do
     expectation_evaluations: []
   ]
 
-  @type status :: :executed | :excluded
-
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          status: status(),
+          status: AgentCheckStatus.t(),
           exclude_expression: String.t() | nil,
           facts: [Fact.t()],
           values: [Value.t()],

--- a/lib/wanda/executions/enums/agent_check_status.ex
+++ b/lib/wanda/executions/enums/agent_check_status.ex
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Wanda.Executions.Enums.AgentCheckStatus do
+  @moduledoc """
+  Type that represents an agent check execution status.
+  """
+
+  use Wanda.Support.Enum, values: [:executed, :excluded]
+end

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -435,6 +435,10 @@ defmodule Wanda.Executions.Evaluation do
         _ -> false
       end)
 
+  defp aggregate_execution_result(%Result{check_results: []} = execution) do
+    %Result{execution | result: ResultEnum.passing()}
+  end
+
   defp aggregate_execution_result(%Result{check_results: check_results} = execution) do
     result =
       check_results

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -24,6 +24,7 @@ defmodule Wanda.Executions.Evaluation do
   alias Wanda.EvaluationEngine
 
   require Wanda.Catalog.Enums.ExpectType, as: ExpectType
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
   require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_failure_message "Expectation not met"
@@ -142,6 +143,7 @@ defmodule Wanda.Executions.Evaluation do
 
       %AgentCheckResult{
         agent_id: agent_id,
+        status: AgentCheckStatus.executed(),
         facts: facts,
         values: resolved_values,
         expectation_evaluations:

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -13,6 +13,7 @@ defmodule Wanda.Executions.Evaluation do
     AgentCheckError,
     AgentCheckResult,
     CheckResult,
+    ExcludedCheckResult,
     ExpectationEvaluation,
     ExpectationEvaluationError,
     ExpectationResult,
@@ -35,10 +36,20 @@ defmodule Wanda.Executions.Evaluation do
           [SelectedCheck.t()],
           map(),
           %{String.t() => boolean() | number() | String.t()},
+          [ExcludedCheckResult.t()],
           [String.t()],
           Rhai.Engine.t()
         ) :: Result.t()
-  def execute(execution_id, group_id, checks, gathered_facts, env, timeouts \\ [], engine) do
+  def execute(
+        execution_id,
+        group_id,
+        checks,
+        gathered_facts,
+        env,
+        excluded_checks,
+        timeouts \\ [],
+        engine
+      ) do
     %Result{
       execution_id: execution_id,
       group_id: group_id,
@@ -50,6 +61,7 @@ defmodule Wanda.Executions.Evaluation do
       env,
       engine
     )
+    |> add_excluded_checks_result(excluded_checks, checks)
     |> aggregate_execution_result()
   end
 
@@ -398,6 +410,72 @@ defmodule Wanda.Executions.Evaluation do
     |> Enum.map(&{&1.return_value, result_weight(&1.return_value)})
     |> Enum.max_by(fn {_, weight} -> weight end)
     |> elem(0)
+  end
+
+  # Adds the excluded (check, agent) pairs into the corresponding check's
+  # `agents_check_results` list, so the excluded host appears inline with the
+  # other agent results rather than being silently dropped.
+  #
+  # A check that is excluded for *every* target is never requested for facts,
+  # so `Evaluation.execute` produces no `CheckResult` for it. Such checks are
+  # re-introduced here as passing results containing only excluded agents,
+  # mirroring the `active_targets == []` branch of `handle_continue/2`. Without
+  # this, a check excluded for all hosts while other checks still run would be
+  # silently dropped from the final execution result.
+  defp add_excluded_checks_result(%Result{} = result, [], _checks),
+    do: result
+
+  defp add_excluded_checks_result(
+         %Result{check_results: check_results} = result,
+         excluded,
+         checks
+       ) do
+    excluded_by_check = Enum.group_by(excluded, & &1.check_id)
+    existing_ids = MapSet.new(check_results, & &1.check_id)
+
+    missing_check_results =
+      checks
+      |> Enum.filter(fn %SelectedCheck{spec: %Check{id: id}} ->
+        Map.has_key?(excluded_by_check, id) and not MapSet.member?(existing_ids, id)
+      end)
+      |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}, customized: customized} ->
+        %CheckResult{
+          check_id: id,
+          customized: customized,
+          agents_check_results: [],
+          expectation_results: [],
+          result: ResultEnum.passing()
+        }
+      end)
+
+    new_check_results =
+      Enum.map(check_results ++ missing_check_results, fn %CheckResult{check_id: check_id} =
+                                                            check_result ->
+        add_excluded_agents_result(check_result, Map.get(excluded_by_check, check_id))
+      end)
+
+    %Result{result | check_results: new_check_results}
+  end
+
+  defp add_excluded_agents_result(check_result, nil), do: check_result
+
+  defp add_excluded_agents_result(%CheckResult{} = check_result, entries) do
+    excluded_agents =
+      Enum.map(entries, fn %ExcludedCheckResult{
+                             agent_id: agent_id,
+                             exclude_expression: exclude_expression
+                           } ->
+        %AgentCheckResult{
+          agent_id: agent_id,
+          status: AgentCheckStatus.excluded(),
+          exclude_expression: exclude_expression
+        }
+      end)
+
+    %CheckResult{
+      check_result
+      | agents_check_results: check_result.agents_check_results ++ excluded_agents
+    }
   end
 
   defp aggregate_check_result(

--- a/lib/wanda/executions/evaluation.ex
+++ b/lib/wanda/executions/evaluation.ex
@@ -450,8 +450,6 @@ defmodule Wanda.Executions.Evaluation do
     %Result{execution | result: result}
   end
 
-  # TODO: is unknown needed?
-  # defp result_weight(:unknown), do: 3
   defp result_weight(ResultEnum.critical()), do: 2
   defp result_weight(ResultEnum.warning()), do: 1
   defp result_weight(ResultEnum.passing()), do: 0

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule Wanda.Executions.ExcludedCheckResult do
   @moduledoc """
   Represents a (check, agent) pair excluded by the check's `exclude` predicate.

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Wanda.Executions.ExcludedCheckResult do
+  @moduledoc """
+  Represents a (check, agent) pair excluded by the check's `exclude` predicate.
+  """
+
+  @derive Jason.Encoder
+  defstruct [:check_id, :agent_id, :status, :exclude_expression]
+
+  @type t :: %__MODULE__{
+          check_id: String.t(),
+          agent_id: String.t(),
+          status: :excluded_by_policy,
+          exclude_expression: String.t() | nil
+        }
+end

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -12,7 +12,7 @@ defmodule Wanda.Executions.ExcludedCheckResult do
   @type t :: %__MODULE__{
           check_id: String.t(),
           agent_id: String.t(),
-          status: :excluded_by_policy,
+          status: :excluded,
           exclude_expression: String.t() | nil
         }
 end

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -6,13 +6,15 @@ defmodule Wanda.Executions.ExcludedCheckResult do
   Represents a (check, agent) pair excluded by the check's `exclude` predicate.
   """
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
+
   @derive Jason.Encoder
   defstruct [:check_id, :agent_id, :status, :exclude_expression]
 
   @type t :: %__MODULE__{
           check_id: String.t(),
           agent_id: String.t(),
-          status: :excluded,
+          status: AgentCheckStatus.t(),
           exclude_expression: String.t() | nil
         }
 end

--- a/lib/wanda/executions/excluded_check_result.ex
+++ b/lib/wanda/executions/excluded_check_result.ex
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# SPDX-FileCopyrightText: SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
-
 defmodule Wanda.Executions.ExcludedCheckResult do
   @moduledoc """
   Represents a (check, agent) pair excluded by the check's `exclude` predicate.

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -6,7 +6,7 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
-  alias Wanda.Executions.CheckResult
+  alias Wanda.Executions.{CheckResult, ExcludedCheckResult}
 
   require Wanda.Executions.Enums.Result, as: ResultEnum
 
@@ -16,6 +16,7 @@ defmodule Wanda.Executions.Result do
     :group_id,
     :result,
     check_results: [],
+    excluded_checks: [],
     timeout: []
   ]
 
@@ -23,6 +24,7 @@ defmodule Wanda.Executions.Result do
           execution_id: String.t(),
           group_id: String.t(),
           check_results: [CheckResult.t()],
+          excluded_checks: [ExcludedCheckResult.t()],
           timeout: [String.t()],
           result: ResultEnum.t()
         }

--- a/lib/wanda/executions/result.ex
+++ b/lib/wanda/executions/result.ex
@@ -6,7 +6,7 @@ defmodule Wanda.Executions.Result do
   Represents the result of an execution.
   """
 
-  alias Wanda.Executions.{CheckResult, ExcludedCheckResult}
+  alias Wanda.Executions.CheckResult
 
   require Wanda.Executions.Enums.Result, as: ResultEnum
 
@@ -16,7 +16,6 @@ defmodule Wanda.Executions.Result do
     :group_id,
     :result,
     check_results: [],
-    excluded_checks: [],
     timeout: []
   ]
 
@@ -24,7 +23,6 @@ defmodule Wanda.Executions.Result do
           execution_id: String.t(),
           group_id: String.t(),
           check_results: [CheckResult.t()],
-          excluded_checks: [ExcludedCheckResult.t()],
           timeout: [String.t()],
           result: ResultEnum.t()
         }

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -335,10 +335,10 @@ defmodule Wanda.Executions.Server do
 
   defp evaluate_exclude_predicate(
          %SelectedCheck{spec: %Check{id: check_id, exclude: exclude_expr}},
-         %Target{agent_id: agent_id, host_data: host_data},
+         %Target{agent_id: agent_id, attributes: attributes},
          engine
        ) do
-    case EvaluationEngine.eval(engine, exclude_expr, %{"host" => host_data}) do
+    case EvaluationEngine.eval(engine, exclude_expr, %{"host" => attributes}) do
       {:ok, true} ->
         :excluded
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -161,7 +161,12 @@ defmodule Wanda.Executions.Server do
       {:stop, :normal, state}
     else
       facts_gathering_requested =
-        Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, active_targets, specs)
+        Messaging.Mapper.to_facts_gathering_requested(
+          execution_id,
+          group_id,
+          active_targets,
+          specs
+        )
 
       :ok = Messaging.publish(Publisher, "agents", facts_gathering_requested)
 
@@ -386,9 +391,9 @@ defmodule Wanda.Executions.Server do
           entries ->
             excluded_agents =
               Enum.map(entries, fn %ExcludedCheckResult{
-                                         agent_id: agent_id,
-                                         exclude_expression: exclude_expression
-                                       } ->
+                                     agent_id: agent_id,
+                                     exclude_expression: exclude_expression
+                                   } ->
                 %AgentCheckResult{
                   agent_id: agent_id,
                   status: :excluded_by_policy,

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -11,10 +11,13 @@ defmodule Wanda.Executions.Server do
 
   use GenServer, restart: :transient
 
-  alias Wanda.Catalog.SelectedCheck
+  alias Wanda.Catalog.{Check, SelectedCheck}
 
   alias Wanda.Executions.{
+    AgentCheckResult,
+    CheckResult,
     Evaluation,
+    ExcludedCheckResult,
     Gathering,
     Result,
     State,
@@ -33,6 +36,7 @@ defmodule Wanda.Executions.Server do
   alias Wanda.Executions.Messaging.Publisher
 
   require Logger
+  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_target_type "cluster"
   @default_timeout 5 * 60 * 1_000
@@ -101,26 +105,71 @@ defmodule Wanda.Executions.Server do
           group_id: group_id,
           targets: targets,
           checks: checks,
+          env: env,
           timeout: timeout
         } = state
       ) do
     engine = EvaluationEngine.new()
 
+    {active_targets, excluded_checks} = evaluate_exclusions(targets, checks, engine)
+
     specs = SelectedCheck.extract_specs(checks)
 
-    facts_gathering_requested =
-      Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, targets, specs)
-
     execution_started = Messaging.Mapper.to_execution_started(execution_id, group_id, targets)
-
     Executions.create_execution!(execution_id, group_id, targets)
-
     :ok = Messaging.publish(Publisher, "results", execution_started)
-    :ok = Messaging.publish(Publisher, "agents", facts_gathering_requested)
 
-    Process.send_after(self(), :timeout, timeout)
+    if active_targets == [] do
+      # Even with no active targets, we still need to surface the excluded
+      # hosts in each check's `agents_check_results` so the UI can list them.
+      checks_with_excluded =
+        excluded_checks
+        |> Enum.group_by(& &1.check_id)
+        |> Map.new(fn {check_id, entries} ->
+          {check_id,
+           Enum.map(entries, fn %ExcludedCheckResult{agent_id: agent_id} = e ->
+             %AgentCheckResult{
+               agent_id: agent_id,
+               status: :excluded_by_policy,
+               exclude_expression: e.exclude_expression
+             }
+           end)}
+        end)
 
-    {:noreply, %State{state | engine: engine}}
+      check_results =
+        checks
+        |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}} = sc ->
+          %CheckResult{
+            check_id: id,
+            customized: sc.customized,
+            agents_check_results: Map.get(checks_with_excluded, id, []),
+            expectation_results: [],
+            result: ResultEnum.passing()
+          }
+        end)
+
+      result = %Result{
+        execution_id: execution_id,
+        group_id: group_id,
+        check_results: check_results,
+        excluded_checks: [],
+        timeout: [],
+        result: ResultEnum.passing()
+      }
+
+      store_and_publish_execution_result(result, env)
+      {:stop, :normal, state}
+    else
+      facts_gathering_requested =
+        Messaging.Mapper.to_facts_gathering_requested(execution_id, group_id, active_targets, specs)
+
+      :ok = Messaging.publish(Publisher, "agents", facts_gathering_requested)
+
+      Process.send_after(self(), :timeout, timeout)
+
+      {:noreply,
+       %State{state | engine: engine, targets: active_targets, excluded_checks: excluded_checks}}
+    end
   end
 
   @impl true
@@ -161,7 +210,8 @@ defmodule Wanda.Executions.Server do
           targets: targets,
           checks: checks,
           env: env,
-          agents_gathered: agents_gathered
+          agents_gathered: agents_gathered,
+          excluded_checks: excluded_checks
         } = state
       ) do
     targets =
@@ -174,15 +224,10 @@ defmodule Wanda.Executions.Server do
     gathered_facts = Gathering.put_gathering_timeouts(gathered_facts, targets)
 
     result =
-      Evaluation.execute(
-        execution_id,
-        group_id,
-        checks,
-        gathered_facts,
-        env,
-        timedout_agents,
-        engine
-      )
+      execution_id
+      |> Evaluation.execute(group_id, checks, gathered_facts, env, timedout_agents, engine)
+      |> inject_excluded_checks(excluded_checks)
+      |> Map.put(:excluded_checks, [])
 
     store_and_publish_execution_result(result, env)
 
@@ -198,7 +243,8 @@ defmodule Wanda.Executions.Server do
            targets: targets,
            checks: checks,
            env: env,
-           agents_gathered: agents_gathered
+           agents_gathered: agents_gathered,
+           excluded_checks: excluded_checks
          } = state,
          agent_id,
          facts
@@ -209,7 +255,11 @@ defmodule Wanda.Executions.Server do
     state = %State{state | gathered_facts: gathered_facts, agents_gathered: agents_gathered}
 
     if Gathering.all_agents_sent_facts?(agents_gathered, targets) do
-      result = Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, engine)
+      result =
+        execution_id
+        |> Evaluation.execute(group_id, checks, gathered_facts, env, engine)
+        |> inject_excluded_checks(excluded_checks)
+        |> Map.put(:excluded_checks, [])
 
       store_and_publish_execution_result(result, env)
 
@@ -228,8 +278,133 @@ defmodule Wanda.Executions.Server do
     :ok = Messaging.publish(Publisher, "results", execution_completed)
   end
 
+  defp evaluate_exclusions(targets, checks, engine) do
+    {active_targets_rev, excluded} =
+      Enum.reduce(targets, {[], []}, fn target, {active_acc, excluded_acc} ->
+        {active_check_ids_rev, excluded_for_target} =
+          Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
+            case Enum.find(checks, &(&1.id == check_id)) do
+              nil ->
+                {[check_id | keep], excl}
+
+              selected_check ->
+                case evaluate_exclude_predicate(selected_check, target, engine) do
+                  :excluded -> {keep, [check_id | excl]}
+                  :keep -> {[check_id | keep], excl}
+                end
+            end
+          end)
+
+        newly_excluded =
+          Enum.map(excluded_for_target, fn check_id ->
+            exclude_expr = find_exclude_expression(checks, check_id)
+
+            %ExcludedCheckResult{
+              check_id: check_id,
+              agent_id: target.agent_id,
+              status: :excluded_by_policy,
+              exclude_expression: exclude_expr
+            }
+          end)
+
+        active_target = %Target{target | checks: Enum.reverse(active_check_ids_rev)}
+        {[active_target | active_acc], newly_excluded ++ excluded_acc}
+      end)
+
+    filtered_targets =
+      active_targets_rev
+      |> Enum.reverse()
+      |> Enum.filter(fn %Target{checks: checks} -> checks != [] end)
+
+    {filtered_targets, excluded}
+  end
+
+  defp find_exclude_expression(checks, check_id) do
+    case Enum.find(checks, &(&1.id == check_id)) do
+      %SelectedCheck{spec: %Check{exclude: expr}} -> expr
+      _ -> nil
+    end
+  end
+
+  defp evaluate_exclude_predicate(
+         %SelectedCheck{spec: %Check{exclude: nil}},
+         _target,
+         _engine
+       ),
+       do: :keep
+
+  defp evaluate_exclude_predicate(
+         %SelectedCheck{spec: %Check{id: check_id, exclude: exclude_expr}},
+         %Target{agent_id: agent_id, host_data: host_data},
+         engine
+       ) do
+    case EvaluationEngine.eval(engine, exclude_expr, %{"host" => host_data}) do
+      {:ok, true} ->
+        :excluded
+
+      {:ok, false} ->
+        :keep
+
+      {:ok, other} ->
+        Logger.warning(
+          "Check #{check_id} exclude predicate for agent #{agent_id} returned non-boolean " <>
+            "#{inspect(other)}, keeping pair"
+        )
+
+        :keep
+
+      {:error, reason} ->
+        Logger.warning(
+          "Check #{check_id} exclude predicate for agent #{agent_id} raised error " <>
+            "#{inspect(reason)}, keeping pair"
+        )
+
+        :keep
+    end
+  end
+
   defp via_tuple(group_id),
     do: {:via, :global, {__MODULE__, group_id}}
+
+  # Injects the excluded (check, agent) pairs into the corresponding check's
+  # `agents_check_results` list, so the excluded host appears inline with the
+  # other agent results rather than being silently dropped.
+  defp inject_excluded_checks(%Result{check_results: _check_results} = result, []),
+    do: result
+
+  defp inject_excluded_checks(%Result{check_results: check_results} = result, excluded) do
+    excluded_by_check =
+      excluded
+      |> Enum.group_by(& &1.check_id)
+
+    new_check_results =
+      Enum.map(check_results, fn %CheckResult{check_id: check_id} = check_result ->
+        case Map.get(excluded_by_check, check_id) do
+          nil ->
+            check_result
+
+          entries ->
+            excluded_agents =
+              Enum.map(entries, fn %ExcludedCheckResult{
+                                         agent_id: agent_id,
+                                         exclude_expression: exclude_expression
+                                       } ->
+                %AgentCheckResult{
+                  agent_id: agent_id,
+                  status: :excluded_by_policy,
+                  exclude_expression: exclude_expression
+                }
+              end)
+
+            %CheckResult{
+              check_result
+              | agents_check_results: check_result.agents_check_results ++ excluded_agents
+            }
+        end
+      end)
+
+    %Result{result | check_results: new_check_results}
+  end
 
   defp maybe_start_execution(_, _, _, [], _, _), do: {:error, :no_checks_selected}
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -137,8 +137,7 @@ defmodule Wanda.Executions.Server do
         end)
 
       check_results =
-        checks
-        |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}} = sc ->
+        Enum.map(checks, fn %SelectedCheck{spec: %Check{id: id}} = sc ->
           %CheckResult{
             check_id: id,
             customized: sc.customized,
@@ -287,18 +286,7 @@ defmodule Wanda.Executions.Server do
     {active_targets_rev, excluded} =
       Enum.reduce(targets, {[], []}, fn %Target{} = target, {active_acc, excluded_acc} ->
         {active_check_ids_rev, excluded_for_target} =
-          Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
-            case Enum.find(checks, &(&1.id == check_id)) do
-              nil ->
-                {[check_id | keep], excl}
-
-              selected_check ->
-                case evaluate_exclude_predicate(selected_check, target, engine) do
-                  :excluded -> {keep, [check_id | excl]}
-                  :keep -> {[check_id | keep], excl}
-                end
-            end
-          end)
+          partition_target_checks(target, checks, engine)
 
         newly_excluded =
           Enum.map(excluded_for_target, fn check_id ->
@@ -322,6 +310,22 @@ defmodule Wanda.Executions.Server do
       |> Enum.filter(fn %Target{checks: checks} -> checks != [] end)
 
     {filtered_targets, excluded}
+  end
+
+  defp partition_target_checks(%Target{} = target, checks, engine) do
+    Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
+      case classify_check(check_id, checks, target, engine) do
+        :keep -> {[check_id | keep], excl}
+        :excluded -> {keep, [check_id | excl]}
+      end
+    end)
+  end
+
+  defp classify_check(check_id, checks, target, engine) do
+    case Enum.find(checks, &(&1.id == check_id)) do
+      nil -> :keep
+      selected_check -> evaluate_exclude_predicate(selected_check, target, engine)
+    end
   end
 
   defp find_exclude_expression(checks, check_id) do
@@ -378,37 +382,35 @@ defmodule Wanda.Executions.Server do
     do: result
 
   defp inject_excluded_checks(%Result{check_results: check_results} = result, excluded) do
-    excluded_by_check =
-      excluded
-      |> Enum.group_by(& &1.check_id)
+    excluded_by_check = Enum.group_by(excluded, & &1.check_id)
 
     new_check_results =
       Enum.map(check_results, fn %CheckResult{check_id: check_id} = check_result ->
-        case Map.get(excluded_by_check, check_id) do
-          nil ->
-            check_result
-
-          entries ->
-            excluded_agents =
-              Enum.map(entries, fn %ExcludedCheckResult{
-                                     agent_id: agent_id,
-                                     exclude_expression: exclude_expression
-                                   } ->
-                %AgentCheckResult{
-                  agent_id: agent_id,
-                  status: :excluded_by_policy,
-                  exclude_expression: exclude_expression
-                }
-              end)
-
-            %CheckResult{
-              check_result
-              | agents_check_results: check_result.agents_check_results ++ excluded_agents
-            }
-        end
+        inject_excluded_agents(check_result, Map.get(excluded_by_check, check_id))
       end)
 
     %Result{result | check_results: new_check_results}
+  end
+
+  defp inject_excluded_agents(check_result, nil), do: check_result
+
+  defp inject_excluded_agents(%CheckResult{} = check_result, entries) do
+    excluded_agents =
+      Enum.map(entries, fn %ExcludedCheckResult{
+                             agent_id: agent_id,
+                             exclude_expression: exclude_expression
+                           } ->
+        %AgentCheckResult{
+          agent_id: agent_id,
+          status: :excluded_by_policy,
+          exclude_expression: exclude_expression
+        }
+      end)
+
+    %CheckResult{
+      check_result
+      | agents_check_results: check_result.agents_check_results ++ excluded_agents
+    }
   end
 
   defp maybe_start_execution(_, _, _, [], _, _), do: {:error, :no_checks_selected}

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -280,7 +280,7 @@ defmodule Wanda.Executions.Server do
 
   defp evaluate_exclusions(targets, checks, engine) do
     {active_targets_rev, excluded} =
-      Enum.reduce(targets, {[], []}, fn target, {active_acc, excluded_acc} ->
+      Enum.reduce(targets, {[], []}, fn %Target{} = target, {active_acc, excluded_acc} ->
         {active_check_ids_rev, excluded_for_target} =
           Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
             case Enum.find(checks, &(&1.id == check_id)) do

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -228,9 +228,16 @@ defmodule Wanda.Executions.Server do
     gathered_facts = Gathering.put_gathering_timeouts(gathered_facts, targets)
 
     result =
-      execution_id
-      |> Evaluation.execute(group_id, checks, gathered_facts, env, timedout_agents, engine)
-      |> inject_excluded_checks(excluded_checks, checks)
+      Evaluation.execute(
+        execution_id,
+        group_id,
+        checks,
+        gathered_facts,
+        env,
+        excluded_checks,
+        timedout_agents,
+        engine
+      )
 
     store_and_publish_execution_result(result, env)
 
@@ -259,9 +266,16 @@ defmodule Wanda.Executions.Server do
 
     if Gathering.all_agents_sent_facts?(agents_gathered, targets) do
       result =
-        execution_id
-        |> Evaluation.execute(group_id, checks, gathered_facts, env, engine)
-        |> inject_excluded_checks(excluded_checks, checks)
+        Evaluation.execute(
+          execution_id,
+          group_id,
+          checks,
+          gathered_facts,
+          env,
+          excluded_checks,
+          [],
+          engine
+        )
 
       store_and_publish_execution_result(result, env)
 
@@ -372,72 +386,6 @@ defmodule Wanda.Executions.Server do
 
   defp via_tuple(group_id),
     do: {:via, :global, {__MODULE__, group_id}}
-
-  # Injects the excluded (check, agent) pairs into the corresponding check's
-  # `agents_check_results` list, so the excluded host appears inline with the
-  # other agent results rather than being silently dropped.
-  #
-  # A check that is excluded for *every* target is never requested for facts,
-  # so `Evaluation.execute` produces no `CheckResult` for it. Such checks are
-  # re-introduced here as passing results containing only excluded agents,
-  # mirroring the `active_targets == []` branch of `handle_continue/2`. Without
-  # this, a check excluded for all hosts while other checks still run would be
-  # silently dropped from the final execution result.
-  defp inject_excluded_checks(%Result{} = result, [], _checks),
-    do: result
-
-  defp inject_excluded_checks(
-         %Result{check_results: check_results} = result,
-         excluded,
-         checks
-       ) do
-    excluded_by_check = Enum.group_by(excluded, & &1.check_id)
-    existing_ids = MapSet.new(check_results, & &1.check_id)
-
-    missing_check_results =
-      checks
-      |> Enum.filter(fn %SelectedCheck{spec: %Check{id: id}} ->
-        Map.has_key?(excluded_by_check, id) and not MapSet.member?(existing_ids, id)
-      end)
-      |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}, customized: customized} ->
-        %CheckResult{
-          check_id: id,
-          customized: customized,
-          agents_check_results: [],
-          expectation_results: [],
-          result: ResultEnum.passing()
-        }
-      end)
-
-    new_check_results =
-      Enum.map(check_results ++ missing_check_results, fn %CheckResult{check_id: check_id} =
-                                                            check_result ->
-        inject_excluded_agents(check_result, Map.get(excluded_by_check, check_id))
-      end)
-
-    %Result{result | check_results: new_check_results}
-  end
-
-  defp inject_excluded_agents(check_result, nil), do: check_result
-
-  defp inject_excluded_agents(%CheckResult{} = check_result, entries) do
-    excluded_agents =
-      Enum.map(entries, fn %ExcludedCheckResult{
-                             agent_id: agent_id,
-                             exclude_expression: exclude_expression
-                           } ->
-        %AgentCheckResult{
-          agent_id: agent_id,
-          status: AgentCheckStatus.excluded(),
-          exclude_expression: exclude_expression
-        }
-      end)
-
-    %CheckResult{
-      check_result
-      | agents_check_results: check_result.agents_check_results ++ excluded_agents
-    }
-  end
 
   defp maybe_start_execution(_, _, _, [], _, _), do: {:error, :no_checks_selected}
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -35,7 +35,6 @@ defmodule Wanda.Executions.Server do
 
   require Logger
   require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
-  require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_target_type "cluster"
   @default_timeout 5 * 60 * 1_000

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -14,8 +14,6 @@ defmodule Wanda.Executions.Server do
   alias Wanda.Catalog.{Check, SelectedCheck}
 
   alias Wanda.Executions.{
-    AgentCheckResult,
-    CheckResult,
     Evaluation,
     ExcludedCheckResult,
     Gathering,
@@ -123,38 +121,10 @@ defmodule Wanda.Executions.Server do
     if active_targets == [] do
       # Even with no active targets, we still need to surface the excluded
       # hosts in each check's `agents_check_results` so the UI can list them.
-      checks_with_excluded =
-        excluded_checks
-        |> Enum.group_by(& &1.check_id)
-        |> Map.new(fn {check_id, entries} ->
-          {check_id,
-           Enum.map(entries, fn %ExcludedCheckResult{agent_id: agent_id} = e ->
-             %AgentCheckResult{
-               agent_id: agent_id,
-               status: AgentCheckStatus.excluded(),
-               exclude_expression: e.exclude_expression
-             }
-           end)}
-        end)
-
-      check_results =
-        Enum.map(checks, fn %SelectedCheck{spec: %Check{id: id}} = sc ->
-          %CheckResult{
-            check_id: id,
-            customized: sc.customized,
-            agents_check_results: Map.get(checks_with_excluded, id, []),
-            expectation_results: [],
-            result: ResultEnum.passing()
-          }
-        end)
-
-      result = %Result{
-        execution_id: execution_id,
-        group_id: group_id,
-        check_results: check_results,
-        timeout: [],
-        result: ResultEnum.passing()
-      }
+      # We delegate to Evaluation.execute with empty gathered_facts, which
+      # will create passing check results containing only excluded agents.
+      result =
+        Evaluation.execute(execution_id, group_id, checks, %{}, env, excluded_checks, [], engine)
 
       store_and_publish_execution_result(result, env)
       {:stop, :normal, state}

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -151,7 +151,6 @@ defmodule Wanda.Executions.Server do
         execution_id: execution_id,
         group_id: group_id,
         check_results: check_results,
-        excluded_checks: [],
         timeout: [],
         result: ResultEnum.passing()
       }
@@ -231,7 +230,6 @@ defmodule Wanda.Executions.Server do
       execution_id
       |> Evaluation.execute(group_id, checks, gathered_facts, env, timedout_agents, engine)
       |> inject_excluded_checks(excluded_checks, checks)
-      |> Map.put(:excluded_checks, [])
 
     store_and_publish_execution_result(result, env)
 
@@ -263,7 +261,6 @@ defmodule Wanda.Executions.Server do
         execution_id
         |> Evaluation.execute(group_id, checks, gathered_facts, env, engine)
         |> inject_excluded_checks(excluded_checks, checks)
-        |> Map.put(:excluded_checks, [])
 
       store_and_publish_execution_result(result, env)
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -230,7 +230,7 @@ defmodule Wanda.Executions.Server do
     result =
       execution_id
       |> Evaluation.execute(group_id, checks, gathered_facts, env, timedout_agents, engine)
-      |> inject_excluded_checks(excluded_checks)
+      |> inject_excluded_checks(excluded_checks, checks)
       |> Map.put(:excluded_checks, [])
 
     store_and_publish_execution_result(result, env)
@@ -262,7 +262,7 @@ defmodule Wanda.Executions.Server do
       result =
         execution_id
         |> Evaluation.execute(group_id, checks, gathered_facts, env, engine)
-        |> inject_excluded_checks(excluded_checks)
+        |> inject_excluded_checks(excluded_checks, checks)
         |> Map.put(:excluded_checks, [])
 
       store_and_publish_execution_result(result, env)
@@ -378,14 +378,42 @@ defmodule Wanda.Executions.Server do
   # Injects the excluded (check, agent) pairs into the corresponding check's
   # `agents_check_results` list, so the excluded host appears inline with the
   # other agent results rather than being silently dropped.
-  defp inject_excluded_checks(%Result{check_results: _check_results} = result, []),
+  #
+  # A check that is excluded for *every* target is never requested for facts,
+  # so `Evaluation.execute` produces no `CheckResult` for it. Such checks are
+  # re-introduced here as passing results containing only excluded agents,
+  # mirroring the `active_targets == []` branch of `handle_continue/2`. Without
+  # this, a check excluded for all hosts while other checks still run would be
+  # silently dropped from the final execution result.
+  defp inject_excluded_checks(%Result{} = result, [], _checks),
     do: result
 
-  defp inject_excluded_checks(%Result{check_results: check_results} = result, excluded) do
+  defp inject_excluded_checks(
+         %Result{check_results: check_results} = result,
+         excluded,
+         checks
+       ) do
     excluded_by_check = Enum.group_by(excluded, & &1.check_id)
+    existing_ids = MapSet.new(check_results, & &1.check_id)
+
+    missing_check_results =
+      checks
+      |> Enum.filter(fn %SelectedCheck{spec: %Check{id: id}} ->
+        Map.has_key?(excluded_by_check, id) and not MapSet.member?(existing_ids, id)
+      end)
+      |> Enum.map(fn %SelectedCheck{spec: %Check{id: id}, customized: customized} ->
+        %CheckResult{
+          check_id: id,
+          customized: customized,
+          agents_check_results: [],
+          expectation_results: [],
+          result: ResultEnum.passing()
+        }
+      end)
 
     new_check_results =
-      Enum.map(check_results, fn %CheckResult{check_id: check_id} = check_result ->
+      Enum.map(check_results ++ missing_check_results, fn %CheckResult{check_id: check_id} =
+                                                            check_result ->
         inject_excluded_agents(check_result, Map.get(excluded_by_check, check_id))
       end)
 

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -36,6 +36,7 @@ defmodule Wanda.Executions.Server do
   alias Wanda.Executions.Messaging.Publisher
 
   require Logger
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
   require Wanda.Executions.Enums.Result, as: ResultEnum
 
   @default_target_type "cluster"
@@ -130,7 +131,7 @@ defmodule Wanda.Executions.Server do
            Enum.map(entries, fn %ExcludedCheckResult{agent_id: agent_id} = e ->
              %AgentCheckResult{
                agent_id: agent_id,
-               status: :excluded,
+               status: AgentCheckStatus.excluded(),
                exclude_expression: e.exclude_expression
              }
            end)}
@@ -292,7 +293,7 @@ defmodule Wanda.Executions.Server do
             %ExcludedCheckResult{
               check_id: check_id,
               agent_id: target.agent_id,
-              status: :excluded,
+              status: AgentCheckStatus.excluded(),
               exclude_expression: exclude_expr
             }
           end)
@@ -427,7 +428,7 @@ defmodule Wanda.Executions.Server do
                            } ->
         %AgentCheckResult{
           agent_id: agent_id,
-          status: :excluded,
+          status: AgentCheckStatus.excluded(),
           exclude_expression: exclude_expression
         }
       end)

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -130,7 +130,7 @@ defmodule Wanda.Executions.Server do
            Enum.map(entries, fn %ExcludedCheckResult{agent_id: agent_id} = e ->
              %AgentCheckResult{
                agent_id: agent_id,
-               status: :excluded_by_policy,
+               status: :excluded,
                exclude_expression: e.exclude_expression
              }
            end)}
@@ -292,7 +292,7 @@ defmodule Wanda.Executions.Server do
             %ExcludedCheckResult{
               check_id: check_id,
               agent_id: target.agent_id,
-              status: :excluded_by_policy,
+              status: :excluded,
               exclude_expression: exclude_expr
             }
           end)
@@ -427,7 +427,7 @@ defmodule Wanda.Executions.Server do
                            } ->
         %AgentCheckResult{
           agent_id: agent_id,
-          status: :excluded_by_policy,
+          status: :excluded,
           exclude_expression: exclude_expression
         }
       end)

--- a/lib/wanda/executions/server.ex
+++ b/lib/wanda/executions/server.ex
@@ -265,76 +265,48 @@ defmodule Wanda.Executions.Server do
   end
 
   defp evaluate_exclusions(targets, checks, engine) do
-    {active_targets_rev, excluded} =
-      Enum.reduce(targets, {[], []}, fn %Target{} = target, {active_acc, excluded_acc} ->
-        {active_check_ids_rev, excluded_for_target} =
-          partition_target_checks(target, checks, engine)
+    checks_by_id = Map.new(checks, &{&1.id, &1})
 
-        newly_excluded =
-          Enum.map(excluded_for_target, fn check_id ->
-            exclude_expr = find_exclude_expression(checks, check_id)
+    Enum.flat_map_reduce(targets, [], fn %Target{checks: target_checks} = target, excluded_acc ->
+      {excluded_checks, active_checks} =
+        Enum.split_with(target_checks, fn check_id ->
+          check_excluded?(check_id, checks_by_id, target, engine)
+        end)
 
-            %ExcludedCheckResult{
-              check_id: check_id,
-              agent_id: target.agent_id,
-              status: AgentCheckStatus.excluded(),
-              exclude_expression: exclude_expr
-            }
-          end)
+      excluded_results = build_excluded_results(excluded_checks, checks_by_id, target.agent_id)
 
-        active_target = %Target{target | checks: Enum.reverse(active_check_ids_rev)}
-        {[active_target | active_acc], newly_excluded ++ excluded_acc}
-      end)
-
-    filtered_targets =
-      active_targets_rev
-      |> Enum.reverse()
-      |> Enum.filter(fn %Target{checks: checks} -> checks != [] end)
-
-    {filtered_targets, excluded}
-  end
-
-  defp partition_target_checks(%Target{} = target, checks, engine) do
-    Enum.reduce(target.checks, {[], []}, fn check_id, {keep, excl} ->
-      case classify_check(check_id, checks, target, engine) do
-        :keep -> {[check_id | keep], excl}
-        :excluded -> {keep, [check_id | excl]}
+      if active_checks == [] do
+        {[], excluded_results ++ excluded_acc}
+      else
+        active_target = %Target{target | checks: active_checks}
+        {[active_target], excluded_results ++ excluded_acc}
       end
     end)
   end
 
-  defp classify_check(check_id, checks, target, engine) do
-    case Enum.find(checks, &(&1.id == check_id)) do
-      nil -> :keep
-      selected_check -> evaluate_exclude_predicate(selected_check, target, engine)
-    end
+  defp check_excluded?(check_id, checks_by_id, target, engine) do
+    selected_check = Map.fetch!(checks_by_id, check_id)
+    evaluate_exclusion(selected_check, target, engine)
   end
 
-  defp find_exclude_expression(checks, check_id) do
-    case Enum.find(checks, &(&1.id == check_id)) do
-      %SelectedCheck{spec: %Check{exclude: expr}} -> expr
-      _ -> nil
-    end
-  end
-
-  defp evaluate_exclude_predicate(
+  defp evaluate_exclusion(
          %SelectedCheck{spec: %Check{exclude: nil}},
          _target,
          _engine
        ),
-       do: :keep
+       do: false
 
-  defp evaluate_exclude_predicate(
+  defp evaluate_exclusion(
          %SelectedCheck{spec: %Check{id: check_id, exclude: exclude_expr}},
          %Target{agent_id: agent_id, attributes: attributes},
          engine
        ) do
     case EvaluationEngine.eval(engine, exclude_expr, %{"host" => attributes}) do
       {:ok, true} ->
-        :excluded
+        true
 
       {:ok, false} ->
-        :keep
+        false
 
       {:ok, other} ->
         Logger.warning(
@@ -342,7 +314,7 @@ defmodule Wanda.Executions.Server do
             "#{inspect(other)}, keeping pair"
         )
 
-        :keep
+        false
 
       {:error, reason} ->
         Logger.warning(
@@ -350,8 +322,21 @@ defmodule Wanda.Executions.Server do
             "#{inspect(reason)}, keeping pair"
         )
 
-        :keep
+        false
     end
+  end
+
+  defp build_excluded_results(excluded_check_ids, checks_by_id, agent_id) do
+    Enum.map(excluded_check_ids, fn check_id ->
+      %SelectedCheck{spec: %Check{exclude: exclude_expr}} = Map.fetch!(checks_by_id, check_id)
+
+      %ExcludedCheckResult{
+        check_id: check_id,
+        agent_id: agent_id,
+        status: AgentCheckStatus.excluded(),
+        exclude_expression: exclude_expr
+      }
+    end)
   end
 
   defp via_tuple(group_id),

--- a/lib/wanda/executions/state.ex
+++ b/lib/wanda/executions/state.ex
@@ -7,7 +7,7 @@ defmodule Wanda.Executions.State do
   """
 
   alias Wanda.Catalog.SelectedCheck
-  alias Wanda.Executions.Target
+  alias Wanda.Executions.{ExcludedCheckResult, Target}
 
   defstruct [
     :engine,
@@ -18,7 +18,8 @@ defmodule Wanda.Executions.State do
     checks: [],
     env: %{},
     gathered_facts: %{},
-    agents_gathered: []
+    agents_gathered: [],
+    excluded_checks: []
   ]
 
   @type t :: %__MODULE__{
@@ -30,6 +31,7 @@ defmodule Wanda.Executions.State do
           checks: [SelectedCheck.t()],
           env: %{String.t() => boolean() | number() | String.t()},
           gathered_facts: map(),
-          agents_gathered: [String.t()]
+          agents_gathered: [String.t()],
+          excluded_checks: [ExcludedCheckResult.t()]
         }
 end

--- a/lib/wanda/executions/target.ex
+++ b/lib/wanda/executions/target.ex
@@ -8,12 +8,14 @@ defmodule Wanda.Executions.Target do
 
   defstruct [
     :agent_id,
-    checks: []
+    checks: [],
+    host_data: %{}
   ]
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
-          checks: [String.t()]
+          checks: [String.t()],
+          host_data: %{String.t() => term()}
         }
 
   @spec get_checks_from_targets([t()]) :: [String.t()]
@@ -26,8 +28,12 @@ defmodule Wanda.Executions.Target do
   def map_targets(map_list) do
     map_list
     |> Enum.uniq_by(& &1.agent_id)
-    |> Enum.map(fn %{agent_id: agent_id, checks: checks} ->
-      %__MODULE__{agent_id: agent_id, checks: checks}
+    |> Enum.map(fn %{agent_id: agent_id, checks: checks} = item ->
+      %__MODULE__{
+        agent_id: agent_id,
+        checks: checks,
+        host_data: Map.get(item, :host_data, %{})
+      }
     end)
   end
 end

--- a/lib/wanda/executions/target.ex
+++ b/lib/wanda/executions/target.ex
@@ -9,13 +9,13 @@ defmodule Wanda.Executions.Target do
   defstruct [
     :agent_id,
     checks: [],
-    host_data: %{}
+    attributes: %{}
   ]
 
   @type t :: %__MODULE__{
           agent_id: String.t(),
           checks: [String.t()],
-          host_data: %{String.t() => term()}
+          attributes: %{String.t() => term()}
         }
 
   @spec get_checks_from_targets([t()]) :: [String.t()]
@@ -32,7 +32,7 @@ defmodule Wanda.Executions.Target do
       %__MODULE__{
         agent_id: agent_id,
         checks: checks,
-        host_data: Map.get(item, :host_data, %{})
+        attributes: Map.get(item, :attributes, %{})
       }
     end)
   end

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -99,12 +99,12 @@ defmodule Wanda.Messaging.Mapper do
       }) do
     plain_targets =
       Enum.map(targets, fn %{agent_id: agent_id, checks: checks} = item ->
-        host_data =
+        attributes =
           item
-          |> Map.get(:host_data, %{})
+          |> Map.get(:attributes, %{})
           |> Map.new(fn {k, v} -> {k, unwrap_proto_value(v)} end)
 
-        %{agent_id: agent_id, checks: checks, host_data: host_data}
+        %{agent_id: agent_id, checks: checks, attributes: attributes}
       end)
 
     %{

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -97,10 +97,20 @@ defmodule Wanda.Messaging.Mapper do
         target_type: target_type,
         env: env
       }) do
+    plain_targets =
+      Enum.map(targets, fn %{agent_id: agent_id, checks: checks} = item ->
+        host_data =
+          item
+          |> Map.get(:host_data, %{})
+          |> Map.new(fn {k, v} -> {k, unwrap_proto_value(v)} end)
+
+        %{agent_id: agent_id, checks: checks, host_data: host_data}
+      end)
+
     %{
       execution_id: execution_id,
       group_id: group_id,
-      targets: Target.map_targets(targets),
+      targets: Target.map_targets(plain_targets),
       target_type: target_type,
       env: from_value(env)
     }
@@ -416,4 +426,20 @@ defmodule Wanda.Messaging.Mapper do
   defp from_value(map) when is_map(map) do
     Enum.into(map, %{}, fn {key, value} -> {key, from_value(value)} end)
   end
+
+  defp unwrap_proto_value(%{kind: {:string_value, s}}), do: s
+
+  defp unwrap_proto_value(%{kind: {:bool_value, b}}), do: b
+
+  defp unwrap_proto_value(%{kind: {:number_value, n}}), do: n
+
+  defp unwrap_proto_value(%{kind: {:null_value, _}}), do: nil
+
+  defp unwrap_proto_value(%{kind: {:list_value, %{values: vals}}}),
+    do: Enum.map(vals, &unwrap_proto_value/1)
+
+  defp unwrap_proto_value(%{kind: {:struct_value, %{fields: fields}}}),
+    do: Map.new(fields, fn {k, v} -> {k, unwrap_proto_value(v)} end)
+
+  defp unwrap_proto_value(_), do: ""
 end

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -98,13 +98,8 @@ defmodule Wanda.Messaging.Mapper do
         env: env
       }) do
     plain_targets =
-      Enum.map(targets, fn %{agent_id: agent_id, checks: checks} = item ->
-        attributes =
-          item
-          |> Map.get(:attributes, %{})
-          |> Map.new(fn {k, v} -> {k, unwrap_proto_value(v)} end)
-
-        %{agent_id: agent_id, checks: checks, attributes: attributes}
+      Enum.map(targets, fn %{agent_id: agent_id, checks: checks, attributes: attributes} ->
+        %{agent_id: agent_id, checks: checks, attributes: from_value(attributes)}
       end)
 
     %{
@@ -426,25 +421,4 @@ defmodule Wanda.Messaging.Mapper do
   defp from_value(map) when is_map(map) do
     Enum.into(map, %{}, fn {key, value} -> {key, from_value(value)} end)
   end
-
-  defp unwrap_proto_value(%{kind: {:string_value, s}}), do: s
-
-  defp unwrap_proto_value(%{kind: {:bool_value, b}}), do: b
-
-  defp unwrap_proto_value(%{kind: {:number_value, n}}) do
-    truncated = trunc(n)
-    if truncated == n, do: truncated, else: n
-  end
-
-  defp unwrap_proto_value(%{kind: {:null_value, _}}), do: nil
-
-  defp unwrap_proto_value(%{kind: {:null_value}}), do: nil
-
-  defp unwrap_proto_value(%{kind: {:list_value, %{values: vals}}}),
-    do: Enum.map(vals, &unwrap_proto_value/1)
-
-  defp unwrap_proto_value(%{kind: {:struct_value, %{fields: fields}}}),
-    do: Map.new(fields, fn {k, v} -> {k, unwrap_proto_value(v)} end)
-
-  defp unwrap_proto_value(_), do: ""
 end

--- a/lib/wanda/messaging/mapper.ex
+++ b/lib/wanda/messaging/mapper.ex
@@ -431,9 +431,14 @@ defmodule Wanda.Messaging.Mapper do
 
   defp unwrap_proto_value(%{kind: {:bool_value, b}}), do: b
 
-  defp unwrap_proto_value(%{kind: {:number_value, n}}), do: n
+  defp unwrap_proto_value(%{kind: {:number_value, n}}) do
+    truncated = trunc(n)
+    if truncated == n, do: truncated, else: n
+  end
 
   defp unwrap_proto_value(%{kind: {:null_value, _}}), do: nil
+
+  defp unwrap_proto_value(%{kind: {:null_value}}), do: nil
 
   defp unwrap_proto_value(%{kind: {:list_value, %{values: vals}}}),
     do: Enum.map(vals, &unwrap_proto_value/1)

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -50,6 +50,19 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
           },
           description:
             "Result of the single expectation evaluation, indicating whether the expectation was met for the agent's check."
+        },
+        status: %Schema{
+          type: :string,
+          nullable: true,
+          enum: ["excluded_by_policy"],
+          description:
+            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+        },
+        exclude_expression: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
         }
       },
       required: [:agent_id, :facts, :expectation_evaluations],

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -13,6 +13,7 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
     Value
   }
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
   require OpenApiSpex
 
   OpenApiSpex.schema(
@@ -53,9 +54,9 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
         },
         status: %Schema{
           type: :string,
-          enum: ["executed", "excluded"],
+          enum: AgentCheckStatus.values(),
           description:
-            "Status of this agent's result for the check. `executed` means the check ran normally for this agent. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
+            "Status of this agent's check execution. `executed` means the check ran normally. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
         },
         exclude_expression: %Schema{
           type: :string,

--- a/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v1/execution/agent_check_result.ex
@@ -53,19 +53,18 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
         },
         status: %Schema{
           type: :string,
-          nullable: true,
-          enum: ["excluded_by_policy"],
+          enum: ["executed", "excluded"],
           description:
-            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+            "Status of this agent's result for the check. `executed` means the check ran normally for this agent. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
         },
         exclude_expression: %Schema{
           type: :string,
           nullable: true,
           description:
-            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded`."
         }
       },
-      required: [:agent_id, :facts, :expectation_evaluations],
+      required: [:agent_id, :facts, :expectation_evaluations, :status],
       example: %{
         agent_id: "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
         facts: [%{check_id: "156F64", name: "node_count", value: 3}],
@@ -78,7 +77,8 @@ defmodule WandaWeb.Schemas.V1.Execution.AgentCheckResult do
             type: "expect",
             return_value: true
           }
-        ]
+        ],
+        status: "executed"
       }
     },
     struct?: false

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -52,6 +52,19 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
           },
           description:
             "An array containing the results of each expectation evaluation performed for the agent during the check execution."
+        },
+        status: %Schema{
+          type: :string,
+          nullable: true,
+          enum: ["excluded_by_policy"],
+          description:
+            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+        },
+        exclude_expression: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
         }
       },
       required: [:agent_id, :facts, :expectation_evaluations],

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -55,19 +55,18 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
         },
         status: %Schema{
           type: :string,
-          nullable: true,
-          enum: ["excluded_by_policy"],
+          enum: ["executed", "excluded"],
           description:
-            "Status of this agent's result for the check. When null, the check was actually executed. When `excluded_by_policy`, the agent was excluded from this check by the check's `exclude` predicate."
+            "Status of this agent's result for the check. `executed` means the check ran normally for this agent. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
         },
         exclude_expression: %Schema{
           type: :string,
           nullable: true,
           description:
-            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded_by_policy`."
+            "The Rhai expression from the check's `exclude` field that evaluated to true and caused this agent to be excluded. Only set when `status` is `excluded`."
         }
       },
-      required: [:agent_id, :facts, :expectation_evaluations],
+      required: [:agent_id, :facts, :expectation_evaluations, :status],
       example: %{
         agent_id: "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
         facts: [%{check_id: "156F64", name: "node_count", value: 3}],
@@ -80,7 +79,8 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
             type: "expect",
             return_value: true
           }
-        ]
+        ],
+        status: "executed"
       }
     },
     struct?: false

--- a/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
+++ b/lib/wanda_web/schemas/v2/execution/agent_check_result.ex
@@ -14,6 +14,7 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
 
   alias WandaWeb.Schemas.V2.Execution.ExpectationEvaluation
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
   require OpenApiSpex
 
   OpenApiSpex.schema(
@@ -55,9 +56,9 @@ defmodule WandaWeb.Schemas.V2.Execution.AgentCheckResult do
         },
         status: %Schema{
           type: :string,
-          enum: ["executed", "excluded"],
+          enum: AgentCheckStatus.values(),
           description:
-            "Status of this agent's result for the check. `executed` means the check ran normally for this agent. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
+            "Status of this agent's check execution. `executed` means the check ran normally. `excluded` means the agent was excluded from this check by the check's `exclude` predicate."
         },
         exclude_expression: %Schema{
           type: :string,

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Wanda.MixProject do
       {:trento_contracts,
        github: "trento-project/contracts",
        sparse: "elixir",
-       ref: "69a5241e3065ebf91af02acd7d3c9c00d01407c7"},
+       ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"},
       {:unplug, "~> 1.1.0"},
       # test deps
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Wanda.MixProject do
       {:trento_contracts,
        github: "trento-project/contracts",
        sparse: "elixir",
-       ref: "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee"},
+       ref: "af252ccb0e64234d65e0581043996b6574687fc8"},
       {:unplug, "~> 1.1.0"},
       # test deps
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Wanda.MixProject do
       {:trento_contracts,
        github: "trento-project/contracts",
        sparse: "elixir",
-       ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"},
+       ref: "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee"},
       {:unplug, "~> 1.1.0"},
       # test deps
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -66,7 +66,7 @@
   "telemetry_poller": {:hex, :telemetry_poller, "1.3.0", "d5c46420126b5ac2d72bc6580fb4f537d35e851cc0f8dbd571acf6d6e10f5ec7", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "51f18bed7128544a50f75897db9974436ea9bfba560420b646af27a9a9b35211"},
   "thoas": {:hex, :thoas, "1.2.1", "19a25f31177a17e74004d4840f66d791d4298c5738790fa2cc73731eb911f195", [:rebar3], [], "hexpm", "e38697edffd6e91bd12cea41b155115282630075c2a727e7a6b2947f5408b86a"},
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "69a5241e3065ebf91af02acd7d3c9c00d01407c7", [sparse: "elixir", ref: "69a5241e3065ebf91af02acd7d3c9c00d01407c7"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "2d0c53202ad364964ea4965445e10ebeeaa70da0", [sparse: "elixir", ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"]},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
   "unplug": {:hex, :unplug, "1.1.0", "acd8c40dfda63a831b01534307c8cc44726389429294a5ed44d7f89fb01ccd02", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "a3b302125ed60b658a9a7c0dff6941050bfc56dc77a0bca72facdb743159898f"},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},

--- a/mix.lock
+++ b/mix.lock
@@ -66,7 +66,7 @@
   "telemetry_poller": {:hex, :telemetry_poller, "1.3.0", "d5c46420126b5ac2d72bc6580fb4f537d35e851cc0f8dbd571acf6d6e10f5ec7", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "51f18bed7128544a50f75897db9974436ea9bfba560420b646af27a9a9b35211"},
   "thoas": {:hex, :thoas, "1.2.1", "19a25f31177a17e74004d4840f66d791d4298c5738790fa2cc73731eb911f195", [:rebar3], [], "hexpm", "e38697edffd6e91bd12cea41b155115282630075c2a727e7a6b2947f5408b86a"},
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "2d0c53202ad364964ea4965445e10ebeeaa70da0", [sparse: "elixir", ref: "2d0c53202ad364964ea4965445e10ebeeaa70da0"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee", [sparse: "elixir", ref: "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee"]},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
   "unplug": {:hex, :unplug, "1.1.0", "acd8c40dfda63a831b01534307c8cc44726389429294a5ed44d7f89fb01ccd02", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "a3b302125ed60b658a9a7c0dff6941050bfc56dc77a0bca72facdb743159898f"},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},

--- a/mix.lock
+++ b/mix.lock
@@ -66,7 +66,7 @@
   "telemetry_poller": {:hex, :telemetry_poller, "1.3.0", "d5c46420126b5ac2d72bc6580fb4f537d35e851cc0f8dbd571acf6d6e10f5ec7", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "51f18bed7128544a50f75897db9974436ea9bfba560420b646af27a9a9b35211"},
   "thoas": {:hex, :thoas, "1.2.1", "19a25f31177a17e74004d4840f66d791d4298c5738790fa2cc73731eb911f195", [:rebar3], [], "hexpm", "e38697edffd6e91bd12cea41b155115282630075c2a727e7a6b2947f5408b86a"},
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
-  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee", [sparse: "elixir", ref: "f3c137c0d92e8d4f49d24604fcdadb6d0091f8ee"]},
+  "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "af252ccb0e64234d65e0581043996b6574687fc8", [sparse: "elixir", ref: "af252ccb0e64234d65e0581043996b6574687fc8"]},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
   "unplug": {:hex, :unplug, "1.1.0", "acd8c40dfda63a831b01534307c8cc44726389429294a5ed44d7f89fb01ccd02", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "a3b302125ed60b658a9a7c0dff6941050bfc56dc77a0bca72facdb743159898f"},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},

--- a/test/fixtures/catalog/exclude_check.yaml
+++ b/test/fixtures/catalog/exclude_check.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+id: exclude_check
+name: Exclude test check
+group: Test
+description: |
+  A check with an exclude predicate
+remediation: |
+  ## Remediation
+  Remediation text
+exclude: host.any_attribute == "excluding_value"
+facts:
+  - name: jedi
+    gatherer: wandalorian
+    argument: -o
+expectations:
+  - name: some_expectation
+    expect: facts.jedi == true

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -106,7 +106,7 @@ defmodule Wanda.Factory do
     %Target{
       agent_id: UUID.uuid4(),
       checks: random_checks(),
-      host_data: %{}
+      attributes: %{}
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,7 +14,6 @@ defmodule Wanda.Factory do
     AgentCheckResult,
     CheckResult,
     Execution,
-    ExcludedCheckResult,
     ExpectationEvaluation,
     ExpectationEvaluationError,
     ExpectationResult,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule Wanda.Factory do
     AgentCheckResult,
     CheckResult,
     Execution,
+    ExcludedCheckResult,
     ExpectationEvaluation,
     ExpectationEvaluationError,
     ExpectationResult,
@@ -62,6 +63,7 @@ defmodule Wanda.Factory do
       values: build_list(10, :catalog_value),
       expectations: build_list(10, :catalog_expectation),
       when: Faker.Lorem.sentence(),
+      exclude: nil,
       customization_disabled: Enum.random([false, true])
     }
   end
@@ -103,7 +105,8 @@ defmodule Wanda.Factory do
   def target_factory do
     %Target{
       agent_id: UUID.uuid4(),
-      checks: random_checks()
+      checks: random_checks(),
+      host_data: %{}
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -38,6 +38,7 @@ defmodule Wanda.Factory do
 
   require Wanda.Catalog.Enums.ExpectType, as: ExpectType
   require Wanda.Catalog.Enums.Severity, as: Severity
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
   require Wanda.Executions.Enums.Result, as: ExecutionResult
   require Wanda.Executions.Enums.Status, as: ExecutionStatus
   require Wanda.Operations.Enums.Result, as: OpeartionResult
@@ -173,6 +174,7 @@ defmodule Wanda.Factory do
   def agent_check_result_factory do
     %AgentCheckResult{
       agent_id: UUID.uuid4(),
+      status: AgentCheckStatus.executed(),
       facts: build_list(2, :fact),
       expectation_evaluations: build_list(2, :expectation_evaluation)
     }

--- a/test/wanda/catalog_test.exs
+++ b/test/wanda/catalog_test.exs
@@ -242,7 +242,7 @@ defmodule Wanda.CatalogTest do
           "id" => "mixed_values_customizability"
         })
 
-      assert length(selectable_checks) == 10
+      assert length(selectable_checks) == 11
 
       refute Enum.any?(selectable_checks, & &1.customized)
 
@@ -327,7 +327,7 @@ defmodule Wanda.CatalogTest do
             "some_key" => "some_value"
           })
 
-        assert length(selectable_checks) == 10
+        assert length(selectable_checks) == 11
 
         Enum.each(
           selectable_checks,

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -21,6 +21,8 @@ defmodule Wanda.Executions.EvaluationTest do
     Value
   }
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
+
   setup do
     engine = EvaluationEngine.new()
 
@@ -64,6 +66,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -75,6 +78,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -149,6 +153,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -160,6 +165,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^incorrect_facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -229,6 +235,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -302,6 +309,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -313,6 +321,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -387,6 +396,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -398,6 +408,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -468,6 +479,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    agents_check_results: [
                      _,
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluationError{
@@ -528,6 +540,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    check_id: ^check_id,
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluationError{
@@ -537,6 +550,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        ]
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluationError{
@@ -888,6 +902,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    result: :critical,
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        expectation_evaluations: [
                          %ExpectationEvaluation{
                            name: "some_expectation",
@@ -994,6 +1009,7 @@ defmodule Wanda.Executions.EvaluationTest do
                      result: ^return_value,
                      agents_check_results: [
                        %AgentCheckResult{
+                         status: AgentCheckStatus.executed(),
                          expectation_evaluations: [
                            %ExpectationEvaluation{
                              name: "some_expectation",
@@ -1071,6 +1087,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    result: :passing,
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        expectation_evaluations: [
                          %ExpectationEvaluation{
                            name: "some_expectation",
@@ -1221,6 +1238,7 @@ defmodule Wanda.Executions.EvaluationTest do
             customized: false,
             agents_check_results: [
               %AgentCheckResult{
+                status: AgentCheckStatus.executed(),
                 agent_id: "agent_1",
                 expectation_evaluations: [
                   %ExpectationEvaluation{
@@ -1245,6 +1263,7 @@ defmodule Wanda.Executions.EvaluationTest do
                 ]
               },
               %AgentCheckResult{
+                status: AgentCheckStatus.executed(),
                 agent_id: "agent_2",
                 expectation_evaluations: [
                   %ExpectationEvaluation{
@@ -1334,6 +1353,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1354,6 +1374,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        ]
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1414,6 +1435,7 @@ defmodule Wanda.Executions.EvaluationTest do
             customized: false,
             agents_check_results: [
               %AgentCheckResult{
+                status: AgentCheckStatus.executed(),
                 agent_id: "agent_1",
                 expectation_evaluations: [
                   %ExpectationEvaluation{
@@ -1434,6 +1456,7 @@ defmodule Wanda.Executions.EvaluationTest do
                 ]
               },
               %AgentCheckResult{
+                status: AgentCheckStatus.executed(),
                 agent_id: "agent_2",
                 expectation_evaluations: [
                   %ExpectationEvaluation{
@@ -1543,6 +1566,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1563,6 +1587,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        ]
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1651,6 +1676,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1663,6 +1689,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^incorrect_facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1742,6 +1769,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1753,6 +1781,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1921,6 +1950,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %CheckResult{
                    agents_check_results: [
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_1",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -1933,6 +1963,7 @@ defmodule Wanda.Executions.EvaluationTest do
                        facts: ^incorrect_facts
                      },
                      %AgentCheckResult{
+                       status: AgentCheckStatus.executed(),
                        agent_id: "agent_2",
                        expectation_evaluations: [
                          %ExpectationEvaluation{
@@ -2084,6 +2115,7 @@ defmodule Wanda.Executions.EvaluationTest do
                      customized: true,
                      agents_check_results: [
                        %AgentCheckResult{
+                         status: AgentCheckStatus.executed(),
                          agent_id: "agent_1",
                          expectation_evaluations: [
                            %ExpectationEvaluation{
@@ -2131,6 +2163,7 @@ defmodule Wanda.Executions.EvaluationTest do
                          ]
                        },
                        %AgentCheckResult{
+                         status: AgentCheckStatus.executed(),
                          agent_id: "agent_2",
                          expectation_evaluations: [
                            %ExpectationEvaluation{

--- a/test/wanda/executions/evaluation_test.exs
+++ b/test/wanda/executions/evaluation_test.exs
@@ -102,7 +102,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :passing
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result when not all the agents fullfill the expectations with an expect condition",
@@ -189,7 +190,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result when some agent gets fact gathering errors", %{
@@ -265,7 +267,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a passing result when all the agents fullfill the expectations with an expect_same condition",
@@ -345,7 +348,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :passing
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result when some of the agents expect_same condition return value is different",
@@ -432,7 +436,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result if a fact is missing from the agent fact gathering", %{
@@ -499,7 +504,8 @@ defmodule Wanda.Executions.EvaluationTest do
                    ]
                  }
                ]
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result if an illegal expression was specified in a check expectation",
@@ -569,7 +575,8 @@ defmodule Wanda.Executions.EvaluationTest do
                    ]
                  }
                ]
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result if an agent times out", %{engine: engine} do
@@ -633,7 +640,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return warning result if the check severity is specified as warning", %{
@@ -675,7 +683,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :warning
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a critical result if an agent times out and severity is warning", %{
@@ -718,7 +727,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
   end
 
@@ -861,6 +871,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    checks,
                    gathered_facts,
                    %{},
+                   [],
                    engine
                  )
       end)
@@ -923,7 +934,15 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ]
              } =
-               Evaluation.execute(UUID.uuid4(), UUID.uuid4(), checks, gathered_facts, %{}, engine)
+               Evaluation.execute(
+                 UUID.uuid4(),
+                 UUID.uuid4(),
+                 checks,
+                 gathered_facts,
+                 %{},
+                 [],
+                 engine
+               )
     end
 
     test "should interpolate the correct failure message", %{engine: engine} do
@@ -1036,6 +1055,7 @@ defmodule Wanda.Executions.EvaluationTest do
                    checks,
                    gathered_facts,
                    %{},
+                   [],
                    engine
                  )
       end)
@@ -1117,7 +1137,15 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ]
              } =
-               Evaluation.execute(UUID.uuid4(), UUID.uuid4(), checks, gathered_facts, %{}, engine)
+               Evaluation.execute(
+                 UUID.uuid4(),
+                 UUID.uuid4(),
+                 checks,
+                 gathered_facts,
+                 %{},
+                 [],
+                 engine
+               )
     end
   end
 
@@ -1170,7 +1198,15 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ]
              } =
-               Evaluation.execute(UUID.uuid4(), UUID.uuid4(), checks, gathered_facts, %{}, engine)
+               Evaluation.execute(
+                 UUID.uuid4(),
+                 UUID.uuid4(),
+                 checks,
+                 gathered_facts,
+                 %{},
+                 [],
+                 engine
+               )
     end
   end
 
@@ -1312,6 +1348,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "some_env" => "whoa"
                  },
+                 [],
                  engine
                )
 
@@ -1324,6 +1361,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "some_env" => "yeah"
                  },
+                 [],
                  engine
                )
     end
@@ -1408,7 +1446,8 @@ defmodule Wanda.Executions.EvaluationTest do
                ],
                result: :passing,
                timeout: []
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, [], engine)
     end
 
     test "should return a passing result based on the default value when environmental condition does not match",
@@ -1501,6 +1540,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "some_value" => "unrecognized"
                  },
+                 [],
                  engine
                )
 
@@ -1513,6 +1553,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "some_value" => nil
                  },
+                 [],
                  engine
                )
 
@@ -1525,6 +1566,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "some_value" => ""
                  },
+                 [],
                  engine
                )
 
@@ -1537,6 +1579,7 @@ defmodule Wanda.Executions.EvaluationTest do
                  %{
                    "unrecognized_value" => "some"
                  },
+                 [],
                  engine
                )
     end
@@ -1620,7 +1663,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, env, [], engine)
     end
   end
 
@@ -1714,7 +1758,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a failure message inside the result when having a failing expect_same", %{
@@ -1806,7 +1851,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return the default failure message inside the result when having a failing expect_same",
@@ -1897,7 +1943,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
 
     test "should return a default failure message in case of an erroring interpolation", %{
@@ -1988,7 +2035,8 @@ defmodule Wanda.Executions.EvaluationTest do
                  }
                ],
                result: :critical
-             } = Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, engine)
+             } =
+               Evaluation.execute(execution_id, group_id, checks, gathered_facts, %{}, [], engine)
     end
   end
 
@@ -2244,9 +2292,205 @@ defmodule Wanda.Executions.EvaluationTest do
                    checks,
                    gathered_facts,
                    env,
+                   [],
                    engine
                  )
       end
+    end
+  end
+
+  describe "exclusion handling in evaluation" do
+    test "should append excluded agents after executed agents in agents_check_results", %{
+      engine: engine
+    } do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      expectations =
+        build_list(1, :catalog_expectation,
+          name: "expectation",
+          expression: "facts.#{fact_name} == true"
+        )
+
+      checks =
+        build_list(1, :selected_check,
+          spec:
+            build(:check,
+              facts: catalog_facts,
+              expectations: expectations,
+              values: []
+            )
+        )
+
+      [%{id: check_id}] = checks
+
+      # Two agents provide facts
+      gathered_facts = %{
+        check_id => %{
+          "agent_1" => [%Fact{check_id: check_id, name: fact_name, value: true}],
+          "agent_2" => [%Fact{check_id: check_id, name: fact_name, value: true}]
+        }
+      }
+
+      # One agent is excluded
+      excluded_checks = [
+        %Wanda.Executions.ExcludedCheckResult{
+          check_id: check_id,
+          agent_id: "agent_3",
+          status: :excluded,
+          exclude_expression: "host.cluster_type == 'ascs_ers'"
+        }
+      ]
+
+      result =
+        Evaluation.execute(
+          execution_id,
+          group_id,
+          checks,
+          gathered_facts,
+          %{},
+          excluded_checks,
+          [],
+          engine
+        )
+
+      assert %Result{
+               check_results: [
+                 %CheckResult{
+                   agents_check_results: [
+                     %AgentCheckResult{agent_id: "agent_1", status: :executed},
+                     %AgentCheckResult{agent_id: "agent_2", status: :executed},
+                     %AgentCheckResult{agent_id: "agent_3", status: :excluded}
+                   ]
+                 }
+               ]
+             } = result
+    end
+
+    test "should handle multiple excluded agents for the same check", %{engine: engine} do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      checks =
+        build_list(1, :selected_check,
+          spec: build(:check, facts: [], expectations: [], values: [])
+        )
+
+      [%{id: check_id}] = checks
+
+      gathered_facts = %{}
+
+      # Three agents excluded with different expressions
+      excluded_checks = [
+        %Wanda.Executions.ExcludedCheckResult{
+          check_id: check_id,
+          agent_id: "agent_1",
+          status: :excluded,
+          exclude_expression: "host.provider == 'azure'"
+        },
+        %Wanda.Executions.ExcludedCheckResult{
+          check_id: check_id,
+          agent_id: "agent_2",
+          status: :excluded,
+          exclude_expression: "host.provider == 'gcp'"
+        },
+        %Wanda.Executions.ExcludedCheckResult{
+          check_id: check_id,
+          agent_id: "agent_3",
+          status: :excluded,
+          exclude_expression: "host.cluster_type == 'hana_scale_up'"
+        }
+      ]
+
+      result =
+        Evaluation.execute(
+          execution_id,
+          group_id,
+          checks,
+          gathered_facts,
+          %{},
+          excluded_checks,
+          [],
+          engine
+        )
+
+      assert %Result{
+               check_results: [
+                 %CheckResult{
+                   agents_check_results: [
+                     %AgentCheckResult{
+                       status: :excluded,
+                       exclude_expression: "host.provider == 'azure'"
+                     },
+                     %AgentCheckResult{
+                       status: :excluded,
+                       exclude_expression: "host.provider == 'gcp'"
+                     },
+                     %AgentCheckResult{
+                       status: :excluded,
+                       exclude_expression: "host.cluster_type == 'hana_scale_up'"
+                     }
+                   ]
+                 }
+               ]
+             } = result
+    end
+
+    test "should set result to passing for fully excluded check regardless of severity", %{
+      engine: engine
+    } do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      # Create a check with critical severity
+      checks =
+        build_list(1, :selected_check,
+          spec:
+            build(:check,
+              severity: :critical,
+              facts: [],
+              expectations: [],
+              values: []
+            )
+        )
+
+      [%{id: check_id}] = checks
+
+      gathered_facts = %{}
+
+      excluded_checks = [
+        %Wanda.Executions.ExcludedCheckResult{
+          check_id: check_id,
+          agent_id: "agent_1",
+          status: :excluded,
+          exclude_expression: "host.provider == 'azure'"
+        }
+      ]
+
+      result =
+        Evaluation.execute(
+          execution_id,
+          group_id,
+          checks,
+          gathered_facts,
+          %{},
+          excluded_checks,
+          [],
+          engine
+        )
+
+      # Despite critical severity, fully excluded check should be passing
+      assert %Result{
+               result: :passing,
+               check_results: [
+                 %CheckResult{
+                   check_id: ^check_id,
+                   result: :passing
+                 }
+               ]
+             } = result
     end
   end
 end

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -367,7 +367,7 @@ defmodule Wanda.Executions.ServerTest do
         )
       ]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
         Publisher, "agents", %FactsGatheringRequested{targets: gathering_targets}, _ ->
           send(pid, {:gathering_targets, gathering_targets})
           :ok
@@ -387,7 +387,6 @@ defmodule Wanda.Executions.ServerTest do
     end
 
     test "excluded pairs are recorded with excluded_by_policy status" do
-      pid = self()
       group_id = UUID.uuid4()
 
       aws_agent = UUID.uuid4()
@@ -406,7 +405,7 @@ defmodule Wanda.Executions.ServerTest do
         )
       ]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
 
       assert :ok = Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
 
@@ -498,7 +497,7 @@ defmodule Wanda.Executions.ServerTest do
         build(:target, checks: [spec.id], attributes: %{"any_attribute" => "excluding_value"})
       ]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
 
       start_supervised!(
         {Server,
@@ -541,7 +540,7 @@ defmodule Wanda.Executions.ServerTest do
 
       targets = [build(:target, checks: [spec.id], attributes: %{})]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
 
       start_supervised!(
         {Server,
@@ -584,7 +583,7 @@ defmodule Wanda.Executions.ServerTest do
       # empty attributes simulates old web version with no attributes
       targets = [build(:target, checks: [spec.id], attributes: %{})]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
 
       start_supervised!(
         {Server,

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -323,8 +323,14 @@ defmodule Wanda.Executions.ServerTest do
       group_id = UUID.uuid4()
 
       targets = [
-        build(:target, checks: ["expect_check"], host_data: %{"provider" => "aws"}),
-        build(:target, checks: ["expect_check"], host_data: %{"provider" => "azure"})
+        build(:target,
+          checks: ["expect_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        ),
+        build(:target,
+          checks: ["expect_check"],
+          attributes: %{"any_attribute" => "including_value"}
+        )
       ]
 
       assert :ok =
@@ -350,9 +356,9 @@ defmodule Wanda.Executions.ServerTest do
 
       targets = [
         build(:target, agent_id: aws_agent, checks: ["exclude_check"],
-          host_data: %{"provider" => "aws"}),
+          attributes: %{"provider" => "aws"}),
         build(:target, agent_id: azure_agent, checks: ["exclude_check"],
-          host_data: %{"provider" => "azure"})
+          attributes: %{"provider" => "azure"})
       ]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn
@@ -383,9 +389,9 @@ defmodule Wanda.Executions.ServerTest do
 
       targets = [
         build(:target, agent_id: aws_agent, checks: ["exclude_check"],
-          host_data: %{"provider" => "aws"}),
+          attributes: %{"provider" => "aws"}),
         build(:target, agent_id: azure_agent, checks: ["exclude_check"],
-          host_data: %{"provider" => "azure"})
+          attributes: %{"provider" => "azure"})
       ]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
@@ -415,8 +421,14 @@ defmodule Wanda.Executions.ServerTest do
       execution_id = UUID.uuid4()
 
       targets = [
-        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"}),
-        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"})
+        build(:target,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        ),
+        build(:target,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        )
       ]
 
       # Expect execution_started + execution_completed (no agents gathering)
@@ -470,7 +482,9 @@ defmodule Wanda.Executions.ServerTest do
 
       selected_check = build(:selected_check, spec: spec)
 
-      targets = [build(:target, checks: [spec.id], host_data: %{"provider" => "aws"})]
+      targets = [
+        build(:target, checks: [spec.id], attributes: %{"any_attribute" => "excluding_value"})
+      ]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
 
@@ -513,7 +527,7 @@ defmodule Wanda.Executions.ServerTest do
 
       selected_check = build(:selected_check, spec: spec)
 
-      targets = [build(:target, checks: [spec.id], host_data: %{})]
+      targets = [build(:target, checks: [spec.id], attributes: %{})]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
 
@@ -538,7 +552,7 @@ defmodule Wanda.Executions.ServerTest do
     end
 
     @tag capture_log: true
-    test "exclude predicate on empty host_data keeps the pair (backwards compatibility)" do
+    test "exclude predicate on empty attributes keeps the pair (backwards compatibility)" do
       group_id = UUID.uuid4()
 
       [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
@@ -555,8 +569,8 @@ defmodule Wanda.Executions.ServerTest do
 
       selected_check = build(:selected_check, spec: spec)
 
-      # empty host_data simulates old web version with no host_data
-      targets = [build(:target, checks: [spec.id], host_data: %{})]
+      # empty attributes simulates old web version with no attributes
+      targets = [build(:target, checks: [spec.id], attributes: %{})]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
 

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -317,4 +317,317 @@ defmodule Wanda.Executions.ServerTest do
       assert actual_targets == expected_targets
     end
   end
+
+  describe "exclusion predicates" do
+    test "check without exclude field keeps all targets" do
+      group_id = UUID.uuid4()
+
+      targets = [
+        build(:target, checks: ["expect_check"], host_data: %{"provider" => "aws"}),
+        build(:target, checks: ["expect_check"], host_data: %{"provider" => "azure"})
+      ]
+
+      assert :ok =
+               Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
+
+      pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(pid)
+
+      assert length(active_targets) == 2
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    test "check with exclude returning true removes target from gathering" do
+      pid = self()
+      group_id = UUID.uuid4()
+      execution_id = UUID.uuid4()
+
+      # exclude_check has `exclude: host.any_attribute == "excluding_value"`
+      aws_agent = UUID.uuid4()
+      azure_agent = UUID.uuid4()
+
+      targets = [
+        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "aws"}),
+        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "azure"})
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn
+        Publisher, "agents", %FactsGatheringRequested{targets: gathering_targets}, _ ->
+          send(pid, {:gathering_targets, gathering_targets})
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      assert :ok = Server.start_execution(execution_id, group_id, targets, "cluster", %{})
+
+      assert_receive {:gathering_targets, gathering_targets}
+
+      # Only azure agent should receive gathering request
+      assert [%{agent_id: ^azure_agent}] = gathering_targets
+
+      stop_supervised(Server)
+    end
+
+    test "excluded pairs are recorded with excluded_by_policy status" do
+      pid = self()
+      group_id = UUID.uuid4()
+
+      aws_agent = UUID.uuid4()
+      azure_agent = UUID.uuid4()
+
+      targets = [
+        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "aws"}),
+        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
+          host_data: %{"provider" => "azure"})
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      assert :ok = Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
+
+      # Wait for handle_continue to run
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      assert [
+               %Wanda.Executions.ExcludedCheckResult{
+                 check_id: "exclude_check",
+                 agent_id: ^aws_agent,
+                 status: :excluded_by_policy
+               }
+             ] = excluded
+
+      stop_supervised(Server)
+    end
+
+    test "all targets excluded completes execution immediately with excluded_by_policy entries" do
+      pid = self()
+      group_id = UUID.uuid4()
+      execution_id = UUID.uuid4()
+
+      targets = [
+        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"}),
+        build(:target, checks: ["exclude_check"], host_data: %{"provider" => "aws"})
+      ]
+
+      # Expect execution_started + execution_completed (no agents gathering)
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "results", %ExecutionCompleted{}, _ ->
+          send(pid, :completed)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      assert :ok = Server.start_execution(execution_id, group_id, targets, "cluster", %{})
+      assert_receive :completed, 500
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               status: :completed,
+               result: %{
+                 "check_results" => [
+                   %{
+                     "check_id" => "exclude_check",
+                     "agents_check_results" => [
+                       %{"agent_id" => _, "status" => "excluded_by_policy"},
+                       %{"agent_id" => _, "status" => "excluded_by_policy"}
+                     ]
+                   }
+                 ]
+               }
+             } = Repo.one!(Execution)
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate returning non-boolean keeps the pair and logs warning" do
+      group_id = UUID.uuid4()
+
+      # Build a check with an exclude expression that returns a non-boolean
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "42"
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      targets = [build(:target, checks: [spec.id], host_data: %{"provider" => "aws"})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      # Pair is kept when predicate returns non-boolean
+      assert length(active_targets) == 1
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate with syntax error keeps the pair and logs warning" do
+      group_id = UUID.uuid4()
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "this is not valid rhai !!!"
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      targets = [build(:target, checks: [spec.id], host_data: %{})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
+
+      assert length(active_targets) == 1
+      assert excluded == []
+
+      stop_supervised(Server)
+    end
+
+    @tag capture_log: true
+    test "exclude predicate on empty host_data keeps the pair (backwards compatibility)" do
+      group_id = UUID.uuid4()
+
+      [%Catalog.Fact{name: fact_name}] = catalog_facts = build_list(1, :catalog_fact)
+
+      spec =
+        build(:check,
+          facts: catalog_facts,
+          values: [],
+          expectations: [
+            build(:catalog_expectation, type: :expect, expression: "#{fact_name}")
+          ],
+          exclude: "host[\"provider\"] == \"aws\""
+        )
+
+      selected_check = build(:selected_check, spec: spec)
+
+      # empty host_data simulates old web version with no host_data
+      targets = [build(:target, checks: [spec.id], host_data: %{})]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)
+
+      start_supervised!(
+        {Server,
+         execution_id: UUID.uuid4(),
+         group_id: group_id,
+         targets: targets,
+         checks: [selected_check],
+         env: %{}}
+      )
+
+      :timer.sleep(50)
+
+      server_pid = :global.whereis_name({Server, group_id})
+      %{targets: active_targets} = :sys.get_state(server_pid)
+
+      assert length(active_targets) == 1
+
+      stop_supervised(Server)
+    end
+
+    test "regression: execution without exclude fields behaves identically to current behaviour",
+         context do
+      pid = self()
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      env = build(:env)
+
+      targets = build_list(3, :target, %{checks: [context[:check].id]})
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 3, fn
+        Publisher, "results", _, _ ->
+          send(pid, :executed)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      {:ok, server_pid} =
+        start_supervised(
+          {Server,
+           [
+             execution_id: execution_id,
+             group_id: group_id,
+             targets: targets,
+             checks: [context[:check]],
+             env: env
+           ]}
+        )
+
+      ref = Process.monitor(server_pid)
+
+      Enum.each(targets, fn target ->
+        Server.receive_facts(
+          execution_id,
+          group_id,
+          target.agent_id,
+          build_list(1, :fact, check_id: context[:check].id)
+        )
+      end)
+
+      assert_receive :executed
+      assert_receive {:DOWN, ^ref, _, ^server_pid, :normal}
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               status: :completed,
+               result: %{"excluded_checks" => []}
+             } = Repo.one!(Execution)
+    end
+  end
 end

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -355,10 +355,16 @@ defmodule Wanda.Executions.ServerTest do
       azure_agent = UUID.uuid4()
 
       targets = [
-        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
-          attributes: %{"provider" => "aws"}),
-        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
-          attributes: %{"provider" => "azure"})
+        build(:target,
+          agent_id: aws_agent,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        ),
+        build(:target,
+          agent_id: azure_agent,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "including_value"}
+        )
       ]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn
@@ -388,10 +394,16 @@ defmodule Wanda.Executions.ServerTest do
       azure_agent = UUID.uuid4()
 
       targets = [
-        build(:target, agent_id: aws_agent, checks: ["exclude_check"],
-          attributes: %{"provider" => "aws"}),
-        build(:target, agent_id: azure_agent, checks: ["exclude_check"],
-          attributes: %{"provider" => "azure"})
+        build(:target,
+          agent_id: aws_agent,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        ),
+        build(:target,
+          agent_id: azure_agent,
+          checks: ["exclude_check"],
+          attributes: %{"any_attribute" => "including_value"}
+        )
       ]
 
       expect(Wanda.Messaging.Adapters.Mock, :publish, fn _, _, _, _ -> :ok end)

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -384,7 +384,7 @@ defmodule Wanda.Executions.ServerTest do
       stop_supervised(Server)
     end
 
-    test "excluded pairs are recorded with excluded_by_policy status" do
+    test "excluded pairs are recorded with excluded status" do
       group_id = UUID.uuid4()
 
       aws_agent = UUID.uuid4()
@@ -428,14 +428,14 @@ defmodule Wanda.Executions.ServerTest do
                %Wanda.Executions.ExcludedCheckResult{
                  check_id: "exclude_check",
                  agent_id: ^aws_agent,
-                 status: :excluded_by_policy
+                 status: :excluded
                }
              ] = excluded
 
       stop_supervised(Server)
     end
 
-    test "all targets excluded completes execution immediately with excluded_by_policy entries" do
+    test "all targets excluded completes execution immediately with excluded entries" do
       pid = self()
       group_id = UUID.uuid4()
       execution_id = UUID.uuid4()
@@ -472,8 +472,8 @@ defmodule Wanda.Executions.ServerTest do
                    %{
                      "check_id" => "exclude_check",
                      "agents_check_results" => [
-                       %{"agent_id" => _, "status" => "excluded_by_policy"},
-                       %{"agent_id" => _, "status" => "excluded_by_policy"}
+                       %{"agent_id" => _, "status" => "excluded"},
+                       %{"agent_id" => _, "status" => "excluded"}
                      ]
                    }
                  ]
@@ -562,8 +562,8 @@ defmodule Wanda.Executions.ServerTest do
       # check.
       assert Enum.sort(Enum.map(agents_check_results, &{&1["agent_id"], &1["status"]})) ==
                Enum.sort([
-                 {aws_agent, "excluded_by_policy"},
-                 {azure_agent, "excluded_by_policy"}
+                 {aws_agent, "excluded"},
+                 {azure_agent, "excluded"}
                ])
 
       # Only the two selected checks should be in the result.

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -87,13 +87,16 @@ defmodule Wanda.Executions.ServerTest do
       group_id = UUID.uuid4()
       env = build(:env)
 
+      checks = build_list(10, :selected_check)
+      check_ids = Enum.map(checks, & &1.id)
+
       start_supervised!(
         {Server,
          [
            execution_id: execution_id,
            group_id: group_id,
-           targets: build_list(10, :target),
-           checks: build_list(10, :selected_check),
+           targets: build_list(10, :target, checks: check_ids),
+           checks: checks,
            env: env
          ]}
       )

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -20,8 +20,6 @@ defmodule Wanda.Executions.ServerTest do
 
   alias Wanda.Executions.Messaging.Publisher
 
-  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
-
   setup [:set_mox_from_context, :verify_on_exit!]
 
   setup_all do

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -240,8 +240,6 @@ defmodule Wanda.Executions.ServerTest do
 
       ref = Process.monitor(pid)
 
-      # TODO: test partial gathering of facts before sending the timeout signal
-
       Process.send(pid, :timeout, [:noconnect])
 
       assert_receive {:DOWN, ^ref, _, ^pid, :normal}
@@ -551,10 +549,11 @@ defmodule Wanda.Executions.ServerTest do
 
       # Every host of the cluster is reported as excluded by policy for this
       # check.
-      assert Enum.map(agents_check_results, &{&1["agent_id"], &1["status"]})
-             |> Enum.sort() ==
-               [{aws_agent, "excluded_by_policy"}, {azure_agent, "excluded_by_policy"}]
-               |> Enum.sort()
+      assert Enum.sort(Enum.map(agents_check_results, &{&1["agent_id"], &1["status"]})) ==
+               Enum.sort([
+                 {aws_agent, "excluded_by_policy"},
+                 {azure_agent, "excluded_by_policy"}
+               ])
 
       # Only the two selected checks should be in the result.
       assert MapSet.new(Map.keys(results_by_check)) ==

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -474,6 +474,93 @@ defmodule Wanda.Executions.ServerTest do
       stop_supervised(Server)
     end
 
+    test "a check excluded for all hosts still appears in the result when other checks run" do
+      pid = self()
+      group_id = UUID.uuid4()
+      execution_id = UUID.uuid4()
+
+      aws_agent = UUID.uuid4()
+      azure_agent = UUID.uuid4()
+
+      # Both targets select two checks. `exclude_check` is excluded for every
+      # host (attributes match its `exclude` predicate), while `check_without_values`
+      # has no `exclude` field and must still run. This forces the non-empty
+      # `active_targets` branch, where the bug used to silently drop the
+      # fully-excluded check from the final result.
+      targets = [
+        build(:target,
+          agent_id: aws_agent,
+          checks: ["check_without_values", "exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        ),
+        build(:target,
+          agent_id: azure_agent,
+          checks: ["check_without_values", "exclude_check"],
+          attributes: %{"any_attribute" => "excluding_value"}
+        )
+      ]
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 3, fn
+        Publisher, "agents", %FactsGatheringRequested{}, _ ->
+          :ok
+
+        Publisher, "results", %ExecutionStarted{}, _ ->
+          :ok
+
+        Publisher, "results", %ExecutionCompleted{}, _ ->
+          send(pid, :completed)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
+
+      assert :ok = Server.start_execution(execution_id, group_id, targets, "cluster", %{})
+
+      Enum.each([aws_agent, azure_agent], fn agent_id ->
+        Server.receive_facts(
+          execution_id,
+          group_id,
+          agent_id,
+          [build(:fact, check_id: "check_without_values", name: "jedi", value: "skywalker")]
+        )
+      end)
+
+      assert_receive :completed, 500
+
+      assert %Execution{
+               execution_id: ^execution_id,
+               status: :completed,
+               result: %{"check_results" => check_results}
+             } = Repo.one!(Execution)
+
+      results_by_check = Map.new(check_results, &{&1["check_id"], &1})
+
+      # The running check is still present and was actually evaluated.
+      assert %{"check_id" => "check_without_values"} =
+               Map.get(results_by_check, "check_without_values")
+
+      # The fully-excluded check must NOT be silently dropped: it appears as a
+      # passing result whose `agents_check_results` lists every host as
+      # excluded by policy.
+      assert %{
+               "check_id" => "exclude_check",
+               "result" => "passing",
+               "agents_check_results" => agents_check_results
+             } = Map.get(results_by_check, "exclude_check")
+
+      # Every host of the cluster is reported as excluded by policy for this
+      # check.
+      assert Enum.map(agents_check_results, &{&1["agent_id"], &1["status"]})
+             |> Enum.sort() ==
+               [{aws_agent, "excluded_by_policy"}, {azure_agent, "excluded_by_policy"}]
+               |> Enum.sort()
+
+      # Only the two selected checks should be in the result.
+      assert MapSet.new(Map.keys(results_by_check)) ==
+               MapSet.new(["check_without_values", "exclude_check"])
+    end
+
     @tag capture_log: true
     test "exclude predicate returning non-boolean keeps the pair and logs warning" do
       group_id = UUID.uuid4()

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -20,6 +20,8 @@ defmodule Wanda.Executions.ServerTest do
 
   alias Wanda.Executions.Messaging.Publisher
 
+  require Wanda.Executions.Enums.AgentCheckStatus, as: AgentCheckStatus
+
   setup [:set_mox_from_context, :verify_on_exit!]
 
   setup_all do
@@ -550,15 +552,15 @@ defmodule Wanda.Executions.ServerTest do
                Map.get(results_by_check, "check_without_values")
 
       # The fully-excluded check must NOT be silently dropped: it appears as a
-      # passing result whose `agents_check_results` lists every host as
-      # excluded by policy.
+      # passing result whose `agents_check_results` lists every host with
+      # excluded status.
       assert %{
                "check_id" => "exclude_check",
                "result" => "passing",
                "agents_check_results" => agents_check_results
              } = Map.get(results_by_check, "exclude_check")
 
-      # Every host of the cluster is reported as excluded by policy for this
+      # Every host of the cluster is reported with excluded status for this
       # check.
       assert Enum.sort(Enum.map(agents_check_results, &{&1["agent_id"], &1["status"]})) ==
                Enum.sort([

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -403,12 +403,23 @@ defmodule Wanda.Executions.ServerTest do
         )
       ]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
+      pid = self()
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "agents", %FactsGatheringRequested{}, _ ->
+          send(pid, :agents_published)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
 
       assert :ok = Server.start_execution(UUID.uuid4(), group_id, targets, "cluster", %{})
 
-      # Wait for handle_continue to run
-      :timer.sleep(50)
+      # Deterministically wait for handle_continue to finish evaluating
+      # exclusions and publish the facts-gathering request (the last action
+      # before the GenServer sets its state).
+      assert_receive :agents_published, 500
 
       server_pid = :global.whereis_name({Server, group_id})
       %{excluded_checks: excluded} = :sys.get_state(server_pid)
@@ -583,7 +594,16 @@ defmodule Wanda.Executions.ServerTest do
         build(:target, checks: [spec.id], attributes: %{"any_attribute" => "excluding_value"})
       ]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
+      pid = self()
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "agents", %FactsGatheringRequested{}, _ ->
+          send(pid, :agents_published)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
 
       start_supervised!(
         {Server,
@@ -594,7 +614,10 @@ defmodule Wanda.Executions.ServerTest do
          env: %{}}
       )
 
-      :timer.sleep(50)
+      # Deterministically wait for handle_continue to finish evaluating the
+      # exclude predicate and publish the facts-gathering request before
+      # asserting on the GenServer state.
+      assert_receive :agents_published, 500
 
       server_pid = :global.whereis_name({Server, group_id})
       %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
@@ -626,7 +649,16 @@ defmodule Wanda.Executions.ServerTest do
 
       targets = [build(:target, checks: [spec.id], attributes: %{})]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
+      pid = self()
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "agents", %FactsGatheringRequested{}, _ ->
+          send(pid, :agents_published)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
 
       start_supervised!(
         {Server,
@@ -637,7 +669,7 @@ defmodule Wanda.Executions.ServerTest do
          env: %{}}
       )
 
-      :timer.sleep(50)
+      assert_receive :agents_published, 500
 
       server_pid = :global.whereis_name({Server, group_id})
       %{targets: active_targets, excluded_checks: excluded} = :sys.get_state(server_pid)
@@ -669,7 +701,16 @@ defmodule Wanda.Executions.ServerTest do
       # empty attributes simulates old web version with no attributes
       targets = [build(:target, checks: [spec.id], attributes: %{})]
 
-      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn _, _, _, _ -> :ok end)
+      pid = self()
+
+      expect(Wanda.Messaging.Adapters.Mock, :publish, 2, fn
+        Publisher, "agents", %FactsGatheringRequested{}, _ ->
+          send(pid, :agents_published)
+          :ok
+
+        _, _, _, _ ->
+          :ok
+      end)
 
       start_supervised!(
         {Server,
@@ -680,7 +721,7 @@ defmodule Wanda.Executions.ServerTest do
          env: %{}}
       )
 
-      :timer.sleep(50)
+      assert_receive :agents_published, 500
 
       server_pid = :global.whereis_name({Server, group_id})
       %{targets: active_targets} = :sys.get_state(server_pid)

--- a/test/wanda/executions/server_test.exs
+++ b/test/wanda/executions/server_test.exs
@@ -738,7 +738,7 @@ defmodule Wanda.Executions.ServerTest do
       assert %Execution{
                execution_id: ^execution_id,
                status: :completed,
-               result: %{"excluded_checks" => []}
+               result: %{"check_results" => _}
              } = Repo.one!(Execution)
     end
   end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -693,4 +693,142 @@ defmodule Wanda.Messaging.MapperTest do
              } = Mapper.to_check_customization_reset(check_id, group_id, target_type)
     end
   end
+
+  describe "host_data unwrapping in from_execution_requested" do
+    test "unwraps string proto value to plain string" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{"provider" => %{kind: {:string_value, "aws"}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   agent_id: "agent_1",
+                   host_data: %{"provider" => "aws"}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps list proto value to list of plain strings" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{
+              "roles" => %{
+                kind:
+                  {:list_value,
+                   %{
+                     values: [
+                       %{kind: {:string_value, "primary"}},
+                       %{kind: {:string_value, "secondary"}}
+                     ]
+                   }}
+              }
+            }
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{"roles" => ["primary", "secondary"]}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps unknown proto value kind to empty string" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{"unknown" => %{kind: {:null_value, :NULL_VALUE}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{"unknown" => ""}
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "maps empty host_data to empty map (backwards compatibility)" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"]
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{host_data: %{}}
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps multiple host_data fields in a single target" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            host_data: %{
+              "provider" => %{kind: {:string_value, "azure"}},
+              "os_family" => %{kind: {:string_value, "suse"}},
+              "arch" => %{kind: {:string_value, "x86_64"}},
+              "roles" => %{
+                kind: {:list_value, %{values: [%{kind: {:string_value, "primary"}}]}}
+              }
+            }
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{
+                   host_data: %{
+                     "provider" => "azure",
+                     "os_family" => "suse",
+                     "arch" => "x86_64",
+                     "roles" => ["primary"]
+                   }
+                 }
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+  end
 end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -761,7 +761,7 @@ defmodule Wanda.Messaging.MapperTest do
           %{
             agent_id: "agent_1",
             checks: ["check_1"],
-            attributes: %{"unknown" => %{kind: {:null_value, :NULL_VALUE}}}
+            attributes: %{"unknown" => %{kind: nil}}
           }
         ],
         env: %{}

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -694,7 +694,7 @@ defmodule Wanda.Messaging.MapperTest do
     end
   end
 
-  describe "host_data unwrapping in from_execution_requested" do
+  describe "attributes unwrapping in from_execution_requested" do
     test "unwraps string proto value to plain string" do
       execution = %ExecutionRequested{
         execution_id: UUID.uuid4(),
@@ -703,7 +703,7 @@ defmodule Wanda.Messaging.MapperTest do
           %{
             agent_id: "agent_1",
             checks: ["check_1"],
-            host_data: %{"provider" => %{kind: {:string_value, "aws"}}}
+            attributes: %{"provider" => %{kind: {:string_value, "aws"}}}
           }
         ],
         env: %{}
@@ -713,7 +713,7 @@ defmodule Wanda.Messaging.MapperTest do
                targets: [
                  %Executions.Target{
                    agent_id: "agent_1",
-                   host_data: %{"provider" => "aws"}
+                   attributes: %{"provider" => "aws"}
                  }
                ]
              } = Mapper.from_execution_requested(execution)
@@ -727,7 +727,7 @@ defmodule Wanda.Messaging.MapperTest do
           %{
             agent_id: "agent_1",
             checks: ["check_1"],
-            host_data: %{
+            attributes: %{
               "roles" => %{
                 kind:
                   {:list_value,
@@ -747,7 +747,7 @@ defmodule Wanda.Messaging.MapperTest do
       assert %{
                targets: [
                  %Executions.Target{
-                   host_data: %{"roles" => ["primary", "secondary"]}
+                   attributes: %{"roles" => ["primary", "secondary"]}
                  }
                ]
              } = Mapper.from_execution_requested(execution)
@@ -761,7 +761,7 @@ defmodule Wanda.Messaging.MapperTest do
           %{
             agent_id: "agent_1",
             checks: ["check_1"],
-            host_data: %{"unknown" => %{kind: {:null_value, :NULL_VALUE}}}
+            attributes: %{"unknown" => %{kind: {:null_value, :NULL_VALUE}}}
           }
         ],
         env: %{}
@@ -770,13 +770,13 @@ defmodule Wanda.Messaging.MapperTest do
       assert %{
                targets: [
                  %Executions.Target{
-                   host_data: %{"unknown" => ""}
+                   attributes: %{"unknown" => ""}
                  }
                ]
              } = Mapper.from_execution_requested(execution)
     end
 
-    test "maps empty host_data to empty map (backwards compatibility)" do
+    test "maps empty attributes to empty map (backwards compatibility)" do
       execution = %ExecutionRequested{
         execution_id: UUID.uuid4(),
         group_id: UUID.uuid4(),
@@ -791,12 +791,12 @@ defmodule Wanda.Messaging.MapperTest do
 
       assert %{
                targets: [
-                 %Executions.Target{host_data: %{}}
+                 %Executions.Target{attributes: %{}}
                ]
              } = Mapper.from_execution_requested(execution)
     end
 
-    test "unwraps multiple host_data fields in a single target" do
+    test "unwraps multiple attributes fields in a single target" do
       execution = %ExecutionRequested{
         execution_id: UUID.uuid4(),
         group_id: UUID.uuid4(),
@@ -804,7 +804,7 @@ defmodule Wanda.Messaging.MapperTest do
           %{
             agent_id: "agent_1",
             checks: ["check_1"],
-            host_data: %{
+            attributes: %{
               "provider" => %{kind: {:string_value, "azure"}},
               "os_family" => %{kind: {:string_value, "suse"}},
               "arch" => %{kind: {:string_value, "x86_64"}},
@@ -820,7 +820,7 @@ defmodule Wanda.Messaging.MapperTest do
       assert %{
                targets: [
                  %Executions.Target{
-                   host_data: %{
+                   attributes: %{
                      "provider" => "azure",
                      "os_family" => "suse",
                      "arch" => "x86_64",

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -180,7 +180,36 @@ defmodule Wanda.Messaging.MapperTest do
         %{
           agent_id: "agent1",
           checks: ["check_1", "check_2"],
-          attributes: %{}
+          attributes: %{
+            some_string: %{
+              kind: {:string_value, "some_string"}
+            },
+            decimal_number: %{
+              kind: {:number_value, 10}
+            },
+            some_number: %{
+              kind: {:number_value, 10.0}
+            },
+            some_float: %{
+              kind: {:number_value, 10.5}
+            },
+            some_boolean: %{
+              kind: {:bool_value, true}
+            },
+            null: %{
+              kind: {:null_value}
+            },
+            some_list: %{
+              kind:
+                {:list_value,
+                 %{
+                   values: [
+                     %{kind: {:string_value, "first"}},
+                     %{kind: {:string_value, "second"}}
+                   ]
+                 }}
+            }
+          }
         },
         %{
           agent_id: "agent3",
@@ -210,11 +239,21 @@ defmodule Wanda.Messaging.MapperTest do
              targets: [
                %Executions.Target{
                  agent_id: "agent1",
-                 checks: ["check_1", "check_2"]
+                 checks: ["check_1", "check_2"],
+                 attributes: %{
+                   some_string: "some_string",
+                   some_number: 10,
+                   decimal_number: 10,
+                   some_float: 10.5,
+                   some_boolean: true,
+                   null: nil,
+                   some_list: ["first", "second"]
+                 }
                },
                %Executions.Target{
                  agent_id: "agent3",
-                 checks: ["check_3", "check_4"]
+                 checks: ["check_3", "check_4"],
+                 attributes: %{}
                }
              ],
              env: %{
@@ -693,190 +732,6 @@ defmodule Wanda.Messaging.MapperTest do
                group_id: ^group_id,
                target_type: ^target_type
              } = Mapper.to_check_customization_reset(check_id, group_id, target_type)
-    end
-  end
-
-  describe "attributes unwrapping in from_execution_requested" do
-    test "unwraps string proto value to plain string" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{"provider" => %{kind: {:string_value, "aws"}}}
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{
-                   agent_id: "agent_1",
-                   attributes: %{"provider" => "aws"}
-                 }
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "unwraps list proto value to list of plain strings" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{
-              "roles" => %{
-                kind:
-                  {:list_value,
-                   %{
-                     values: [
-                       %{kind: {:string_value, "primary"}},
-                       %{kind: {:string_value, "secondary"}}
-                     ]
-                   }}
-              }
-            }
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{
-                   attributes: %{"roles" => ["primary", "secondary"]}
-                 }
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "maps empty attributes to empty map (backwards compatibility)" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{}
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{attributes: %{}}
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "unwraps multiple attributes fields in a single target" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{
-              "provider" => %{kind: {:string_value, "azure"}},
-              "os_family" => %{kind: {:string_value, "suse"}},
-              "arch" => %{kind: {:string_value, "x86_64"}},
-              "roles" => %{
-                kind: {:list_value, %{values: [%{kind: {:string_value, "primary"}}]}}
-              }
-            }
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{
-                   attributes: %{
-                     "provider" => "azure",
-                     "os_family" => "suse",
-                     "arch" => "x86_64",
-                     "roles" => ["primary"]
-                   }
-                 }
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "unwraps whole-number proto value to integer (consistent with from_value/1)" do
-      # Whole numbers must arrive as integers, not floats, so that Rhai
-      # comparisons like `host.cpu_count == 42` behave as expected.
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{"cpu_count" => %{kind: {:number_value, 42.0}}}
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{attributes: %{"cpu_count" => 42}}
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "unwraps fractional number proto value as float" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{"load" => %{kind: {:number_value, 1.5}}}
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{attributes: %{"load" => 1.5}}
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
-    test "unwraps null proto values to nil (both null_value shapes)" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{
-              "a" => %{kind: {:null_value, nil}},
-              "b" => %{kind: {:null_value}}
-            }
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{attributes: %{"a" => nil, "b" => nil}}
-               ]
-             } = Mapper.from_execution_requested(execution)
     end
   end
 end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -830,5 +830,73 @@ defmodule Wanda.Messaging.MapperTest do
                ]
              } = Mapper.from_execution_requested(execution)
     end
+
+    test "unwraps whole-number proto value to integer (consistent with from_value/1)" do
+      # Whole numbers must arrive as integers, not floats, so that Rhai
+      # comparisons like `host.cpu_count == 42` behave as expected.
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            attributes: %{"cpu_count" => %{kind: {:number_value, 42.0}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{attributes: %{"cpu_count" => 42}}
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps fractional number proto value as float" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            attributes: %{"load" => %{kind: {:number_value, 1.5}}}
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{attributes: %{"load" => 1.5}}
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
+
+    test "unwraps null proto values to nil (both null_value shapes)" do
+      execution = %ExecutionRequested{
+        execution_id: UUID.uuid4(),
+        group_id: UUID.uuid4(),
+        targets: [
+          %{
+            agent_id: "agent_1",
+            checks: ["check_1"],
+            attributes: %{
+              "a" => %{kind: {:null_value, nil}},
+              "b" => %{kind: {:null_value}}
+            }
+          }
+        ],
+        env: %{}
+      }
+
+      assert %{
+               targets: [
+                 %Executions.Target{attributes: %{"a" => nil, "b" => nil}}
+               ]
+             } = Mapper.from_execution_requested(execution)
+    end
   end
 end

--- a/test/wanda/messaging/mapper_test.exs
+++ b/test/wanda/messaging/mapper_test.exs
@@ -179,11 +179,13 @@ defmodule Wanda.Messaging.MapperTest do
       targets: [
         %{
           agent_id: "agent1",
-          checks: ["check_1", "check_2"]
+          checks: ["check_1", "check_2"],
+          attributes: %{}
         },
         %{
           agent_id: "agent3",
-          checks: ["check_3", "check_4"]
+          checks: ["check_3", "check_4"],
+          attributes: %{}
         }
       ],
       env: %{
@@ -753,29 +755,6 @@ defmodule Wanda.Messaging.MapperTest do
              } = Mapper.from_execution_requested(execution)
     end
 
-    test "unwraps unknown proto value kind to empty string" do
-      execution = %ExecutionRequested{
-        execution_id: UUID.uuid4(),
-        group_id: UUID.uuid4(),
-        targets: [
-          %{
-            agent_id: "agent_1",
-            checks: ["check_1"],
-            attributes: %{"unknown" => %{kind: nil}}
-          }
-        ],
-        env: %{}
-      }
-
-      assert %{
-               targets: [
-                 %Executions.Target{
-                   attributes: %{"unknown" => ""}
-                 }
-               ]
-             } = Mapper.from_execution_requested(execution)
-    end
-
     test "maps empty attributes to empty map (backwards compatibility)" do
       execution = %ExecutionRequested{
         execution_id: UUID.uuid4(),
@@ -783,7 +762,8 @@ defmodule Wanda.Messaging.MapperTest do
         targets: [
           %{
             agent_id: "agent_1",
-            checks: ["check_1"]
+            checks: ["check_1"],
+            attributes: %{}
           }
         ],
         env: %{}

--- a/test/wanda/policy_test.exs
+++ b/test/wanda/policy_test.exs
@@ -44,7 +44,8 @@ defmodule Wanda.PolicyTest do
                                                              [
                                                                %Target{
                                                                  agent_id: ^agent_id,
-                                                                 checks: ["check_id"]
+                                                                 checks: ["check_id"],
+                                                                 attributes: %{}
                                                                }
                                                              ],
                                                              ^target_type,
@@ -59,7 +60,7 @@ defmodule Wanda.PolicyTest do
              Wanda.Policy.handle_event(%ExecutionRequested{
                execution_id: execution_id,
                group_id: group_id,
-               targets: [%{agent_id: agent_id, checks: ["check_id"]}],
+               targets: [%{agent_id: agent_id, checks: ["check_id"], attributes: %{}}],
                target_type: target_type,
                env: %{
                  "key" => %{kind: {:string_value, "value"}},

--- a/test/wanda_web/controllers/v1/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v1/catalog_controller_test.exs
@@ -41,6 +41,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
                "items" => [
                  %{"id" => "check_without_values"},
                  %{"id" => "customizable_check"},
+                 %{"id" => "exclude_check"},
                  %{"id" => "expect_check"},
                  %{"id" => "expect_enum_check"},
                  %{"id" => "expect_same_check"},
@@ -83,7 +84,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
         |> json_response(:ok)
         |> assert_schema("SelectableChecksResponseV1", api_spec)
 
-      assert length(selectable_checks) == 10
+      assert length(selectable_checks) == 11
       refute Enum.any?(selectable_checks, & &1.customized)
     end
 
@@ -126,7 +127,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
           |> json_response(:ok)
           |> assert_schema("SelectableChecksResponseV1", api_spec)
 
-        assert length(selectable_checks) == 10
+        assert length(selectable_checks) == 11
 
         assert selectable_checks
                |> Enum.filter(& &1.customized)
@@ -134,7 +135,7 @@ defmodule WandaWeb.V1.CatalogControllerTest do
 
         assert selectable_checks
                |> Enum.filter(&(not &1.customized))
-               |> length() == 9
+               |> length() == 10
 
         %{
           values: customized_check_values,

--- a/test/wanda_web/controllers/v2/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v2/catalog_controller_test.exs
@@ -30,6 +30,7 @@ defmodule WandaWeb.V2.CatalogControllerTest do
                "items" => [
                  %{"id" => "check_without_values"},
                  %{"id" => "customizable_check"},
+                 %{"id" => "exclude_check"},
                  %{"id" => "expect_check"},
                  %{"id" => "expect_enum_check"},
                  %{"id" => "expect_same_check"},
@@ -55,6 +56,7 @@ defmodule WandaWeb.V2.CatalogControllerTest do
                "items" => [
                  %{"id" => "check_without_values"},
                  %{"id" => "customizable_check"},
+                 %{"id" => "exclude_check"},
                  %{"id" => "expect_check"},
                  %{"id" => "expect_enum_check"},
                  %{"id" => "expect_same_check"},

--- a/test/wanda_web/controllers/v3/catalog_controller_test.exs
+++ b/test/wanda_web/controllers/v3/catalog_controller_test.exs
@@ -30,6 +30,7 @@ defmodule WandaWeb.V3.CatalogControllerTest do
                "items" => [
                  %{"id" => "check_without_values"},
                  %{"id" => "customizable_check"},
+                 %{"id" => "exclude_check"},
                  %{"id" => "expect_check"},
                  %{"id" => "expect_enum_check"},
                  %{"id" => "expect_same_check"},
@@ -55,6 +56,7 @@ defmodule WandaWeb.V3.CatalogControllerTest do
                "items" => [
                  %{"id" => "check_without_values"},
                  %{"id" => "customizable_check"},
+                 %{"id" => "exclude_check"},
                  %{"id" => "expect_check"},
                  %{"id" => "expect_enum_check"},
                  %{"id" => "expect_same_check"},


### PR DESCRIPTION
Following RFC https://github.com/trento-project/docs/pull/188

In this PR, an optional `exclude` predicate is evaluated before check execution to exclude. For agents for which the predicate verifies, the check is not evaluated against them and they are reported as "excluded by policy" in the check result.

Please note that the fact-gathering dispatch mechanism has not been touched, because it would have introduced a disruption too big to fit in the scope of these changes. It might be refined later.