### PR TITLE
Disable fail-fast in the CI for most jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,7 @@ jobs:
     needs: [setup-matrix-env, elixir-deps]
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
@@ -108,6 +109,7 @@ jobs:
     needs: [setup-matrix-env, elixir-deps]
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
@@ -186,6 +188,7 @@ jobs:
     needs: [setup-matrix-env, elixir-deps]
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
@@ -230,6 +233,7 @@ jobs:
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
@@ -278,6 +282,7 @@ jobs:
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - version: Unversioned
@@ -343,6 +348,9 @@ jobs:
             _build/${{ env.MIX_ENV }}
             priv/plts
           key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-rust-${{ needs.setup-matrix-env.outputs.RUST_DEV }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
+      - name: Install missing dependencies
+        if: steps.mix-cache-target.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Generate target openapi.json
         run: |
           mix openapi.spec.json --start-app=false --spec WandaWeb.Schemas.${{ matrix.version }}.ApiSpec /tmp/specs/target-spec.json
@@ -372,6 +380,7 @@ jobs:
     if: >-
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - mix_env: prod

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [setup-matrix-env]
     strategy:
+      fail-fast: false
       matrix:
         mix_env: ${{ fromJSON(inputs.mix_envs) }}
         versions:


### PR DESCRIPTION
### Description

Disable fail-fast on most jobs in the standard CI workflow.

This would help in pinpointing  which actual run is failing and which not. Also, with occasional failures of a single check, the whole group needs to be re-run which takes time on subsequent re-trigger, which unnecessarily wastes dev time.

We have the same in trento-web: https://github.com/trento-project/web/pull/4708