### PR TITLE
Make catalog_fact factory name value sequential

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -70,7 +70,7 @@ defmodule Wanda.Factory do
 
   def catalog_fact_factory do
     %Catalog.Fact{
-      name: Faker.Cat.name(),
+      name: sequence(:fact_name, &"fact_#{&1}"),
       gatherer: Faker.StarWars.character(),
       argument: Faker.StarWars.quote()
     }


### PR DESCRIPTION
### Description

Make `catalog_fact` factory `name` field sequential.
This fixes some annoying flaky tests that depend always on having different names.
Fact names should be different by nature (unless specifically we need to have the same ones, which we should explicitly set in the factory usage).

This fixes some annoying flaky tests, specially this one `test/wanda/executions/evaluation_test.exs:736`:
https://github.com/trento-project/wanda/actions/runs/31107950339/job/92640071542?pr=742

Before the change, the factory was using the `Cat` faker entry to create the fact name, with only 28 unique names, and getting the same value for both facts was making the test flaky:

```
[
    %Catalog.Fact{name: fact_1_name},
    %Catalog.Fact{name: fact_2_name}
] = catalog_facts = build_list(2, :catalog_fact)
```

PD: the other solution would be to simply change test `test/wanda/executions/evaluation_test.exs:736` to set 2 different fact names when the factory is used. We already do this in some tests.

### How was this tested?

UT

### Documentation changes

No