### PR TITLE
Revert backport workflow back to normal

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,7 +5,7 @@
 name: Backport PR
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [closed, labeled]
 


### PR DESCRIPTION
### Description

Reverting the backport workflow to be triggered on `pull_request` event, instead of `pull_request_target`. The backport of older PRs is complete, so every new one would be picked by the standard safe `pull_request` event.