### PR TITLE
Add runtime LOG_LEVEL option to change logging level

### DIFF
--- a/config/demo.exs
+++ b/config/demo.exs
@@ -8,7 +8,5 @@ config :wanda, WandaWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true
 
-config :logger, level: :debug
-
 config :wanda, Wanda.Executions.Server, facts_gathering_impl: Wanda.Executions.FactsGathering.Fake
 config :wanda, Wanda.Executions.FakeGatheredFacts, demo_facts_config: "priv/demo/fake_facts.yaml"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,9 +17,6 @@ config :wanda, WandaWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true
 
-# Do not print debug messages in production
-config :logger, level: :info
-
 amqp_connection = "amqp://wanda:wanda@localhost:5672"
 
 config :wanda, Wanda.Messaging.Adapters.AMQP,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -10,6 +10,18 @@ import Config
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
 if config_env() in [:prod, :demo] do
+  log_levels = ~w(debug info warning error)
+  log_level = System.get_env("LOG_LEVEL", "info")
+
+  if log_level not in log_levels do
+    raise """
+    environment variable LOG_LEVEL is invalid.
+    Valid values are: #{Enum.join(log_levels, ", ")}
+    """
+  end
+
+  config :logger, level: String.to_atom(log_level)
+
   database_url =
     System.get_env("DATABASE_URL") ||
       raise """

--- a/packaging/suse/rpm/systemd/trento-wanda.example
+++ b/packaging/suse/rpm/systemd/trento-wanda.example
@@ -1,3 +1,4 @@
+LOG_LEVEL=info
 CORS_ORIGIN=localhost
 SECRET_KEY_BASE=<secret-key-base>
 AMQP_URL=amqp://trento_user:trento_user_password@rabbitmq-host/vhost


### PR DESCRIPTION
### Description

Add runtime LOG_LEVEL option to change logging level.
Default values continues being `info`.
If the given value is wrong, the start process will fail with this error:
```
ERROR! Config provider Config.Reader failed with:
** (RuntimeError) environment variable LOG_LEVEL is invalid.
Valid values are: debug, info, warning, error
```

### How was this tested?

Manually