### PR TITLE
Export version in rpm packages to use same value during compilation

### DIFF
--- a/packaging/suse/rpm/trento-wanda.spec
+++ b/packaging/suse/rpm/trento-wanda.spec
@@ -68,6 +68,7 @@ export MIX_ENV=prod
 export MIX_HOME=/usr/bin
 export MIX_REBAR3=/usr/bin/rebar3
 export MIX_PATH=/usr/lib/elixir/lib/hex/ebin
+export VERSION=%{version}
 mix phx.digest
 mix release
 


### PR DESCRIPTION
# Description
Backport of #716 to `release`.