### PR TITLE
Adds explicit system env variable for ipv4/ ipv6 handling

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,14 +51,19 @@ if config_env() in [:prod, :demo] do
 
   port = String.to_integer(System.get_env("PORT") || "4000")
 
-  # Returns an IP address to bind the HTTP server, based on IPv6 support.
+  # Returns an IP address to bind the HTTP server, based on explicit operator choice
   # This prevents startup failures on systems without IPv6 where the app would crash
-  # Falls back to IPv4 `{0, 0, 0, 0}` if IPv6 is not available.
+  # upon start up.
+  # Exposed as a deployment environment variable.
+  # If the environment variable is not set it defaults to ipv4.
+  # Accepts either ipv4 or ipv6 as possible values. (Case-insensitive)
   ip =
-    case :inet.getaddr(~c"localhost", :inet6) do
-      {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
-      {:error, _} -> {0, 0, 0, 0}
+    case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
+      "ipv4" -> {0, 0, 0, 0}
+      "ipv6" -> {0, 0, 0, 0, 0, 0, 0, 0}
+      _ -> raise "Invalid value set for environment variable IPV4_OR_IPV6"
     end
+
 
   config :wanda, WandaWeb.Endpoint,
     http: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -64,7 +64,6 @@ if config_env() in [:prod, :demo] do
       _ -> raise "Invalid value set for environment variable IPV4_OR_IPV6"
     end
 
-
   config :wanda, WandaWeb.Endpoint,
     http: [
       # Enable IPv6 and bind on all interfaces.

--- a/packaging/suse/rpm/systemd/trento-wanda.example
+++ b/packaging/suse/rpm/systemd/trento-wanda.example
@@ -3,3 +3,4 @@ CORS_ORIGIN=localhost
 SECRET_KEY_BASE=<secret-key-base>
 AMQP_URL=amqp://trento_user:trento_user_password@rabbitmq-host/vhost
 DATABASE_URL=ecto://wanda_user:wanda_password@postgres-host/wanda
+IPV4_OR_IPV6=IPV4


### PR DESCRIPTION
### Description

Explicit system env. variable for ipv4 vs ipv6 support. Exposed as operator configuration.
Rest of the motivation is same as that for https://github.com/trento-project/web/pull/4615
(This is the wanda equivalent of the changes seen previously on web.)

### How was this tested?

The test package/PTF will be tested by the case reporter, after this PR is reviewed by all involved.

### Documentation changes

Docs changes will be needed and will be done subsequently.
