### PR TITLE
Add `exclude` field to specification json schema

### DIFF
--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -18,7 +18,7 @@
     "when": {
       "type": "string"
     },
-    "excluded": {
+    "exclude": {
       "type": "string"
     },
     "metadata": {

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -202,13 +202,19 @@
       ],
       "oneOf": [
         {
-          "required": ["expect"]
+          "required": [
+            "expect"
+          ]
         },
         {
-          "required": ["expect_same"]
+          "required": [
+            "expect_same"
+          ]
         },
         {
-          "required": ["expect_enum"]
+          "required": [
+            "expect_enum"
+          ]
         }
       ]
     },

--- a/guides/check_definition.schema.json
+++ b/guides/check_definition.schema.json
@@ -18,6 +18,9 @@
     "when": {
       "type": "string"
     },
+    "excluded": {
+      "type": "string"
+    },
     "metadata": {
       "$ref": "#/definitions/Metadata"
     },

--- a/guides/specification.adoc
+++ b/guides/specification.adoc
@@ -157,7 +157,7 @@ yaml.
 
 |`+metadata+` |not required |link:#metadata[see more]
 
-|`+excluded+` |not required |link:#excluded[see more]
+|`+exclude+` |not required |link:#exclude[see more]
 
 |`+facts+` |required |link:#facts[see more]
 
@@ -378,7 +378,7 @@ metadata:
   qux: [foo, bar, baz]
 ----
 
-==== excluded
+==== exclude
 
 An expression used to exclude facts gathering process and evaluation from
 targets where the assertion is true.
@@ -387,7 +387,7 @@ Example:
 
 [source,yaml]
 ----
-excluded: host.is_majority_maker == true
+exclude: host.is_majority_maker == true
 ----
 
 Excludes fact gathering and evaluation from cluster hosts that act as

--- a/guides/specification.adoc
+++ b/guides/specification.adoc
@@ -157,6 +157,8 @@ yaml.
 
 |`+metadata+` |not required |link:#metadata[see more]
 
+|`+excluded+` |not required |link:#excluded[see more]
+
 |`+facts+` |required |link:#facts[see more]
 
 |`+customization_disabled+` |not required
@@ -375,6 +377,21 @@ metadata:
   baz: true
   qux: [foo, bar, baz]
 ----
+
+==== excluded
+
+An expression used to exclude facts gathering process and evaluation from
+targets where the assertion is true.
+
+Example:
+
+[source,yaml]
+----
+excluded: host.is_majority_maker == true
+----
+
+Excludes fact gathering and evaluation from cluster hosts that act as
+majority maker.
 
 ==== Facts, Values, Expectations
 


### PR DESCRIPTION
### Description

Add `exclude` field to specification json schema.
It is need for `tlint` to accept this new field in its validation.

I have documented the field as well.

### How was this tested?

No need

### Documentation changes

Done