### PR TITLE
Fix conflicting erlang27 packages

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -39,6 +39,7 @@ Requires:       trento-checks
 %if !0%{?is_opensuse} && 0%{?suse_version} < 1600
 BuildRequires:  erlang26
 BuildConflicts: erlang27
+BuildConflicts: erlang27-providers
 BuildRequires:  elixir115
 BuildConflicts: elixir119
 %else


### PR DESCRIPTION
### Description

Sibling of https://github.com/trento-project/web/pull/4744.

Needs to be backported to 2.1.1.

This https://github.com/trento-project/wanda/pull/723 was never backported